### PR TITLE
bump crane-lib dependency to include the fix related to whiteouting operator related resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.4.3
 	github.com/jarcoal/httpmock v1.2.0
-	github.com/konveyor/crane-lib v0.1.5
+	github.com/konveyor/crane-lib v0.1.6-0.20260330113445-b620e71fd7bb
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.0

--- a/go.sum
+++ b/go.sum
@@ -339,8 +339,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/konveyor/crane-lib v0.1.5 h1:3O0/RRVRP4QoSglIjqT/pkbHw4G1RJmDe0dltBTpo8o=
-github.com/konveyor/crane-lib v0.1.5/go.mod h1:oYw915/11lZhW5k+nVxZtWdpl5AGc0lL52Z1YcKjU7Y=
+github.com/konveyor/crane-lib v0.1.6-0.20260330113445-b620e71fd7bb h1:vgFhx/8fJES4dAawno/CRvC5A/N26AsnK7GADejNMxk=
+github.com/konveyor/crane-lib v0.1.6-0.20260330113445-b620e71fd7bb/go.mod h1:oYw915/11lZhW5k+nVxZtWdpl5AGc0lL52Z1YcKjU7Y=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
Bump `github.com/konveyor/crane-lib` from **v0.1.5** to **`v0.1.6-0.20260330113445-b620e71fd7bb`** (current **migtools/crane-lib** `main`) so Crane picks up **OLM resource whiteouts** in the Kubernetes transform plugin (#134) and the **s2i pull-secret** fix (#133). Uses a pseudo-version until **v0.1.6** is tagged; follow up with `go get github.com/konveyor/crane-lib@v0.1.6` when released.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency to latest version.

---

**Note:** This release contains no user-facing changes. The update is purely a maintenance release affecting internal dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->