### PR TITLE
bug: make export respect context

### DIFF
--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -1,10 +1,8 @@
 package export
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/konveyor/crane/internal/flags"
 	"github.com/spf13/cobra"
@@ -18,69 +16,109 @@ import (
 )
 
 type ExportOptions struct {
+	configFlags *genericclioptions.ConfigFlags
+
 	// Two GlobalFlags struct fields are needed
 	// 1. cobraGlobalFlags for explicit CLI args parsed by cobra
 	// 2. globalFlags for the args merged with values from the viper config file
 	cobraGlobalFlags *flags.GlobalFlags
 	globalFlags      *flags.GlobalFlags
-	// Two Flags struct fields are needed
-	// 1. cobraFlags for explicit CLI args parsed by cobra
-	// 2. Flags for the args merged with values from the viper config file
-	cobraFlags Flags
-	Flags
 
-	configFlags *genericclioptions.ConfigFlags
-	extras      map[string][]string
+	rawConfig api.Config
+	exportDir string `mapstructure:"export-dir"`
+	// TODO(djzager): how do we handle viper + k8s cli options?
+	namespace string
+
 	genericclioptions.IOStreams
 }
 
-type Flags struct {
-	ExportDir string `mapstructure:"export-dir"`
-	Context   string `mapstructure:"context"`
-	Namespace string `mapstructure:"namespace"`
-
-	//User Impersonation Flags
-	User  string   `mapstructure:"as-user"`
-	Group []string `mapstructure:"as-group"`
-	Extra string   `mapstructure:"as-extras"`
-}
-
-func (o *ExportOptions) setExtras() error {
-	if o.Extra == "" {
-		return nil
-	}
-	keysAndStrings := strings.Split(o.Extra, ";")
-	o.extras = map[string][]string{}
-	for _, keysAndString := range keysAndStrings {
-		keyString := strings.Split(keysAndString, "=")
-		if len(keyString) != 2 {
-			// Todo: Much better error message here.
-			return fmt.Errorf("invalid extra options")
-		}
-		o.extras[keyString[0]] = strings.Split(keyString[1], ",")
-	}
-	return nil
-}
-
 func (o *ExportOptions) Complete(c *cobra.Command, args []string) error {
-	// TODO: @alpatel
+	var err error
+	o.rawConfig, err = o.configFlags.ToRawKubeConfigLoader().RawConfig()
+	if err != nil {
+		return err
+	}
+
+	o.namespace, _, err = o.configFlags.ToRawKubeConfigLoader().Namespace()
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
 func (o *ExportOptions) Validate() error {
-	// TODO: @alpatel
-	if len(o.User) == 0 && len(o.Group) == 0 && len(o.Extra) != 0 {
-		return fmt.Errorf("if adding extras must also provide a group or user")
-	}
-
-	if err := o.setExtras(); err != nil {
-		return err
-	}
+	// This is where pre-run validations should be performed
 	return nil
 }
 
 func (o *ExportOptions) Run() error {
-	return o.run()
+	var err error
+
+	log := o.globalFlags.GetLogger()
+
+	// create export directory if it doesnt exist
+	err = os.MkdirAll(filepath.Join(o.exportDir, "resources", o.namespace), 0700)
+	switch {
+	case os.IsExist(err):
+	case err != nil:
+		log.Errorf("error creating the resources directory: %#v", err)
+		return err
+	}
+
+	// create export directory if it doesnt exist
+	err = os.MkdirAll(filepath.Join(o.exportDir, "failures", o.namespace), 0700)
+	switch {
+	case os.IsExist(err):
+	case err != nil:
+		log.Errorf("error creating the failures directory: %#v", err)
+		return err
+	}
+
+	discoveryClient, err := o.configFlags.ToDiscoveryClient()
+	if err != nil {
+		log.Errorf("cannot create discovery client: %#v", err)
+		return err
+	}
+
+	// Always request fresh data from the server
+	discoveryClient.Invalidate()
+
+	restConfig, err := o.configFlags.ToRESTConfig()
+	if err != nil {
+		log.Errorf("cannot create rest config: %#v", err)
+		return err
+	}
+
+	dynamicClient := dynamic.NewForConfigOrDie(restConfig)
+
+	features.NewFeatureFlagSet()
+
+	discoveryHelper, err := discovery.NewHelper(discoveryClient, log)
+	if err != nil {
+		log.Errorf("cannot create discovery helper: %#v", err)
+		return err
+	}
+
+	var errs []error
+
+	resources, resourceErrs := resourceToExtract(o.namespace, dynamicClient, discoveryHelper.Resources(), log)
+
+	log.Debugf("attempting to write resources to files\n")
+	writeResourcesErrors := writeResources(resources, filepath.Join(o.exportDir, "resources", o.namespace), log)
+	for _, e := range writeResourcesErrors {
+		log.Warnf("error writing manifests to file: %#v, ignoring\n", e)
+	}
+
+	writeErrorsErrors := writeErrors(resourceErrs, filepath.Join(o.exportDir, "failures", o.namespace), log)
+	for _, e := range writeErrorsErrors {
+		log.Warnf("error writing errors to file: %#v, ignoring\n", e)
+	}
+
+	errs = append(errs, writeResourcesErrors...)
+	errs = append(errs, writeErrorsErrors...)
+
+	return errorsutil.NewAggregate(errs)
 }
 
 func NewExportCommand(streams genericclioptions.IOStreams, f *flags.GlobalFlags) *cobra.Command {
@@ -108,134 +146,12 @@ func NewExportCommand(streams genericclioptions.IOStreams, f *flags.GlobalFlags)
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
 			viper.BindPFlags(cmd.Flags())
-			viper.Unmarshal(&o.Flags)
 			viper.Unmarshal(&o.globalFlags)
 		},
 	}
 
