### PR TITLE
Update README with old-main branch and tag links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Crane 
 
-**Important: This repository is under active development including breaking changes. If you looking for the `crane` you used in last few years, use the [old-main](https://github.com/migtools/crane/tree/old-main) branch or [v0.0.6](https://github.com/migtools/crane/releases/tag/v0.0.6) tag.**
+**Important: This repository is under active development including breaking changes. If you are looking for the `crane` you used in last few years, use the [old-main](https://github.com/migtools/crane/tree/old-main) branch or [v0.0.6](https://github.com/migtools/crane/releases/tag/v0.0.6) tag.**
 
 ---
 


### PR DESCRIPTION
Expecting possible breaking changes to come in this repo, so created old-main branch and linked v0.0.6 tag into readme, so existing users could continue using original crane.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a prominent “Important” notice at the top of the documentation indicating active development and potential breaking changes, separated from other content.
  * Added clear pointers to the previous stable release (branch and release tag) for users who need the earlier behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->