### PR TITLE
feat: lay down kustomization in apply

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,5 +19,6 @@ require (
 	k8s.io/cli-runtime v0.22.2
 	k8s.io/client-go v0.22.2
 	sigs.k8s.io/controller-runtime v0.10.1
+	sigs.k8s.io/kustomize/api v0.8.11
 	sigs.k8s.io/yaml v1.3.0
 )

--- a/internal/file/file_helper.go
+++ b/internal/file/file_helper.go
@@ -112,3 +112,9 @@ func (opts *PathOpts) GetOutputFilePath(filePath string) string {
 	dir = strings.Replace(dir, opts.ExportDir, opts.OutputDir, 1)
 	return filepath.Join(dir, fname)
 }
+
+func (opts *PathOpts) GetKustomizationFilePath(filePath string) string {
+	dir, _ := filepath.Split(filePath)
+	dir = strings.Replace(dir, opts.ExportDir, opts.OutputDir, 1)
+	return filepath.Join(dir, "kustomization.yaml")
+}


### PR DESCRIPTION
Include kustomization.yaml in the output directory so that it can be
used with kustomize directly (overriding namespace etc.).