-	addFlagsForOptions(&o.cobraFlags, cmd)
+	cmd.Flags().StringVarP(&o.exportDir, "export-dir", "e", "export", "The path where files are to be exported")
+	o.configFlags.AddFlags(cmd.Flags())
 
 	return cmd
-}
-
-func addFlagsForOptions(o *Flags, cmd *cobra.Command) {
-	cmd.Flags().StringVarP(&o.ExportDir, "export-dir", "e", "export", "The path where files are to be exported")
-	cmd.Flags().StringVar(&o.Context, "context", "", "The kube context, if empty it will use the current context. If --namespace is set it will take precedence")
-	cmd.Flags().StringVarP(&o.Namespace, "namespace", "n", "", "The kube namespace to export.")
-	cmd.Flags().StringVar(&o.User, "as-user", "", "The user to impersonation.")
-	cmd.Flags().StringSliceVar(&o.Group, "as-group", nil, "The group to impersonation.")
-	cmd.Flags().StringVar(&o.Extra, "as-extras", "", "The extra info for impersonation can only be used with User or Group but is not required. An eample is --as-extras key=string1,string2;key2=string3")
-}
-
-func (o *ExportOptions) run() error {
-	log := o.globalFlags.GetLogger()
-
-	config := o.configFlags.ToRawKubeConfigLoader()
-	rawConfig, err := config.RawConfig()
-	if err != nil {
-		log.Errorf("error in generating raw config")
-		return err
-	}
-	if o.Context == "" {
-		o.Context = rawConfig.CurrentContext
-	}
-
-	if o.Context == "" {
-		log.Errorf("current kubecontext is empty and not kubecontext is specified")
-		return fmt.Errorf("current kubecontext is empty and not kubecontext is specified")
-	}
-
-	var currentContext *api.Context
-	contextName := ""
-
-	for name, ctx := range rawConfig.Contexts {
-		if name == o.Context {
-			currentContext = ctx
-			contextName = name
-		}
-	}
-
-	if currentContext == nil {
-		log.Errorf("currentContext is nil\n")
-		return err
-	}
-
-	if o.Namespace == "" {
-		log.Debugf("--namespace is empty, defaulting to current context namespace\n")
-		if currentContext.Namespace == "" {
-			log.Errorf("current context %s namespace is empty, exiting\n", contextName)
-			return fmt.Errorf("current context %s namespace is empty, exiting", contextName)
-		}
-		o.Namespace = currentContext.Namespace
-	}
-
-	log.Debugf("current context is: %s\n", currentContext.AuthInfo)
-
-	// create export directory if it doesnt exist
-	err = os.MkdirAll(filepath.Join(o.ExportDir, "resources", o.Namespace), 0700)
-	switch {
-	case os.IsExist(err):
-	case err != nil:
-		log.Errorf("error creating the resources directory: %#v", err)
-		return err
-	}
-
-	// create export directory if it doesnt exist
-	err = os.MkdirAll(filepath.Join(o.ExportDir, "failures", o.Namespace), 0700)
-	switch {
-	case os.IsExist(err):
-	case err != nil:
-		log.Errorf("error creating the failures directory: %#v", err)
-		return err
-	}
-
-	discoveryClient, err := o.configFlags.ToDiscoveryClient()
-	if err != nil {
-		log.Errorf("cannot create discovery client: %#v", err)
-		return err
-	}
-
-	// Always request fresh data from the server
-	discoveryClient.Invalidate()
-
-	restConfig, err := o.configFlags.ToRESTConfig()
-	if err != nil {
-		log.Errorf("cannot create rest config: %#v", err)
-		return err
-	}
-
-	// Act as th user requested by the CLI
-	restConfig.Impersonate.UserName = o.User
-	restConfig.Impersonate.Groups = o.Group
-	restConfig.Impersonate.Extra = o.extras
-
-	dynamicClient := dynamic.NewForConfigOrDie(restConfig)
-
-	features.NewFeatureFlagSet()
-
-	discoveryHelper, err := discovery.NewHelper(discoveryClient, log)
-	if err != nil {
-		log.Errorf("cannot create discovery helper: %#v", err)
-		return err
-	}
-
-	var errs []error
-
-	resources, resourceErrs := resourceToExtract(o.Namespace, dynamicClient, discoveryHelper.Resources(), log)
-
-	log.Debugf("attempting to write resources to files\n")
-	writeResourcesErrors := writeResources(resources, filepath.Join(o.ExportDir, "resources", o.Namespace), log)
-	for _, e := range writeResourcesErrors {
-		log.Warnf("error writing manifests to file: %#v, ignoring\n", e)
-	}
-
-	writeErrorsErrors := writeErrors(resourceErrs, filepath.Join(o.ExportDir, "failures", o.Namespace), log)
-	for _, e := range writeErrorsErrors {
-		log.Warnf("error writing errors to file: %#v, ignoring\n", e)
-	}
-
-	errs = append(errs, writeResourcesErrors...)
-	errs = append(errs, writeErrorsErrors...)
-
-	return errorsutil.NewAggregate(errs)
 }

