### PR TITLE
Fix nil pointer dereference on TransferredData in progress status check

### DIFF
--- a/cmd/transfer-pvc/progress.go
+++ b/cmd/transfer-pvc/progress.go
@@ -301,7 +301,7 @@ func (p *Progress) Status() status {
 			return succeeded
 		}
 		if p.TransferredFiles == 0 &&
-			p.TransferredData.val == 0 &&
+			(p.TransferredData == nil || p.TransferredData.val == 0) &&
 			p.TotalFiles == nil {
 			return failed
 		}


### PR DESCRIPTION
## Summary

- Add nil check for `TransferredData` in `Progress.Status()` to prevent panic when rsync fails without transferring any data

## Problem

When `transfer-pvc` rsync retries are exhausted, the progress tracking code accesses `p.TransferredData.val` without checking if `TransferredData` is nil. This causes a nil pointer dereference panic instead of a clean "Failed" status.

## Fix

Added a nil check for `p.TransferredData` before accessing `.val` in `progress.go:304`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential crash in PVC transfer progress tracking when transfer data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->