### PR TITLE
Allow restricting export using a label selector

### DIFF
--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -29,6 +29,7 @@ type ExportOptions struct {
 
 	rawConfig              api.Config
 	exportDir              string
+	labelSelector          string
 	userSpecifiedNamespace string
 	asExtras               string
 	extras                 map[string][]string
@@ -129,7 +130,7 @@ func (o *ExportOptions) Run() error {
 
 	var errs []error
 
-	resources, resourceErrs := resourceToExtract(o.userSpecifiedNamespace, dynamicClient, discoveryHelper.Resources(), discoveryHelper.APIGroups(), log)
+	resources, resourceErrs := resourceToExtract(o.userSpecifiedNamespace, o.labelSelector, dynamicClient, discoveryHelper.Resources(), discoveryHelper.APIGroups(), log)
 
 	log.Debugf("attempting to write resources to files\n")
 	writeResourcesErrors := writeResources(resources, filepath.Join(o.exportDir, "resources", o.userSpecifiedNamespace), log)
@@ -180,6 +181,7 @@ func NewExportCommand(streams genericclioptions.IOStreams, f *flags.GlobalFlags)
 	}
 
 	cmd.Flags().StringVarP(&o.exportDir, "export-dir", "e", "export", "The path where files are to be exported")
+	cmd.Flags().StringVarP(&o.labelSelector, "label-selector", "l", "export", "Restrict export to resources matching a label selector")
 	cmd.Flags().StringVar(&o.asExtras, "as-extras", "", "The extra info for impersonation can only be used with User or Group but is not required. An example is --as-extras key=string1,string2;key2=string3")
 	cmd.Flags().Float32VarP(&o.QPS, "qps", "q", 100, "Query Per Second Rate.")
 	cmd.Flags().IntVarP(&o.Burst, "burst", "b", 1000, "API Burst Rate.")


### PR DESCRIPTION
```
$ rm -rf export
$ crane export -l "app=mariadb-1" 2>/dev/null
$ ls export/resources/mediawiki/
Deployment_apps_v1_mediawiki_mariadb-1.yaml                       Pod__v1_mediawiki_mariadb-1-68bd8b966d-2rntb.yaml
EndpointSlice_discovery.k8s.io_v1_mediawiki_mariadb-1-6xrtw.yaml  ReplicaSet_apps_v1_mediawiki_mariadb-1-68bd8b966d.yaml
Endpoints__v1_mediawiki_mariadb-1.yaml                            Service__v1_mediawiki_mariadb-1.yaml

$ rm -rf export
$ crane export -l "app=mariadb-2,service=mariadb" 2>/dev/null
$ ls export/resources/mediawiki/
Deployment_apps_v1_mediawiki_mariadb-2.yaml                       Pod__v1_mediawiki_mariadb-2-64b44675c9-2blsp.yaml       Service__v1_mediawiki_mariadb-2.yaml
EndpointSlice_discovery.k8s.io_v1_mediawiki_mariadb-2-bcjzr.yaml  ReplicaSet_apps_v1_mediawiki_mariadb-2-64b44675c9.yaml
Endpoints__v1_mediawiki_mariadb-2.yaml                            ReplicaSet_apps_v1_mediawiki_mariadb-2-78bb6b6796.yaml

$ rm -rf export
$ crane export -l "service=mariadb" 2>/dev/null
$ ls export/resources/mediawiki/
Deployment_apps_v1_mediawiki_mariadb-1.yaml                       Pod__v1_mediawiki_mariadb-2-64b44675c9-2blsp.yaml
Deployment_apps_v1_mediawiki_mariadb-2.yaml                       ReplicaSet_apps_v1_mediawiki_mariadb-1-68bd8b966d.yaml
EndpointSlice_discovery.k8s.io_v1_mediawiki_mariadb-1-6xrtw.yaml  ReplicaSet_apps_v1_mediawiki_mariadb-2-64b44675c9.yaml
EndpointSlice_discovery.k8s.io_v1_mediawiki_mariadb-2-bcjzr.yaml  ReplicaSet_apps_v1_mediawiki_mariadb-2-78bb6b6796.yaml
Endpoints__v1_mediawiki_mariadb-1.yaml                            Service__v1_mediawiki_mariadb-1.yaml
Endpoints__v1_mediawiki_mariadb-2.yaml                            Service__v1_mediawiki_mariadb-2.yaml
```