### PR TITLE
Added missing User & Group Subject checks for CRB & SCCs

### DIFF
--- a/cmd/export/cluster.go
+++ b/cmd/export/cluster.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	authv1 "github.com/openshift/api/authorization/v1"
 	securityv1 "github.com/openshift/api/security/v1"
 	"github.com/sirupsen/logrus"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -87,6 +87,52 @@ func NewClusterScopedRbacHandler(log logrus.FieldLogger) *ClusterScopedRbacHandl
 	return handler
 }
 
+// serviceAccountsGroupPrefix is the OpenShift/Kubernetes group that contains all
+// ServiceAccounts in a namespace (used in ClusterRoleBinding subjects and SCC groups).
+const serviceAccountsGroupPrefix = "system:serviceaccounts:"
+
+// exportedSANamespaces returns distinct namespaces of exported ServiceAccounts.
+func (c *ClusterScopedRbacHandler) exportedSANamespaces() map[string]struct{} {
+	m := make(map[string]struct{})
+	for _, sa := range c.serviceAccounts {
+		if ns := sa.GetNamespace(); ns != "" {
+			m[ns] = struct{}{}
+		}
+	}
+	return m
+}
+
+// groupMatchesExportedSANamespaces is true when groupName is exactly
+// system:serviceaccounts:<ns> for some exported SA namespace. Broad groups
+// (e.g. system:authenticated) are rejected.
+func groupMatchesExportedSANamespaces(groupName string, nsSet map[string]struct{}) bool {
+	if len(nsSet) == 0 {
+		return false
+	}
+	if !strings.HasPrefix(groupName, serviceAccountsGroupPrefix) {
+		return false
+	}
+	ns := strings.TrimPrefix(groupName, serviceAccountsGroupPrefix)
+	if ns == "" {
+		return false
+	}
+	_, ok := nsSet[ns]
+	return ok
+}
+
+// parseServiceAccountUserSubject parses user principal strings of the form
+// system:serviceaccount:<namespace>:<serviceaccountname>.
+func parseServiceAccountUserSubject(userName string) (namespace, saName string, ok bool) {
+	parts := strings.Split(userName, ":")
+	if len(parts) != 4 || parts[0] != "system" || parts[1] != "serviceaccount" {
+		return "", "", false
+	}
+	if parts[2] == "" || parts[3] == "" {
+		return "", "", false
+	}
+	return parts[2], parts[3], true
+}
+
 func (c *ClusterScopedRbacHandler) prepareForFiltering() {
 	c.readyToFilter = true
 	c.log.Infof("Preparing matching ClusterRoleBindings")
@@ -158,15 +204,35 @@ func (c *ClusterScopedRbacHandler) accept(kind string, clusterResource unstructu
 }
 
 func (c *ClusterScopedRbacHandler) acceptClusterRoleBinding(clusterResource unstructured.Unstructured) bool {
-	var crb authv1.ClusterRoleBinding
+	var crb rbacv1.ClusterRoleBinding
 	err := runtime.DefaultUnstructuredConverter.
 		FromUnstructured(clusterResource.Object, &crb)
 	if err != nil {
-		c.log.Warnf("Cannot convert to authv1.ClusterRoleBinding: %s", err)
-	} else {
-		for _, s := range crb.Subjects {
-			if s.Kind == "ServiceAccount" && c.anyServiceAccountInNamespace(s.Namespace, s.Name) {
+		c.log.Warnf("Cannot convert to rbacv1.ClusterRoleBinding: %s", err)
+		return false
+	}
+	nsSet := c.exportedSANamespaces()
+	if len(nsSet) == 0 {
+		return false
+	}
+	for _, s := range crb.Subjects {
+		switch s.Kind {
+		case rbacv1.ServiceAccountKind:
+			if c.anyServiceAccountInNamespace(s.Namespace, s.Name) {
 				c.log.Infof("Accepted %s of kind %s", clusterResource.GetName(), clusterResource.GetKind())
+				return true
+			}
+		case rbacv1.GroupKind:
+			if groupMatchesExportedSANamespaces(s.Name, nsSet) {
+				c.log.Infof("Accepted %s of kind %s (match via Group %s)",
+					clusterResource.GetName(), clusterResource.GetKind(), s.Name)
+				return true
+			}
+		case rbacv1.UserKind:
+			ns, saName, ok := parseServiceAccountUserSubject(s.Name)
+			if ok && c.anyServiceAccountInNamespace(ns, saName) {
+				c.log.Infof("Accepted %s of kind %s (match via User %s)",
+					clusterResource.GetName(), clusterResource.GetKind(), s.Name)
 				return true
 			}
 		}
@@ -175,18 +241,18 @@ func (c *ClusterScopedRbacHandler) acceptClusterRoleBinding(clusterResource unst
 }
 
 func (c *ClusterScopedRbacHandler) acceptClusterRole(clusterResource unstructured.Unstructured) bool {
-	var cr authv1.ClusterRole
+	var cr rbacv1.ClusterRole
 	err := runtime.DefaultUnstructuredConverter.
 		FromUnstructured(clusterResource.Object, &cr)
 	if err != nil {
-		c.log.Warnf("Cannot convert to authv1.ClusterRole: %s", err)
+		c.log.Warnf("Cannot convert to rbacv1.ClusterRole: %s", err)
 	} else {
 		for _, f := range c.filteredClusterRoleBindings.objects.Items {
-			var crb authv1.ClusterRoleBinding
+			var crb rbacv1.ClusterRoleBinding
 			err := runtime.DefaultUnstructuredConverter.
 				FromUnstructured(f.Object, &crb)
 			if err != nil {
-				c.log.Warnf("Cannot convert to authv1.ClusterRoleBinding: %s", err)
+				c.log.Warnf("Cannot convert to rbacv1.ClusterRoleBinding: %s", err)
 			} else {
 				if crb.RoleRef.Kind == "ClusterRole" && crb.RoleRef.Name == cr.Name {
 					c.log.Infof("Accepted %s of kind %s", clusterResource.GetName(), clusterResource.GetKind())
@@ -208,11 +274,11 @@ func (c *ClusterScopedRbacHandler) acceptSecurityContextConstraints(clusterResou
 	}
 
 	for _, f := range c.filteredClusterRoleBindings.objects.Items {
-		var crb authv1.ClusterRoleBinding
+		var crb rbacv1.ClusterRoleBinding
 		err := runtime.DefaultUnstructuredConverter.
 			FromUnstructured(f.Object, &crb)
 		if err != nil {
-			c.log.Warnf("Cannot convert to authv1.ClusterRoleBinding: %s", err)
+			c.log.Warnf("Cannot convert to rbacv1.ClusterRoleBinding: %s", err)
 			continue
 		}
 
@@ -231,14 +297,19 @@ func (c *ClusterScopedRbacHandler) acceptSecurityContextConstraints(clusterResou
 
 	// Last option, look at the users field if it contains one of the exported serviceaccounts
 	for _, u := range scc.Users {
-		if strings.Contains(u, "system:serviceaccount:") && len(strings.Split(u, ":")) == 4 {
-			namespaceName := strings.Split(u, ":")[2]
-			serviceAccountName := strings.Split(u, ":")[3]
-			if c.anyServiceAccountInNamespace(namespaceName, serviceAccountName) {
-				c.log.Infof("Accepted %s of kind %s (match wia user %s)",
-					clusterResource.GetName(), clusterResource.GetKind(), u)
-				return true
-			}
+		if ns, saName, ok := parseServiceAccountUserSubject(u); ok && c.anyServiceAccountInNamespace(ns, saName) {
+			c.log.Infof("Accepted %s of kind %s (match via user %s)",
+				clusterResource.GetName(), clusterResource.GetKind(), u)
+			return true
+		}
+	}
+
+	nsSet := c.exportedSANamespaces()
+	for _, g := range scc.Groups {
+		if groupMatchesExportedSANamespaces(g, nsSet) {
+			c.log.Infof("Accepted %s of kind %s (match via group %s)",
+				clusterResource.GetName(), clusterResource.GetKind(), g)
+			return true
 		}
 	}
 

--- a/cmd/export/cluster_test.go
+++ b/cmd/export/cluster_test.go
@@ -1,0 +1,289 @@
+package export
+
+import (
+	"io"
+	"testing"
+
+	securityv1 "github.com/openshift/api/security/v1"
+	"github.com/sirupsen/logrus"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func testLogger() logrus.FieldLogger {
+	l := logrus.New()
+	l.SetOutput(io.Discard)
+	return l
+}
+
+func clusterRoleBindingToUnstructured(t *testing.T, crb *rbacv1.ClusterRoleBinding) unstructured.Unstructured {
+	t.Helper()
+	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(crb)
+	if err != nil {
+		t.Fatalf("ToUnstructured: %v", err)
+	}
+	return unstructured.Unstructured{Object: u}
+}
+
+func securityContextConstraintsToUnstructured(t *testing.T, scc *securityv1.SecurityContextConstraints) unstructured.Unstructured {
+	t.Helper()
+	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(scc)
+	if err != nil {
+		t.Fatalf("ToUnstructured: %v", err)
+	}
+	return unstructured.Unstructured{Object: u}
+}
+
+func TestParseServiceAccountUserSubject(t *testing.T) {
+	tests := []struct {
+		user     string
+		wantNS   string
+		wantSA   string
+		wantOK   bool
+	}{
+		{"system:serviceaccount:my-ns:app-sa", "my-ns", "app-sa", true},
+		{"system:serviceaccount:my-ns:", "", "", false},
+		{"system:serviceaccount::app-sa", "", "", false},
+		{"user:alice", "", "", false},
+		{"system:authenticated", "", "", false},
+		{"system:serviceaccounts:my-ns", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.user, func(t *testing.T) {
+			ns, sa, ok := parseServiceAccountUserSubject(tt.user)
+			if ok != tt.wantOK || ns != tt.wantNS || sa != tt.wantSA {
+				t.Fatalf("parseServiceAccountUserSubject(%q) = (%q,%q,%v), want (%q,%q,%v)",
+					tt.user, ns, sa, ok, tt.wantNS, tt.wantSA, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestGroupMatchesExportedSANamespaces(t *testing.T) {
+	nsSet := map[string]struct{}{"my-ns": {}, "other": {}}
+	tests := []struct {
+		group string
+		want  bool
+	}{
+		{"system:serviceaccounts:my-ns", true},
+		{"system:serviceaccounts:other", true},
+		{"system:serviceaccounts:foreign", false},
+		{"system:authenticated", false},
+		{"system:serviceaccounts:", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := groupMatchesExportedSANamespaces(tt.group, nsSet); got != tt.want {
+			t.Errorf("groupMatchesExportedSANamespaces(%q) = %v, want %v", tt.group, got, tt.want)
+		}
+	}
+	if groupMatchesExportedSANamespaces("system:serviceaccounts:my-ns", nil) {
+		t.Error("empty nsSet should not match")
+	}
+}
+
+func TestAcceptClusterRoleBinding_Subjects(t *testing.T) {
+	roleRef := rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "role1"}
+
+	t.Run("ServiceAccount subject", func(t *testing.T) {
+		h := NewClusterScopedRbacHandler(testLogger())
+		sa := unstructured.Unstructured{}
+		sa.SetName("app-sa")
+		sa.SetNamespace("my-ns")
+		h.serviceAccounts = []unstructured.Unstructured{sa}
+
+		crb := &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "crb-sa"},
+			Subjects: []rbacv1.Subject{
+				{Kind: rbacv1.ServiceAccountKind, Namespace: "my-ns", Name: "app-sa"},
+			},
+			RoleRef: roleRef,
+		}
+		u := clusterRoleBindingToUnstructured(t, crb)
+		if !h.acceptClusterRoleBinding(u) {
+			t.Fatal("expected accept for ServiceAccount subject")
+		}
+	})
+
+	t.Run("Group system:serviceaccounts namespace", func(t *testing.T) {
+		h := NewClusterScopedRbacHandler(testLogger())
+		sa := unstructured.Unstructured{}
+		sa.SetName("any-sa")
+		sa.SetNamespace("my-ns")
+		h.serviceAccounts = []unstructured.Unstructured{sa}
+
+		crb := &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "crb-group"},
+			Subjects: []rbacv1.Subject{
+				{Kind: rbacv1.GroupKind, APIGroup: rbacv1.GroupName, Name: "system:serviceaccounts:my-ns"},
+			},
+			RoleRef: roleRef,
+		}
+		u := clusterRoleBindingToUnstructured(t, crb)
+		if !h.acceptClusterRoleBinding(u) {
+			t.Fatal("expected accept for Group subject matching exported namespace")
+		}
+	})
+
+	t.Run("Group other namespace rejected", func(t *testing.T) {
+		h := NewClusterScopedRbacHandler(testLogger())
+		sa := unstructured.Unstructured{}
+		sa.SetName("app-sa")
+		sa.SetNamespace("my-ns")
+		h.serviceAccounts = []unstructured.Unstructured{sa}
+
+		crb := &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "crb-wrong-ns"},
+			Subjects: []rbacv1.Subject{
+				{Kind: rbacv1.GroupKind, APIGroup: rbacv1.GroupName, Name: "system:serviceaccounts:foreign"},
+			},
+			RoleRef: roleRef,
+		}
+		u := clusterRoleBindingToUnstructured(t, crb)
+		if h.acceptClusterRoleBinding(u) {
+			t.Fatal("expected reject for Group in non-exported namespace")
+		}
+	})
+
+	t.Run("Group system authenticated rejected", func(t *testing.T) {
+		h := NewClusterScopedRbacHandler(testLogger())
+		sa := unstructured.Unstructured{}
+		sa.SetName("app-sa")
+		sa.SetNamespace("my-ns")
+		h.serviceAccounts = []unstructured.Unstructured{sa}
+
+		crb := &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "crb-auth"},
+			Subjects: []rbacv1.Subject{
+				{Kind: rbacv1.GroupKind, APIGroup: rbacv1.GroupName, Name: "system:authenticated"},
+			},
+			RoleRef: roleRef,
+		}
+		u := clusterRoleBindingToUnstructured(t, crb)
+		if h.acceptClusterRoleBinding(u) {
+			t.Fatal("expected reject for system:authenticated")
+		}
+	})
+
+	t.Run("User system serviceaccount string", func(t *testing.T) {
+		h := NewClusterScopedRbacHandler(testLogger())
+		sa := unstructured.Unstructured{}
+		sa.SetName("app-sa")
+		sa.SetNamespace("my-ns")
+		h.serviceAccounts = []unstructured.Unstructured{sa}
+
+		crb := &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "crb-user"},
+			Subjects: []rbacv1.Subject{
+				{Kind: rbacv1.UserKind, APIGroup: rbacv1.GroupName, Name: "system:serviceaccount:my-ns:app-sa"},
+			},
+			RoleRef: roleRef,
+		}
+		u := clusterRoleBindingToUnstructured(t, crb)
+		if !h.acceptClusterRoleBinding(u) {
+			t.Fatal("expected accept for User subject with SA principal string")
+		}
+	})
+
+	t.Run("User malformed rejected", func(t *testing.T) {
+		h := NewClusterScopedRbacHandler(testLogger())
+		sa := unstructured.Unstructured{}
+		sa.SetName("app-sa")
+		sa.SetNamespace("my-ns")
+		h.serviceAccounts = []unstructured.Unstructured{sa}
+
+		crb := &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "crb-bad-user"},
+			Subjects: []rbacv1.Subject{
+				{Kind: rbacv1.UserKind, APIGroup: rbacv1.GroupName, Name: "not-a-sa-string"},
+			},
+			RoleRef: roleRef,
+		}
+		u := clusterRoleBindingToUnstructured(t, crb)
+		if h.acceptClusterRoleBinding(u) {
+			t.Fatal("expected reject for malformed User subject")
+		}
+	})
+
+	t.Run("no exported SAs", func(t *testing.T) {
+		h := NewClusterScopedRbacHandler(testLogger())
+		crb := &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "crb"},
+			Subjects: []rbacv1.Subject{
+				{Kind: rbacv1.GroupKind, APIGroup: rbacv1.GroupName, Name: "system:serviceaccounts:my-ns"},
+			},
+			RoleRef: roleRef,
+		}
+		u := clusterRoleBindingToUnstructured(t, crb)
+		if h.acceptClusterRoleBinding(u) {
+			t.Fatal("expected reject with no exported service accounts")
+		}
+	})
+}
+
+func TestAcceptSecurityContextConstraints_Groups(t *testing.T) {
+	h := NewClusterScopedRbacHandler(testLogger())
+	sa := unstructured.Unstructured{}
+	sa.SetName("app-sa")
+	sa.SetNamespace("my-ns")
+	h.serviceAccounts = []unstructured.Unstructured{sa}
+	h.filteredClusterRoleBindings = &groupResource{
+		objects: &unstructured.UnstructuredList{Items: []unstructured.Unstructured{}},
+	}
+
+	scc := &securityv1.SecurityContextConstraints{
+		ObjectMeta: metav1.ObjectMeta{Name: "custom-scc"},
+		Groups:     []string{"system:serviceaccounts:my-ns"},
+		Users:      nil,
+	}
+	u := securityContextConstraintsToUnstructured(t, scc)
+	if !h.acceptSecurityContextConstraints(u) {
+		t.Fatal("expected SCC accepted via groups only")
+	}
+}
+
+func TestAcceptSecurityContextConstraints_GroupWrongNamespace(t *testing.T) {
+	h := NewClusterScopedRbacHandler(testLogger())
+	sa := unstructured.Unstructured{}
+	sa.SetName("app-sa")
+	sa.SetNamespace("my-ns")
+	h.serviceAccounts = []unstructured.Unstructured{sa}
+	h.filteredClusterRoleBindings = &groupResource{
+		objects: &unstructured.UnstructuredList{Items: []unstructured.Unstructured{}},
+	}
+
+	scc := &securityv1.SecurityContextConstraints{
+		ObjectMeta: metav1.ObjectMeta{Name: "custom-scc"},
+		Groups:     []string{"system:serviceaccounts:other-ns"},
+		Users:      nil,
+	}
+	u := securityContextConstraintsToUnstructured(t, scc)
+	if h.acceptSecurityContextConstraints(u) {
+		t.Fatal("expected SCC rejected when group namespace does not match exported SAs")
+	}
+}
+
+func TestExportedSANamespaces(t *testing.T) {
+	h := NewClusterScopedRbacHandler(testLogger())
+	s1 := unstructured.Unstructured{}
+	s1.SetNamespace("a")
+	s1.SetName("x")
+	s2 := unstructured.Unstructured{}
+	s2.SetNamespace("b")
+	s2.SetName("y")
+	s3 := unstructured.Unstructured{}
+	s3.SetNamespace("a")
+	s3.SetName("z")
+	h.serviceAccounts = []unstructured.Unstructured{s1, s2, s3}
+	m := h.exportedSANamespaces()
+	if len(m) != 2 {
+		t.Fatalf("want 2 namespaces, got %d", len(m))
+	}
+	_, okA := m["a"]
+	_, okB := m["b"]
+	if !okA || !okB {
+		t.Fatalf("missing keys: %#v", m)
+	}
+}


### PR DESCRIPTION
## Summary

Extends `crane export` cluster-scoped RBAC filtering so **ClusterRoleBindings** and **SecurityContextConstraints** match common OpenShift/Kubernetes patterns beyond explicit **ServiceAccount** subjects on CRBs.

## What changed

### ClusterRoleBinding matching (`cmd/export/cluster.go`)

- **`ServiceAccount`** subjects — unchanged behavior (namespace + name must match an exported SA).
- **`Group`** — accept CRBs whose subject is `system:serviceaccounts:<namespace>` when that namespace is one of the namespaces of **exported** ServiceAccounts. Broad groups (e.g. `system:authenticated`) are ignored.
- **`User`** — accept CRBs whose subject name is `system:serviceaccount:<namespace>:<serviceaccountname>` when that matches an exported SA.

### SecurityContextConstraints matching

- After existing CRB-based checks and **`users`** (`system:serviceaccount:…`), SCCs are also accepted when **`groups`** contains `system:serviceaccounts:<namespace>` for an exported SA namespace.
- **`users`** parsing now uses the same `system:serviceaccount:ns:sa` parser as CRB **User** subjects.

### Types

- **ClusterRole** / **ClusterRoleBinding** decoding uses **`k8s.io/api/rbac/v1`** instead of OpenShift `authorization/v1`, since these are core RBAC resources. **SCC** remains on **`security.openshift.io`** (`securityv1`).

### Tests

- New **`cmd/export/cluster_test.go`** covering helpers, CRB subjects, and SCC `groups`.

## Why

Namespace workloads often receive **ClusterRole** bindings via **`Group`** (`system:serviceaccounts:<ns>`) or **User** principal strings, and **SCC** grants via **`groups`** only. Previously those were dropped even when they applied to exported SAs.

## Testing

- `go test ./cmd/export/...`
- `go test $(go list ./... | grep -v '/e2e-tests/tests')`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced cluster export to more reliably handle authorization resources and support additional subject types when processing role bindings and security configurations.

* **Tests**
  * Added comprehensive test coverage for authorization resource validation during export operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->