### PR TITLE
fix pvc transfer issue by removing password related code and bumping …

### DIFF
--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	random "math/rand"
 	"os"
 	"strings"
 	"time"
@@ -392,8 +391,6 @@ func (t *TransferPVCCommand) run() error {
 	destPVCList := transfer.NewSingletonPVC(destPVC)
 	srcPVCList := transfer.NewSingletonPVC(srcPVC)
 
-	rsyncPassword := getRsyncPassword()
-
 	serverPodSecContext, err := getRsyncServerPodSecurityContext(destClient, destPVC.Namespace)
 	if err != nil {
 		log.Fatal(err, "error creating security context for rsync server")
@@ -404,7 +401,7 @@ func (t *TransferPVCCommand) run() error {
 	rsyncServer, err := rsynctransfer.NewServer(
 		context.TODO(),
 		destClient,
-		logger, destPVCList, stunnelServer, e, labels, nil, rsyncPassword,
+		logger, destPVCList, stunnelServer, e, labels, nil,
 		transfer.PodOptions{
 			ContainerSecurityContext: corev1.SecurityContext{
 				Capabilities: &corev1.Capabilities{
@@ -447,7 +444,7 @@ func (t *TransferPVCCommand) run() error {
 
 	_, err = rsynctransfer.NewClient(
 		context.TODO(),
-		srcClient, srcPVCList, stunnelClient, e, logger, "rsync-client", labels, nil, rsyncPassword,
+		srcClient, srcPVCList, stunnelClient, logger, "rsync-client", labels, nil,
 		transfer.PodOptions{
 			NodeName: nodeName,
 			CommandOptions: rsynctransfer.NewDefaultOptionsFrom(
@@ -513,17 +510,6 @@ func getNodeNameForPVC(srcClient client.Client, namespace string, pvcName string
 		}
 	}
 	return "", nil
-}
-
-// getRsyncPassword returns a random password for rsync
-func getRsyncPassword() string {
-	var letters = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
-	random.Seed(time.Now().UnixNano())
-	password := make([]byte, 6)
-	for i := range password {
-		password[i] = letters[random.Intn(len(letters))]
-	}
-	return string(password)
 }
 
 func getIDsForNamespace(client client.Client, namespace string) (*corev1.SecurityContext, error) {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.4
 
 require (
-	github.com/backube/pvc-transfer v0.0.0-20220718185428-1d2440958552
+	github.com/backube/pvc-transfer v0.0.0-20220810121213-5f9e29a1f6e5
 	github.com/bombsimon/logrusr/v3 v3.0.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws/aws-sdk-go v1.28.2/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
-github.com/backube/pvc-transfer v0.0.0-20220718185428-1d2440958552 h1:0QNd+XrqNpOt4vsO29EQg2IZKohmX3wugdWROMyNVpg=
-github.com/backube/pvc-transfer v0.0.0-20220718185428-1d2440958552/go.mod h1:pkCOc4hLmDHNAqgZGOypDcaHEi2dGgjqP9jMshlNvYw=
+github.com/backube/pvc-transfer v0.0.0-20220810121213-5f9e29a1f6e5 h1:unOJfSjp5VZ9XK5+qVLSf+0Txce7qIostmT92koibc8=
+github.com/backube/pvc-transfer v0.0.0-20220810121213-5f9e29a1f6e5/go.mod h1:pkCOc4hLmDHNAqgZGOypDcaHEi2dGgjqP9jMshlNvYw=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=


### PR DESCRIPTION
**Problem**

When running crane transfer-pvc to copy PVC data between clusters, the rsync client pod on the source cluster fails with:
@ERROR: auth failed on module <module-id>rsync error: error starting client-server protocol (code 5)

The client pod's RSYNC_PASSWORD env var has no value and no SecretKeyRef, so it never authenticates with the rsync server. The expected client-side password secret (backube-rsync-password-*) is never created on the source cluster.

**Root Cause**

Crane was pinned to an old version of github.com/backube/pvc-transfer (v0.0.0-20220718185428-1d2440958552, Jul 18, 2022) which used rsync password-based authentication. 

**Fix**

Bump github.com/backube/pvc-transfer from v0.0.0-20220718185428-1d2440958552 to v0.0.0-20220810121213-5f9e29a1f6e5
Remove getRsyncPassword() function and math/rand import
Remove rsyncPassword parameter from rsynctransfer.NewServer()
Remove rsyncPassword and endpoint parameters from rsynctransfer.NewClient()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streamlined rsync authentication handling in transfer operations

* **Chores**
  * Updated pvc-transfer dependency to latest version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->