### PR TITLE
Corrected the typo  `crane export --help`

### DIFF
--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -174,7 +174,7 @@ func NewExportCommand(streams genericclioptions.IOStreams, f *flags.GlobalFlags)
 	}
 
 	cmd.Flags().StringVarP(&o.exportDir, "export-dir", "e", "export", "The path where files are to be exported")
-	cmd.Flags().StringVar(&o.asExtras, "as-extras", "", "The extra info for impersonation can only be used with User or Group but is not required. An eample is --as-extras key=string1,string2;key2=string3")
+	cmd.Flags().StringVar(&o.asExtras, "as-extras", "", "The extra info for impersonation can only be used with User or Group but is not required. An example is --as-extras key=string1,string2;key2=string3")
 	o.configFlags.AddFlags(cmd.Flags())
 
 	return cmd


### PR DESCRIPTION
Correct the typo "example" in the description of `oc export --as-extras`. This meets the 1st point in https://github.com/konveyor/crane/issues/71

I have just started exploring crane, so in case the 2 & 3 points in https://github.com/konveyor/crane/issues/71 are also required, I'd be happy to add those as well in the same PR. Let me know, thanks!
