### PR TITLE
Fix: Issue #13: File error logs to be more descriptive

### DIFF
--- a/internal/file/file_helper.go
+++ b/internal/file/file_helper.go
@@ -24,7 +24,7 @@ func ReadFiles(ctx context.Context, dir string) ([]File, error) {
 
 	files, err := ioutil.ReadDir(dir)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read directory %q: %w", dir, err)
 	}
 	return readFiles(ctx, dir, files, log)
 }
@@ -39,7 +39,7 @@ func readFiles(ctx context.Context, path string, files []os.FileInfo, log *logru
 			}
 			newFiles, err := ioutil.ReadDir(filePath)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to read directory %q: %w", filePath, err)
 			}
 			files, err := readFiles(ctx, filePath, newFiles, log)
 			if err != nil {

--- a/internal/file/file_helper_test.go
+++ b/internal/file/file_helper_test.go
@@ -54,67 +54,34 @@ data:
 	}
 }
 
-func TestReadFilesEmptyFile(t *testing.T) {
-	dir := createTestDir(t)
-	writeFile(t, filepath.Join(dir, "empty.yaml"), "")
+func TestReadFilesInvalidContent(t *testing.T) {
+	cases := []struct {
+		name     string
+		filename string
+		content  string
+	}{
+		{"empty file", "empty.yaml", ""},
+		{"null YAML", "null.yaml", "null"},
+		{"invalid YAML syntax", "bad.yaml", "this is not yaml {{{"},
+		{"YAML missing Kind", "nokind.yaml", "foo: bar"},
+	}
 
-	_, err := file.ReadFiles(context.TODO(), dir)
-	if err == nil {
-		t.Fatal("expected error for empty file, got nil")
-	}
-	if !strings.Contains(err.Error(), "empty.yaml") {
-		t.Errorf("error should contain file name, got: %v", err)
-	}
-	if !strings.Contains(err.Error(), "is not a valid Kubernetes resource") {
-		t.Errorf("error should contain descriptive message, got: %v", err)
-	}
-}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := createTestDir(t)
+			writeFile(t, filepath.Join(dir, tc.filename), tc.content)
 
-func TestReadFilesNullYAML(t *testing.T) {
-	dir := createTestDir(t)
-	writeFile(t, filepath.Join(dir, "null.yaml"), "null")
-
-	_, err := file.ReadFiles(context.TODO(), dir)
-	if err == nil {
-		t.Fatal("expected error for null YAML, got nil")
-	}
-	if !strings.Contains(err.Error(), "null.yaml") {
-		t.Errorf("error should contain file name, got: %v", err)
-	}
-	if !strings.Contains(err.Error(), "is not a valid Kubernetes resource") {
-		t.Errorf("error should contain descriptive message, got: %v", err)
-	}
-}
-
-func TestReadFilesInvalidYAMLSyntax(t *testing.T) {
-	dir := createTestDir(t)
-	writeFile(t, filepath.Join(dir, "bad.yaml"), "this is not yaml {{{")
-
-	_, err := file.ReadFiles(context.TODO(), dir)
-	if err == nil {
-		t.Fatal("expected error for invalid YAML, got nil")
-	}
-	if !strings.Contains(err.Error(), "bad.yaml") {
-		t.Errorf("error should contain file name, got: %v", err)
-	}
-	if !strings.Contains(err.Error(), "is not a valid Kubernetes resource") {
-		t.Errorf("error should contain descriptive message, got: %v", err)
-	}
-}
-
-func TestReadFilesYAMLMissingKind(t *testing.T) {
-	dir := createTestDir(t)
-	writeFile(t, filepath.Join(dir, "nokind.yaml"), "foo: bar")
-
-	_, err := file.ReadFiles(context.TODO(), dir)
-	if err == nil {
-		t.Fatal("expected error for YAML missing Kind, got nil")
-	}
-	if !strings.Contains(err.Error(), "nokind.yaml") {
-		t.Errorf("error should contain file name, got: %v", err)
-	}
-	if !strings.Contains(err.Error(), "is not a valid Kubernetes resource") {
-		t.Errorf("error should contain descriptive message, got: %v", err)
+			_, err := file.ReadFiles(context.TODO(), dir)
+			if err == nil {
+				t.Fatalf("expected error for %s, got nil", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.filename) {
+				t.Errorf("error should contain file name, got: %v", err)
+			}
+			if !strings.Contains(err.Error(), "is not a valid Kubernetes resource") {
+				t.Errorf("error should contain descriptive message, got: %v", err)
+			}
+		})
 	}
 }
 
@@ -153,9 +120,13 @@ metadata:
 }
 
 func TestReadFilesNonExistentDir(t *testing.T) {
-	_, err := file.ReadFiles(context.TODO(), "/does/not/exist")
+	dir := "/does/not/exist"
+	_, err := file.ReadFiles(context.TODO(), dir)
 	if err == nil {
 		t.Fatal("expected error for non-existent dir, got nil")
+	}
+	if !strings.Contains(err.Error(), dir) {
+		t.Errorf("error should contain directory path, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                
  - Wrapped error returns in `internal/file/file_helper.go` `readFiles()` with `fmt.Errorf` to include the offending file path and operation context                                                                        
  - Affects all commands that read export directories: `transform`, `apply`, `skopeo-sync-gen`                                                                                                                              
                                                                                                                                                                                                                            
  ### Before                                                                                                                                                                                                                
  Error: Object 'Kind' is missing in 'null'                                                                                                                                                                                 
  Error: json: cannot unmarshal string into Go value of type map[string]interface {}                                                                                                                                        
                  
  ### After                                                                                                                                                                                                                 
  Error: file "/path/to/export/resources/ns/null.yaml" is not a valid Kubernetes resource: Object 'Kind' is missing in 'null'
  Error: file "/path/to/export/resources/ns/bad.yaml" is not a valid Kubernetes resource: json: cannot unmarshal string into Go value of type map[string]interface {}                                                       
  Error: failed to read file "/path/to/export/resources/ns/missing.yaml": open ...: no such file or directory                                                        
  Error: failed to parse YAML in file "/path/to/export/resources/ns/bad.yaml": ...                                                                                                                                          
                                                                                                                                                                                                                            
  ## Test plan                                                                                                                                                                                                              
  - [x] Empty YAML file in export directory — error now shows file path                                                                                                                                                     
  - [x] Non-YAML content (e.g. `this is not yaml {{{`) — error now shows file path                                                                                                                                          
  - [x] Valid YAML but missing Kind field (`foo: bar`) — error now shows file path                                                                                                                                          
  - [x] Null YAML (`null`) — exact scenario from issue #13, error now shows file path                                                                                                                                       
  - [x] Bad file deeply nested in subdirectories — full path shown, easy to locate                                                                                                                                          
  - [x] `apply` command with same invalid files — also shows improved errors                                                                                                                                                
  - [x] Valid export directory with valid files — no regression, works as before                                                                                                                                            
                                                                                                                                                                                                                            
  Fixes https://github.com/migtools/crane/issues/13    

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File and directory error messages now include the specific path and clearer failure context to simplify troubleshooting.

* **Tests**
  * Added tests for successful parsing and multiple failure cases (empty, null, malformed, missing required fields), nested paths, skipped failure folders, and handling of non-existent directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->