### PR TITLE
changing the output format for list plugins

### DIFF
--- a/cmd/plugin-manager/list/list.go
+++ b/cmd/plugin-manager/list/list.go
@@ -165,12 +165,13 @@ func (o *Options) run() error {
 
 //TODO: this can be merged with printParamsInformation
 func printInstalledInformation(plugins []transform2.Plugin) {
-	headers := []string{"Name", "Version", "OptionalFields"}
-	var data [][]string
 	for _, thisPlugin := range plugins {
-		data = append(data, []string{thisPlugin.Metadata().Name, thisPlugin.Metadata().Version, getOptionalFields(thisPlugin.Metadata().OptionalFields)})
+		printTable([][]string{
+			{"Name", thisPlugin.Metadata().Name},
+			{"Version", thisPlugin.Metadata().Version},
+			{"OptionalFields", getOptionalFields(thisPlugin.Metadata().OptionalFields)},
+		})
 	}
-	printTable(headers, data)
 }
 
 func groupInformationForPlugins(manifestMap map[string]plugin.Manifest) {
@@ -191,37 +192,29 @@ func groupInformationForPlugins(manifestMap map[string]plugin.Manifest) {
 }
 
 func printInformation(plugins map[string]AvailablePlugins) {
-	var data [][]string
-	header := []string{"Name", "ShortDescription", "AvailableVersions"}
 	for _, plugin := range plugins {
 		if plugin.Name != "" {
-			data = append(data, []string{
-				plugin.Name,
-				plugin.ShortDescription,
-				strings.Join(plugin.Versions, ", "),
+			printTable([][]string{
+				{"Name", plugin.Name},
+				{"ShortDescription", plugin.ShortDescription},
+				{"AvailableVersions", strings.Join(plugin.Versions, ", ")},
 			})
 		}
 	}
-	printTable(header, data)
 }
 
 func printParamsInformation(manifests map[string]plugin.Manifest) {
-	var data [][]string
-	header := []string{"Name", "ShortDescription", "Description", "AvailableVersions", "OptionalFields"}
-
 	for _, manifest := range manifests {
 		if manifest.Name != "" {
-			data = append(data,
-				[]string{
-					manifest.Name,
-					manifest.ShortDescription,
-					manifest.Description,
-					string(manifest.Version),
-					getOptionalFields(manifest.OptionalFields),
-				})
+			printTable([][]string{
+				{"Name", manifest.Name},
+				{"ShortDescription", manifest.ShortDescription},
+				{"Description", manifest.Description},
+				{"AvailableVersions", string(manifest.Version)},
+				{"OptionalFields", getOptionalFields(manifest.OptionalFields)},
+			})
 		}
 	}
-	printTable(header, data)
 }
 
 func getOptionalFields(fields []transform2.OptionalFields) string {
@@ -249,12 +242,9 @@ func getOptionalFields(fields []transform2.OptionalFields) string {
 	return retstr
 }
 
-func printTable(headers []string, data [][]string) {
+func printTable(data [][]string) {
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetAutoWrapText(false)
-	table.SetRowSeparator("-")
-	table.SetRowLine(true)
-	table.SetHeader(headers)
 	table.AppendBulk(data)
 	table.Render()
 }


### PR DESCRIPTION
changing output format from table to something similar of `dnf` command

```
Listing from the repo default
+-------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Name              | OpenshiftPlugin                                                                                                                                                                      |
| ShortDescription  | OpenshiftPlugin                                                                                                                                                                      |
| Description       | this is OpenshiftPlugin                                                                                                                                                              |
| AvailableVersions | v0.0.1                                                                                                                                                                               |
| OptionalFields    | - FlagName: strip-default-pull-secrets                                                                                                                                               |
|                   |   Help: Whether to strip Pod and BuildConfig default pull secrets (beginning with builder/default/deployer-dockercfg-) that aren't replaced by the map param pull-secret-replacement |
|                   |   Example: true                                                                                                                                                                      |
|                   | - FlagName: pull-secret-replacement                                                                                                                                                  |
|                   |   Help: Map of pull secrets to replace in Pods and BuildConfigs while transforming in format secret1=destsecret1,secret2=destsecret2[...]                                            |
|                   |   Example: default-dockercfg-h4n7g=default-dockercfg-12345,builder-dockercfg-abcde=builder-dockercfg-12345                                                                           |
|                   | - FlagName: registry-replacement                                                                                                                                                     |
|                   |   Help: Map of image registry paths to swap on transform, in the format original-registry1=target-registry1,original-registry2=target-registry2...                                   |
|                   |   Example: docker-registry.default.svc:5000=image-registry.openshift-image-registry.svc:5000,docker.io/foo=quay.io/bar                                                               |
+-------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

```