### PR TITLE
fix bad label selector handling

### DIFF
--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -12,6 +12,7 @@ import (
 	"github.com/konveyor/crane/internal/flags"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"k8s.io/apimachinery/pkg/labels"
 	errorsutil "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/dynamic"
@@ -75,6 +76,11 @@ func (o *ExportOptions) Complete(c *cobra.Command, args []string) error {
 func (o *ExportOptions) Validate() error {
 	if o.asExtras != "" && *o.configFlags.Impersonate == "" && len(*o.configFlags.ImpersonateGroup) == 0 {
 		return fmt.Errorf("extras requires specifying a user or group to impersonate")
+	}
+	if o.labelSelector != "" {
+		if _, err := labels.Parse(o.labelSelector); err != nil {
+			return fmt.Errorf("invalid --label-selector: %w", err)
+		}
 	}
 	return nil
 }

--- a/cmd/export/export_test.go
+++ b/cmd/export/export_test.go
@@ -100,6 +100,7 @@ func TestValidate(t *testing.T) {
 	tests := []struct {
 		name            string
 		asExtras        string
+		labelSelector   string
 		impersonate     string
 		impersonateGrp  []string
 		wantErr         bool
@@ -123,13 +124,31 @@ func TestValidate(t *testing.T) {
 			asExtras: "key=val",
 			wantErr:  true,
 		},
+		{
+			name:          "empty label selector - ok",
+			labelSelector: "",
+		},
+		{
+			name:          "valid label selector equality - ok",
+			labelSelector: "app=nginx",
+		},
+		{
+			name:          "valid label selector set-based - ok",
+			labelSelector: "env in (prod,staging)",
+		},
+		{
+			name:          "invalid label selector - error",
+			labelSelector: "key in (unclosed",
+			wantErr:       true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			o := &ExportOptions{
-				configFlags: genericclioptions.NewConfigFlags(true),
-				asExtras:    tt.asExtras,
+				configFlags:   genericclioptions.NewConfigFlags(true),
+				asExtras:      tt.asExtras,
+				labelSelector: tt.labelSelector,
 			}
 			o.configFlags.Impersonate = &tt.impersonate
 			o.configFlags.ImpersonateGroup = &tt.impersonateGrp


### PR DESCRIPTION
## Summary

Validate `--label-selector` before calling the API so invalid Kubernetes label selector syntax fails fast with one clear error and a non-zero exit, instead of listing every resource type, spamming logs, filling `failures/`, and still exiting 0.

## Problem

- Invalid selectors caused **400 BadRequest** on every `List`.
- Each failure was logged and written under `failures/<namespace>/`.
- `Run()` only aggregated **write** errors, so the process could **exit 0** despite widespread list failures.

## Solution

- In `ExportOptions.Validate()`, when `--label-selector` is set, parse it with `k8s.io/apimachinery/pkg/labels.Parse`.
- Return `invalid --label-selector: …` wrapped error on parse failure (runs before discovery/listing).

## Files

- `cmd/export/export.go` — validation + import
- `cmd/export/export_test.go` — `TestValidate` cases for valid/invalid selectors

## How to test
go test ./cmd/export/... -run TestValidate -count=1


## Before the fix

<img width="3530" height="710" alt="image" src="https://github.com/user-attachments/assets/960a4b6c-c969-43d4-a73a-11bb7b873685" />


## After the fix

<img width="3548" height="1346" alt="image" src="https://github.com/user-attachments/assets/6006f799-0094-4d4e-a13f-0566b97bbaaf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for the `--label-selector` flag to reject invalid selectors before execution, preventing downstream errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->