### PR TITLE
add version command; bump crane-lib version

### DIFF
--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -212,11 +212,12 @@ func (t *TransferPVCOptions) run() error {
 	}
 
 	// create a route for data transfer
+	// TODO: pass in subdomain instead of ""
 	r := route.NewEndpoint(
 		types.NamespacedName{
 			Namespace: pvc.Namespace,
 			Name:      pvc.Name,
-		}, route.EndpointTypePassthrough, metadata.Labels)
+		}, route.EndpointTypePassthrough, metadata.Labels, "")
 	e, err := endpoint.Create(r, destClient)
 	if err != nil {
 		log.Fatal(err, "unable to create route endpoint")

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -1,0 +1,66 @@
+package version
+
+import (
+	"fmt"
+
+	"github.com/konveyor/crane/internal/buildinfo"
+	"github.com/konveyor/crane/internal/flags"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+type Options struct {
+        // Two GlobalFlags struct fields are needed
+        // 1. cobraGlobalFlags for explicit CLI args parsed by cobra
+        // 2. globalFlags for the args merged with values from the viper config file
+        cobraGlobalFlags *flags.GlobalFlags
+        globalFlags      *flags.GlobalFlags
+}
+func (o *Options) Complete(c *cobra.Command, args []string) error {
+        // TODO: @sseago
+        return nil
+}
+
+func (o *Options) Validate() error {
+        // TODO: @sseago
+        return nil
+}
+
+func (o *Options) Run() error {
+        return o.run()
+}
+
+func NewVersionCommand(f *flags.GlobalFlags) *cobra.Command {
+        o := &Options{
+                cobraGlobalFlags: f,
+        }
+        cmd := &cobra.Command{
+                Use:   "version",
+                Short: "Return the current crane (and crane-lib) version",
+                RunE: func(c *cobra.Command, args []string) error {
+                        if err := o.Complete(c, args); err != nil {
+                                return err
+                        }
+                        if err := o.Validate(); err != nil {
+                                return err
+                        }
+                        if err := o.Run(); err != nil {
+                                return err
+                        }
+                        return nil
+                },
+		PreRun: func(cmd *cobra.Command, args []string) {
+                        viper.Unmarshal(&o.globalFlags)
+                },
+
+        }
+        return cmd
+}
+
+func (o *Options) run() error {
+	fmt.Println("crane:")
+	fmt.Printf("\tVersion: %s\n", buildinfo.Version)
+	fmt.Println("crane-lib:")
+	fmt.Printf("\tVersion: %s\n", buildinfo.CranelibVersion)
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/ghodss/yaml v1.0.0
-	github.com/konveyor/crane-lib v0.0.3
+	github.com/konveyor/crane-lib v0.0.4
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5
 	github.com/openshift/api v0.0.0-20210625082935-ad54d363d274

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,7 @@ github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUM
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Luzifer/go-dhparam v1.1.0/go.mod h1:3Kuj59C67/G2EzQHjUzAryaAa70K5fqvStR2VkFLszU=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
@@ -457,8 +458,8 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/konveyor/crane-lib v0.0.3 h1:9RpCkhYkAqor89O97R/i3xhV2o68KWavvutej45a7So=
-github.com/konveyor/crane-lib v0.0.3/go.mod h1:7xlMNVE0ZgbAThr9+R7G3zZ88TOD7d4br50URQnv5U8=
+github.com/konveyor/crane-lib v0.0.4 h1:CWGBC5MTmdlrEqu1F5eBSR0HRYBlo2QV/Y/bHguJPvM=
+github.com/konveyor/crane-lib v0.0.4/go.mod h1:C0H3dr85YlsaAt1Av7zFu4IPdwG4+SW7wEBFE+1udTw=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -1,0 +1,10 @@
+package buildinfo
+
+import (
+	cranelibversion "github.com/konveyor/crane-lib/version"
+)
+var (
+	Version string = "v0.0.2"
+
+	CranelibVersion string = cranelibversion.Version
+)

--- a/main.go
+++ b/main.go
@@ -6,9 +6,10 @@ import (
 
 	"github.com/konveyor/crane/cmd/apply"
 	export "github.com/konveyor/crane/cmd/export"
-	"github.com/konveyor/crane/cmd/transform"
-	"github.com/konveyor/crane/internal/flags"
 	"github.com/konveyor/crane/cmd/plugin-manager"
+	"github.com/konveyor/crane/cmd/transform"
+	"github.com/konveyor/crane/cmd/version"
+	"github.com/konveyor/crane/internal/flags"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
@@ -24,6 +25,7 @@ func main() {
 	root.AddCommand(transform.NewTransformCommand(f))
 	root.AddCommand(apply.NewApplyCommand(f))
 	root.AddCommand(plugin_manager.NewPluginManagerCommand(f))
+	root.AddCommand(version.NewVersionCommand(f))
 	if err := root.Execute(); err != nil {
 		os.Exit(1)
 	}


### PR DESCRIPTION
This can't be merged until crane-lib 0.0.4 is released (with corresponding go.mod update), as that's where cranelib's version.Version is defined.