--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -25,8 +25,7 @@ type ExportOptions struct {
 	globalFlags      *flags.GlobalFlags
 
 	rawConfig api.Config
-	exportDir string `mapstructure:"export-dir"`
-	// TODO(djzager): how do we handle viper + k8s cli options?
+	exportDir string
 	namespace string
 
 	genericclioptions.IOStreams
@@ -147,6 +146,8 @@ func NewExportCommand(streams genericclioptions.IOStreams, f *flags.GlobalFlags)
 		PreRun: func(cmd *cobra.Command, args []string) {
 			viper.BindPFlags(cmd.Flags())
 			viper.Unmarshal(&o.globalFlags)
+			viper.Unmarshal(&o.configFlags)
+			viper.UnmarshalKey("export-dir", &o.exportDir)
 		},
 	}
 

--- a/internal/flags/global_flags.go
+++ b/internal/flags/global_flags.go
@@ -35,5 +35,4 @@ func (g *GlobalFlags) initConfig() {
 	if err := viper.ReadInConfig(); err == nil {
 		g.GetLogger().Infof("Using config file: %v", viper.ConfigFileUsed())
 	}
-
 }


### PR DESCRIPTION
Several of the methods from cli-runtime's genericclioptions package
expect for the AddFlags() method to be called first. Calling AddFlags()
first should allow us to remove some options and rely on cli-runtime to
handle cluster/namespace/context/auth/etc for us.

Fixes #67 