### PR TITLE
fix pr comment checkout code

### DIFF
--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -12,6 +12,11 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - name: Check out source code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
       - name: Set up Go
         uses: actions/setup-go@v6
         with:


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                        
  - Fix the "Post coverage comment" workflow that was failing because `go tool cover -func` requires Go module context to resolve package paths in `coverage.out`                                                                   
  - Added `actions/checkout@v4` step with `ref: ${{ github.event.workflow_run.head_sha }}` to check out the actual PR source code (not main) so `go tool cover` has the module context it needs                                     
                                                                                                                                                                                                                                    
  ## Root Cause                                                                                                                                                                                                                     
  The `coverage-comment.yml` workflow uses `workflow_run` trigger, which downloads the `coverage.out` artifact but never checked out the source code. Since Go 1.25, `go tool cover -func` needs the module to resolve package      
  paths, causing the error:                                                                                                                                                                                                         
  cover: no required module provides package github.com/konveyor/crane/cmd/apply:
  go.mod file not found in current directory or any parent directory                                                                                                                                                                
                                                                    
  ## Changes                                                                                                                                                                                                                        
  - `.github/workflows/coverage-comment.yml`
    - Added `actions/checkout@v4` step with `ref: ${{ github.event.workflow_run.head_sha }}` to check out the PR's head commit                                                                                                      
    - Kept existing `actions/setup-go@v6` step for `go tool cover`                                                                                                                                                                  
                                                                                                                                                                                                                                    
  ## Test plan                                                                                                                                                                                                                      
  - [ ] Merge to main (required since `workflow_run` workflows always run from the default branch)                                                                                                                                  
  - [ ] Push a commit to any open PR to trigger "Go build and unit tests"                                                                                                                                                           
  - [ ] Verify "Post coverage comment" workflow completes successfully                                                                                                                                                              
  - [ ] Verify the coverage comment appears on the PR                                                                                                                                                                               
                                                        