### PR TITLE
fix: crd export to be called before _cluster dir creation action

### DIFF
--- a/cmd/export/discover_test.go
+++ b/cmd/export/discover_test.go
@@ -191,6 +191,18 @@ func TestHasClusterScopedManifests(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			name: "only CustomResourceDefinition cluster object",
+			resources: []*groupResource{
+				{
+					APIResource: metav1.APIResource{Kind: "CustomResourceDefinition"},
+					objects: &unstructured.UnstructuredList{
+						Items: []unstructured.Unstructured{crdObj("widgets.example.com")},
+					},
+				},
+			},
+			want: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -301,6 +313,39 @@ func TestPrepareClusterResourceDir(t *testing.T) {
 		}
 		if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
 			t.Fatal("stale file should have been removed")
+		}
+	})
+
+	t.Run("CRD-only cluster manifests create dir", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "_cluster")
+		resources := []*groupResource{
+			{
+				APIResource: metav1.APIResource{Kind: "Deployment"},
+				objects: &unstructured.UnstructuredList{
+					Items: []unstructured.Unstructured{namespacedObj("ns", "d1")},
+				},
+			},
+			{
+				APIResource: metav1.APIResource{
+					Kind:         "CustomResourceDefinition",
+					Name:         "customresourcedefinitions",
+					SingularName: "customresourcedefinition",
+					Namespaced:   false,
+				},
+				objects: &unstructured.UnstructuredList{
+					Items: []unstructured.Unstructured{crdObj("widgets.example.com")},
+				},
+			},
+		}
+		if err := prepareClusterResourceDir(dir, resources); err != nil {
+			t.Fatal(err)
+		}
+		info, err := os.Stat(dir)
+		if err != nil {
+			t.Fatalf("dir not created: %v", err)
+		}
+		if !info.IsDir() {
+			t.Fatal("expected a directory")
 		}
 	})
 }
@@ -536,5 +581,14 @@ func namespacedObj(ns, name string) unstructured.Unstructured {
 func clusterScopedObj(name string) unstructured.Unstructured {
 	u := unstructured.Unstructured{}
 	u.SetName(name)
+	return u
+}
+
+// crdObj returns a cluster-scoped CRD-shaped object (empty namespace), matching collectRelatedCRDs output.
+func crdObj(name string) unstructured.Unstructured {
+	u := unstructured.Unstructured{}
+	u.SetName(name)
+	u.SetKind("CustomResourceDefinition")
+	u.SetAPIVersion("apiextensions.k8s.io/v1")
 	return u
 }

--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -135,16 +135,17 @@ func (o *ExportOptions) Run() error {
 	clusterScopeHandler := NewClusterScopeHandler()
 	resources = clusterScopeHandler.filterRbacResources(resources, log)
 
-	// create cluster resources directory if it needs to be created
 	clusterResourceDir := filepath.Join(o.exportDir, "resources", o.userSpecifiedNamespace, "_cluster")
-	if err = prepareClusterResourceDir(clusterResourceDir, resources); err != nil {
-		log.Errorf("error preparing cluster resources directory: %#v", err)
-		return err
-	}
 
 	crdResources, crdErrs := collectRelatedCRDs(resources, dynamicClient, log, o.crdSkipGroups, o.crdIncludeGroups)
 	resourceErrs = append(resourceErrs, crdErrs...)
 	resources = append(resources, crdResources...)
+
+	// After merging CRDs: prepare _cluster so hasClusterScopedManifests sees cluster-scoped CRD objects.
+	if err = prepareClusterResourceDir(clusterResourceDir, resources); err != nil {
+		log.Errorf("error preparing cluster resources directory: %#v", err)
+		return err
+	}
 
 	//count and log the no of crds
 	crdCount := len(crdResources)


### PR DESCRIPTION
## Problem         
                                                                                                                                                                                                                            
  The **_cluster** directory creation logic (prepareClusterResourceDir) was called before **collectRelatedCRDs**, which meant CRD resources were not yet part of the resources slice when hasClusterScopedManifests was evaluated.  
  As a result, when CRDs were the only cluster-scoped resources present, the _cluster directory was never created, and CRD manifests were silently dropped from the export.
                                                                                                                                                                                                                            
 ## Fix                                                                                                                                                                                                                       
   
Moved the **prepareClusterResourceDir** call to after **collectRelatedCRDs** and the resources = append(resources, crdResources...) merge, so that cluster-scoped CRD objects are included in the check for whether the _cluster  
  directory should be created.
                                                                                                                                                                                                                            
 ## Changes                                                                                                                                                                                                                   
   
  - cmd/export/export.go — Reordered prepareClusterResourceDir to run after CRD collection and merge.                                                                                                                       
  - cmd/export/discover_test.go — Added test cases:
    - TestHasClusterScopedManifests: CRD-only cluster resources correctly return true.                                                                                                                                      
    - TestPrepareClusterResourceDir: CRD-only resources trigger _cluster directory creation.                                                                                                                                
    - Helper crdObj() for constructing CRD-shaped unstructured objects.                     
    
  FIxes #232 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended test coverage for cluster-scoped manifest detection, including scenarios with CustomResourceDefinition objects
  * Added verification that cluster resource directories are created correctly when CustomResourceDefinitions are present

* **Bug Fixes**
  * Fixed the order of operations to ensure CustomResourceDefinitions discovered during resource collection are included in cluster-scoped exports, improving export completeness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->