### PR TITLE
adding plugin-manager add, list and remove

### DIFF
--- a/cmd/plugin-manager/add/add.go
+++ b/cmd/plugin-manager/add/add.go
@@ -1,0 +1,196 @@
+package add
+
+import (
+	"errors"
+	"fmt"
+	"github.com/konveyor/crane/internal/flags"
+	"github.com/konveyor/crane/internal/plugin"
+	"github.com/spf13/cobra"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+type Options struct {
+	globalFlags *flags.GlobalFlags
+	Repo        string
+	PluginDir   string
+	Version     string
+}
+
+func (o *Options) Complete(c *cobra.Command, args []string) error {
+	// TODO: @jgabani
+	return nil
+}
+
+func (o *Options) Validate(args []string) error {
+	// TODO: @jgabani
+	log := o.globalFlags.GetLogger()
+
+	pluginDir, err := filepath.Abs(fmt.Sprintf("%v/%v", o.PluginDir, o.Repo))
+	if err != nil {
+		return err
+	}
+
+	files, err := ioutil.ReadDir(pluginDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	paths, err := plugin.LocateBinaryInPluginDir(o.PluginDir, args[0], files)
+	if err != nil {
+		return err
+	}
+
+	if len(paths) > 0 {
+		log.Errorf("The binary is already installed in the following path, either delete the binary or mention a repo from which the binary is needed")
+		for _, path := range paths {
+			fmt.Printf("%s \n", path)
+		}
+		return errors.New("the binary is already installed in the following path, either delete the binary or mention a repo from which the binary is needed")
+	}
+	return nil
+}
+
+func (o *Options) Run(args []string) error {
+	return o.run(args)
+}
+
+func NewAddCommand(f *flags.GlobalFlags) *cobra.Command {
+	o := &Options{
+		globalFlags: f,
+	}
+	cmd := &cobra.Command{
+		Use:   "add",
+		Short: "installs the desired plugin",
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := o.Complete(c, args); err != nil {
+				return err
+			}
+			if err := o.Validate(args); err != nil {
+				return nil
+			}
+			if err := o.Run(args); err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+	addFlagsForOptions(o, cmd)
+	return cmd
+}
+
+func addFlagsForOptions(o *Options, cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&o.Repo, "repo", "", "", "Install plugin from specific repo (optional), if not passed iterate through all the repo and install the desired plugin. In case of conflicting name the command fails and asks user to specify the repo from which to install the plugin")
+	cmd.Flags().StringVarP(&o.PluginDir, "plugin-dir", "p", "plugins/managed", "The path where binary plugins are located")
+	cmd.Flags().StringVarP(&o.Version, "version", "", "", "Install specific plugin version (if not passed, installs latest plugin version or the only available one)")
+}
+
+func (o *Options) run(args []string) error {
+	log := o.globalFlags.GetLogger()
+
+	manifestMap, err := plugin.BuildManifestMap(log, args[0], o.Repo)
+	if err != nil {
+		return nil
+	}
+
+	path := BuildInstallBinaryPath(o.PluginDir)
+	installVersion := "latest"
+	if o.Version != "" {
+		installVersion = o.Version
+	}
+
+	if len(manifestMap) > 1 {
+		// if the plugin is found across multiple repository then fail and ask for a specific repo
+		log.Errorf(fmt.Sprintf("The plugin %s is found across multiple repos, please specify one repo with --repo flag", args[0]))
+	} else if len(manifestMap) == 1 {
+		// the plugin is found in only one repo
+		for repo, manifest := range manifestMap {
+			// install the only available version of the plugin
+			if len(manifest) == 1 {
+				for _, value := range manifest {
+					// check if the version is mentioned and matches the version in manifest file
+					if value.Name != "" && (o.Version == "" || string(value.Version) == o.Version) {
+						err := DownloadBinary(fmt.Sprintf("%s/%s", path, repo), value.Name, value.Binaries[0].URI)
+						if err != nil {
+							return err
+						}
+						fmt.Println(fmt.Sprintf("Adding plugin %s from repo %s", args[0], repo))
+						log.Infof("plugin %s added to the path - %s", args[0], fmt.Sprintf("%s/%s", path, repo))
+						return nil
+					} else {
+						log.Errorf(fmt.Sprintf("The version %s of plugin %s is not available", o.Version, args[0]))
+					}
+				}
+			} else if len(manifest) > 1 {
+				// if there are multiple version of the plugins are available then look for the latest or mentioned version and if not found fail and ask user to input a version using --version flag
+				for repo, manifest := range manifestMap {
+					for _, value := range manifest {
+						if string(value.Version) == installVersion {
+							err := DownloadBinary(fmt.Sprintf("%s/%s", path, repo), value.Name, value.Binaries[0].URI)
+							if err != nil {
+								return err
+							}
+							fmt.Println(fmt.Sprintf("Adding plugin %s from repo %s", args[0], repo))
+							log.Infof("plugin %s added to the path - %s", args[0], fmt.Sprintf("%s/%s", path, repo))
+							return nil
+						}
+					}
+					log.Errorf(fmt.Sprintf("The %s version of the plugin %s is not found, please mention one version using --version", installVersion, args[0]))
+				}
+			} else {
+				// throw error saying that the plugin doest exists
+				log.Errorf(fmt.Sprintf("The plugin %s is not found", args[0]))
+			}
+		}
+	} else {
+		// throw error saying that the plugin doest exists
+		log.Errorf(fmt.Sprintf("The plugin %s is not found", args[0]))
+	}
+	return nil
+}
+
+func DownloadBinary(filepath string, filename string, url string) error {
+
+	// Get the data
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	// Create dir if not exists
+	if _, err := os.Stat(filepath); os.IsNotExist(err) {
+		err = os.MkdirAll(filepath, os.ModePerm)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Create the file
+	out, err := os.OpenFile(filepath+"/"+filename, syscall.O_RDWR|syscall.O_CREAT|syscall.O_TRUNC, 0777)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	// Write the body to file
+	_, err = io.Copy(out, resp.Body)
+	return err
+}
+
+func BuildInstallBinaryPath(path string) string {
+	pluginDir := "plugins/managed"
+
+	if path != "" {
+		pluginDir = path
+	}
+
+	return pluginDir
+}

--- a/cmd/plugin-manager/list/list.go
+++ b/cmd/plugin-manager/list/list.go
@@ -1,0 +1,157 @@
+package list
+
+import (
+	"fmt"
+	"github.com/konveyor/crane/internal/flags"
+	"github.com/konveyor/crane/internal/plugin"
+	"github.com/spf13/cobra"
+	"os"
+	"text/tabwriter"
+)
+
+type Options struct {
+	globalFlags *flags.GlobalFlags
+	Repo        string
+	Installed   bool
+	PluginDir   string
+	Params      bool
+	Name        string
+	Versions    bool
+}
+
+type AvailablePlugins struct {
+	Name             string
+	ShortDescription string
+	Description      string
+	Versions         []plugin.Version
+}
+
+func (o *Options) Complete(c *cobra.Command, args []string) error {
+	// TODO: @jgabani
+	return nil
+}
+
+func (o *Options) Validate() error {
+	// TODO: @jgabani
+	return nil
+}
+
+func (o *Options) Run() error {
+	return o.run()
+}
+
+func NewListCommand(f *flags.GlobalFlags) *cobra.Command {
+	o := &Options{
+		globalFlags: f,
+	}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "Lists all the available plugins",
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := o.Complete(c, args); err != nil {
+				return err
+			}
+			if err := o.Validate(); err != nil {
+				return err
+			}
+			if err := o.Run(); err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+	addFlagsForOptions(o, cmd)
+	return cmd
+}
+
+// TODO: flags to implement repo, installed, name
+
+func addFlagsForOptions(o *Options, cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&o.Repo, "repo", "", "", "The name of the repository from which to list the plugins from")
+	cmd.Flags().BoolVarP(&o.Installed, "installed", "", false, "Flag to list installed plugins")
+	// TODO: look into plugin-dir to see what is installed
+	cmd.Flags().StringVarP(&o.PluginDir, "plugin-dir", "p", "plugins", "The path where binary plugins are located")
+	cmd.Flags().BoolVarP(&o.Params, "params", "", false, "If passed, returns with metadata information for all the version of specific plugin. This flag is to be used with \"--name\" flag")
+	cmd.Flags().StringVarP(&o.Name, "name", "", "", "To be used with \"--params\" or \"--versions\" flag to specify the plugin for which additional information is needed. In case of conflict, command fails and asks for a specific repository information.")
+	cmd.Flags().BoolVarP(&o.Versions, "versions", "", false, "If passed, returns with all the versions available for a plugin. This flag is to be used with \"--name\" flag.")
+}
+
+func (o *Options) run() error {
+	log := o.globalFlags.GetLogger()
+
+	manifestMap, err := plugin.BuildManifestMap(log, "", o.Repo)
+	if err != nil {
+		return nil
+	}
+
+	if o.Name != "" && (o.Params || o.Versions) {
+		if o.Params {
+			// retrieve all the information for all the versions available for a specific plugin
+			for repo, manifests := range manifestMap {
+				fmt.Printf("Listing from the repo %s\n", repo)
+				for name, manifest := range manifests {
+					if manifest.Name != o.Name {
+						delete(manifestMap, name)
+					} else {
+						printParamsInformation(manifest)
+					}
+				}
+			}
+		} else if o.Versions {
+			// retrieve all the available version of the plugin
+			for repo, manifest := range manifestMap {
+				fmt.Printf("Listing from the repo %s\n", repo)
+				for name, manifest := range manifest {
+					if manifest.Name != o.Name {
+						delete(manifestMap, name)
+					} else {
+						fmt.Printf("Version: %s\n", manifest.Version)
+					}
+				}
+			}
+		}
+	} else {
+		for repo, manifest := range manifestMap {
+			// output information
+			fmt.Printf("Listing from the repo %s\n", repo)
+			groupInformationForPlugins(manifest)
+		}
+	}
+	return nil
+}
+
+func groupInformationForPlugins(manifestMap map[string]plugin.Manifest) {
+	availablePlugin := map[string]AvailablePlugins{}
+	for _, manifest := range manifestMap {
+		if _, ok := availablePlugin[manifest.Name]; ok {
+			availablePlugin[manifest.Name] = AvailablePlugins{Name: manifest.Name, ShortDescription: manifest.ShortDescription, Versions: append(availablePlugin[manifest.Name].Versions, manifest.Version)}
+		} else {
+			availablePlugin[manifest.Name] = AvailablePlugins{
+				Name:             manifest.Name,
+				ShortDescription: manifest.ShortDescription,
+				Versions:         []plugin.Version{manifest.Version},
+			}
+		}
+	}
+
+	printInformation(availablePlugin)
+}
+
+func printInformation(plugins map[string]AvailablePlugins) {
+	w := tabwriter.NewWriter(os.Stdout, 1, 1, 1, ' ', 0)
+	fmt.Fprintf(w, "Name \t ShortDescription \t AvailableVersions \n")
+	for _, plugin := range plugins {
+		if plugin.Name != "" {
+			fmt.Fprintf(w, "%v \t %v \t %v \n", plugin.Name, plugin.ShortDescription, plugin.Versions)
+		}
+	}
+	w.Flush()
+}
+
+func printParamsInformation(plugin plugin.Manifest) {
+	w := tabwriter.NewWriter(os.Stdout, 1, 1, 1, ' ', 0)
+	fmt.Fprintf(w, "Name \t ShortDescription \t AvailableVersions \t Binaries \n")
+	fmt.Fprintf(w, "%v \t %v \t %v \t %#v \n ", plugin.Name, plugin.ShortDescription, plugin.Version, plugin.Binaries)
+	w.Flush()
+}

--- a/cmd/plugin-manager/plugin-manager.go
+++ b/cmd/plugin-manager/plugin-manager.go
@@ -1,0 +1,59 @@
+package plugin_manager
+
+import (
+	"github.com/konveyor/crane/cmd/plugin-manager/add"
+	"github.com/konveyor/crane/cmd/plugin-manager/list"
+	"github.com/konveyor/crane/cmd/plugin-manager/remove"
+	"github.com/konveyor/crane/internal/flags"
+	"github.com/spf13/cobra"
+)
+
+type Options struct {
+	globalFlags *flags.GlobalFlags
+}
+
+func (o *Options) Complete(c *cobra.Command, args []string) error {
+	// TODO: @jgabani
+	return nil
+}
+
+func (o *Options) Validate() error {
+	// TODO: @jgabani
+	return nil
+}
+
+func (o *Options) Run() error {
+	return o.run()
+}
+
+func NewPluginManagerCommand(f *flags.GlobalFlags) *cobra.Command {
+	o := &Options{
+		globalFlags: f,
+	}
+	cmd := &cobra.Command{
+		Use:   "plugin-manager",
+		Short: "Plugin-manager is command that helps manage plugins",
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := o.Complete(c, args); err != nil {
+				return err
+			}
+			if err := o.Validate(); err != nil {
+				return err
+			}
+			if err := o.Run(); err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+
+	cmd.AddCommand(list.NewListCommand(f))
+	cmd.AddCommand(add.NewAddCommand(f))
+	cmd.AddCommand(remove.NewRemoveCommand(f))
+	return cmd
+}
+
+func (o *Options) run() error {
+	return nil
+}

--- a/cmd/plugin-manager/remove/remove.go
+++ b/cmd/plugin-manager/remove/remove.go
@@ -1,0 +1,97 @@
+package remove
+
+import (
+	"fmt"
+	"github.com/konveyor/crane/internal/flags"
+	"github.com/konveyor/crane/internal/plugin"
+	"github.com/spf13/cobra"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+type Options struct {
+	globalFlags *flags.GlobalFlags
+	Repo        string
+	PluginDir   string
+}
+
+func (o *Options) Complete(c *cobra.Command, args []string) error {
+	// TODO: @jgabani
+	return nil
+}
+
+func (o *Options) Validate() error {
+	// TODO: @jgabani
+	return nil
+}
+
+func (o *Options) Run(args []string) error {
+	return o.run(args)
+}
+
+func NewRemoveCommand(f *flags.GlobalFlags) *cobra.Command {
+	o := &Options{
+		globalFlags: f,
+	}
+	cmd := &cobra.Command{
+		Use:   "remove",
+		Short: "removes the desired plugin",
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := o.Complete(c, args); err != nil {
+				return err
+			}
+			if err := o.Validate(); err != nil {
+				return err
+			}
+			if err := o.Run(args); err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+	addFlagsForOptions(o, cmd)
+	return cmd
+}
+
+func addFlagsForOptions(o *Options, cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&o.Repo, "repo", "", "", "Remove plugin from specific repo (optional), if not passed iterate through all the repo and remove the desired plugin. In case of conflicting name the command fails and asks user to specify the repo from which to remove the plugin")
+	cmd.Flags().StringVarP(&o.PluginDir, "plugin-dir", "p", "plugins/managed", "The path where binary plugins are located (default 'plugins/managed')")
+}
+
+func (o *Options) run(args []string) error {
+	log := o.globalFlags.GetLogger()
+
+	pluginDir, err := filepath.Abs(fmt.Sprintf("%v/%v", o.PluginDir, o.Repo))
+	if err != nil {
+		return err
+	}
+
+	files, err := ioutil.ReadDir(pluginDir)
+	if err != nil {
+		return err
+	}
+
+	paths, err := plugin.LocateBinaryInPluginDir(pluginDir, args[0], files)
+	if err != nil {
+		return err
+	}
+
+	if len(paths) > 1 {
+		// fail and ask for a specific repo
+		log.Errorf("The binary is installed from multiple source, please specify repository from which you want to remove the plugin using --repo \n")
+		fmt.Printf("The binary is present in the following path")
+		for _, path := range paths {
+			fmt.Printf("%s \n", path)
+		}
+	} else {
+		err = os.Remove(paths[0])
+		if err != nil {
+			return err
+		}
+		log.Infof("The plugin %s removed from path - %s", args[0], paths[0])
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/konveyor/crane
 go 1.16
 
 require (
+	github.com/ghodss/yaml v1.0.0
 	github.com/konveyor/crane-lib v0.0.1
 	github.com/openshift/api v0.0.0-20210625082935-ad54d363d274
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -206,6 +206,7 @@ github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
@@ -343,8 +344,14 @@ github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
+github.com/google/go-github/v39 v39.1.0 h1:1vf4gM0D1e+Df2HMxaYC3+o9+Huj3ywGTtWc3VVYaDA=
+github.com/google/go-github/v39 v39.1.0/go.mod h1:C1s8C5aCC9L+JXIYpJM5GYytdX52vC1bLvHEF1IhBrE=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
@@ -751,6 +758,7 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 h1:/ZScEX8SfEmUGRHs0gxpqteO5nfNW6axyZbBdw9A12g=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
+golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -940,6 +948,7 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2 h1:c8PlLMqBbOHoqtjteWm5/kbe6rNY2pbRfbIMVnepueo=
 golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/plugin/plugin_helper.go
+++ b/internal/plugin/plugin_helper.go
@@ -43,7 +43,7 @@ func getBinaryPlugins(path string, files []os.FileInfo, logger *logrus.Logger) (
 				return nil, err
 			}
 			pluginList = append(pluginList, plugins...)
-		} else if file.Mode().IsRegular() && isExecAny(file.Mode().Perm()) {
+		} else if file.Mode().IsRegular() && IsExecAny(file.Mode().Perm()) {
 			newPlugin, err := binary_plugin.NewBinaryPlugin(filePath, logger)
 			if err != nil {
 				return nil, err
@@ -54,7 +54,7 @@ func getBinaryPlugins(path string, files []os.FileInfo, logger *logrus.Logger) (
 	return pluginList, nil
 }
 
-func isExecAny(mode os.FileMode) bool {
+func IsExecAny(mode os.FileMode) bool {
 	return mode&0111 != 0
 }
 

--- a/internal/plugin/plugin_manager_helper.go
+++ b/internal/plugin/plugin_manager_helper.go
@@ -1,0 +1,163 @@
+package plugin
+
+import (
+	"errors"
+	"fmt"
+	"github.com/ghodss/yaml"
+	"github.com/sirupsen/logrus"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"runtime"
+	"strings"
+)
+
+const (
+	DEFAULT_REPO     = "default"
+	DEFAULT_REPO_URL = "DEFAULT_REPO_URL"
+	DEFAULT_URL      = "https://raw.githubusercontent.com/konveyor/crane-plugins/main/index.yml"
+)
+
+type Manifest struct {
+	Name             string   `json:"name"`
+	ShortDescription string   `json:"shortDescription"`
+	Description      string   `json:"description"`
+	Version          Version  `json:"version"`
+	Binaries         []Binary `json:"binaries"`
+}
+
+type Binary struct {
+	OS   string `json:"os"`
+	Arch string `json:"arch"`
+	URI  string `json:"uri"`
+	SHA  string `json:"sha,omitempty"`
+}
+
+type Version string
+
+func BuildManifestMap(log *logrus.Logger, name string, repoName string) (map[string]map[string]Manifest, error) {
+	// TODO: for multiple repo, read values from conf file to this map
+	repos := make(map[string]string)
+
+	if repoName != "" {
+		// read the repo and url from the conf file and update the map with the same
+		// repos[repoName] = <repoUrl>
+		log.Errorf("Multiple repository is not supported right now so the flag --repo will not work till next release")
+		return nil, errors.New("multiple repository is not supported right now so the flag --repo will not work till next release")
+	} else {
+		// read the whole config file and iterate through all repos to make sure every manifest is read
+		repos[DEFAULT_REPO] = GetDefaultSource()
+	}
+	manifestMap := make(map[string]map[string]Manifest)
+
+	for repo, url := range repos {
+		urlMap, err := GetYamlFromUrl(url)
+		if err != nil {
+			return nil, err
+		}
+		manifestMap[repo] = make(map[string]Manifest)
+		for key, value := range urlMap {
+			if s, ok := value.(string); ok {
+				if name == "" || strings.Contains(key, name) {
+					plugin, err := YamlToManifest(s)
+					if err != nil {
+						log.Errorf("Error reading %s plugin manifest located at %s - Error: %s", key, s, err)
+						return nil, err
+					} else {
+						manifestMap[repo][key] = plugin
+					}
+				}
+			}
+		}
+	}
+	return manifestMap, nil
+}
+
+func GetYamlFromUrl(url string) (map[string]interface{}, error) {
+	res, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	defer res.Body.Close()
+
+	body, err := ioutil.ReadAll(res.Body)
+
+	if err != nil {
+		return nil, err
+	}
+	var manifest map[string]interface{}
+	err = yaml.Unmarshal(body, &manifest)
+	if err != nil {
+		panic(err)
+	}
+	return manifest, nil
+}
+
+func YamlToManifest(url string) (Manifest, error) {
+	plugin := Manifest{}
+	res, err := http.Get(url)
+	if err != nil {
+		return plugin, err
+	}
+
+	defer res.Body.Close()
+
+	body, err := ioutil.ReadAll(res.Body)
+
+	if err != nil {
+		return plugin, err
+	}
+	err = yaml.Unmarshal(body, &plugin)
+	isPluginAvailable := FilterPluginForOsArch(&plugin)
+	if isPluginAvailable {
+		return plugin, nil
+	}
+	// TODO: figure out a better way to not return the plugin
+	return Manifest{}, nil
+}
+
+func FilterPluginForOsArch(plugin *Manifest) bool {
+	// filter manifests for current os/arch
+	isPluginAvailable := false
+	for _, binary := range plugin.Binaries {
+		if binary.OS == runtime.GOOS && binary.Arch == runtime.GOARCH {
+			isPluginAvailable = true
+			plugin.Binaries = []Binary{
+				binary,
+			}
+			break
+		}
+	}
+	return isPluginAvailable
+}
+
+func GetDefaultSource() string {
+	val, present := os.LookupEnv(DEFAULT_REPO_URL)
+	if present {
+		return val
+	}
+	return DEFAULT_URL
+}
+
+func LocateBinaryInPluginDir(pluginDir string, name string, files []os.FileInfo) ([]string, error) {
+	paths := []string{}
+
+	for _, file := range files {
+		filePath := fmt.Sprintf("%v/%v", pluginDir, file.Name())
+		if file.IsDir() {
+			newFiles, err := ioutil.ReadDir(filePath)
+			if err != nil {
+				return nil, err
+			}
+			plugins, err := LocateBinaryInPluginDir(filePath, name, newFiles)
+			if err != nil {
+				return nil, err
+			}
+			paths = append(paths, plugins...)
+		} else if file.Mode().IsRegular() && IsExecAny(file.Mode().Perm()) && file.Name() == name {
+			paths = append(paths, filePath)
+		}
+	}
+	return paths, nil
+}

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	export "github.com/konveyor/crane/cmd/export"
 	"github.com/konveyor/crane/cmd/transform"
 	"github.com/konveyor/crane/internal/flags"
+	"github.com/konveyor/crane/cmd/plugin-manager"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
@@ -22,6 +23,7 @@ func main() {
 	root.AddCommand(transfer_pvc.NewTransferOptions(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}))
 	root.AddCommand(transform.NewTransformCommand(f))
 	root.AddCommand(apply.NewApplyCommand(f))
+	root.AddCommand(plugin_manager.NewPluginManagerCommand(f))
 	if err := root.Execute(); err != nil {
 		os.Exit(1)
 	}


### PR DESCRIPTION
This PR includes changes that add the functionality of an additional `plugin-manager` subcommand under `crane`. [Here](https://github.com/konveyor/enhancements/tree/master/enhancements/crane-2.0/plugin-management) is the proposed enhancement for the same.

This PR is not the whole implementation of the proposed enhancement, but some. Following are the changes that are added.
- To be able to list the plugins from the hardcoded default repository
- To be able to add the plugin from the hardcoded default repository
- To be able to remove the installed plugin


Future work may be from the following PR or might be the modification of the current PR:
- To be able to retrieve metadata information of the plugin with list plugin command
- To be able to add the desired version of the plugin
- To be able to list the installed plugins
- To be able to override hardcoded default repository URL and override default plugin path
There might be more tasks related to validation and otherwise than what is mentioned above. 