### PR TITLE
Improve shell script safety in minikube-clusters-start.sh

### DIFF
--- a/hack/minikube-clusters-start.sh
+++ b/hack/minikube-clusters-start.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set +x
+set -euo pipefail
 
 SRC_CLUSTER_NAME=src
 DEST_CLUSTER_NAME=dest


### PR DESCRIPTION
## Summary
- Replace `set +x` with `set -euo pipefail` to improve script safety and error handling

## Details
This change improves the safety of the minikube cluster setup script by:
- **Exit on errors** (`set -e`): Script will stop if any command fails instead of continuing
- **Treat unset variables as errors** (`set -u`): Catches typos and undefined variables  
- **Fail on pipeline errors** (`set -o pipefail`): Properly detects failures in piped commands

The previous `set +x` disabled debug output (which was already off by default), providing no benefit.

## Context
This addresses a security issue identified in a codebase audit. While this is a test/development script with low severity, following shell scripting best practices prevents potential issues and sets a good example.

## Test plan
- [ ] Verify script still creates clusters successfully
- [ ] Test that script properly exits on errors (e.g., if minikube not installed)
- [ ] Confirm networking setup completes without issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error handling in cluster startup script to ensure stricter execution and more reliable failure detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->