### PR TITLE
Fix error check logic in transform file handling

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -137,9 +137,9 @@ func (o *Options) run() error {
 		// If the transform does not exist, assume that the resource file is
 		// not needed and ignore for now.
 		_, tfStatErr := os.Stat(tfPath)
-		if err != nil && !errors.Is(tfStatErr, os.ErrNotExist) {
+		if tfStatErr != nil && !errors.Is(tfStatErr, os.ErrNotExist) {
 			// Some other error here err out
-			return err
+			return tfStatErr
 		}
 
 		if !errors.Is(tfStatErr, os.ErrNotExist) {


### PR DESCRIPTION
Corrected the error check to use tfStatErr instead of err when checking for file stat errors. The previous code was checking the wrong variable, which could mask real errors during transform file stat operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error handling in the apply command's transform file validation to properly identify genuine file operation failures while preventing false failures from unrelated errors, ensuring more reliable and predictable behavior during the apply process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->