### PR TITLE
update cli doc to make it clear how to use slice/map params

### DIFF
--- a/cmd/transform/transform.go
+++ b/cmd/transform/transform.go
@@ -95,7 +95,7 @@ func addFlagsForOptions(o *Flags, cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&o.TransformDir, "transform-dir", "t", "transform", "The path where files that contain the transformations are saved")
 	cmd.Flags().StringVar(&o.IgnoredPatchesDir, "ignored-patches-dir", "", "The path where files that contain transformations that were discarded due to conflicts are saved. If left blank, these files will not be saved.")
 	cmd.Flags().StringSliceVar(&o.PluginPriorities, "plugin-priorities", nil, "A comma-separated list of plugin names. A plugin listed will take priority in the case of patch conflict over a plugin listed later in the list or over one not listed at all.")
-	cmd.Flags().StringToStringVar(&o.OptionalFlags, "optional-flags", nil, "A comma-separated list of flag-name=value pairs. These flags with values will be passed into all plugins that are executed in the transform operation.")
+	cmd.Flags().StringToStringVar(&o.OptionalFlags, "optional-flags", nil, "A comma-separated list of flag-name=value pairs. These flags with values will be passed into all plugins that are executed in the transform operation. Note that for array/slice or map-valued parameters, placing double quotes around the <paramName>=<paramValue> pair is required. In addition, if any map or slice params are included, the entire param list must be enclosed in single quotes. (ie. '\"foo-flag=foo-a=/data,foo-b=/data\",bar-flag=bar-value')")
 	// These flags pass down to subcommands
 	cmd.PersistentFlags().StringVarP(&o.PluginDir, "plugin-dir", "p", "plugins", "The path where binary plugins are located")
 	cmd.PersistentFlags().StringSliceVarP(&o.SkipPlugins, "skip-plugins", "s", nil, "A comma-separated list of plugins to skip")
@@ -150,6 +150,7 @@ func (o *Options) run() error {
 	}
 	if len(o.OptionalFlags) > 0 {
 		runner.OptionalFlags = optionalFlagsToLower(o.OptionalFlags)
+		log.Debugf("parsed optional-flags: %v", runner.OptionalFlags)
 	}
 
 	for _, f := range files {


### PR DESCRIPTION
As we discussed earlier on slack, we may still want to revisit this to see if we can find a way to refactor this to remove the need for the extra layer of quoting, but in the meantime, this doc update makes it clear how to input doc and map params in the optional-flags list.