### PR TITLE
fixed namespace validation in crane export

### DIFF
--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/konveyor/crane/internal/flags"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -99,8 +100,10 @@ func (o *ExportOptions) Validate() error {
 	return nil
 }
 
-// validateExportNamespace returns an error if the namespace does not exist or cannot be read.
-func validateExportNamespace(ctx context.Context, client kubernetes.Interface, namespace string) error {
+// validateExportNamespace returns an error if the namespace does not exist.
+// Non-NotFound errors (e.g. Forbidden) are logged as warnings so that users
+// without "get namespaces" RBAC permission are not blocked.
+func validateExportNamespace(ctx context.Context, client kubernetes.Interface, namespace string, log *logrus.Logger) error {
 	if namespace == "" {
 		return fmt.Errorf("namespace must be set (use -n/--namespace or your kubeconfig context default)")
 	}
@@ -109,7 +112,7 @@ func validateExportNamespace(ctx context.Context, client kubernetes.Interface, n
 		if apierrors.IsNotFound(err) {
 			return fmt.Errorf(`namespaces "%s" not found`, namespace)
 		}
-		return fmt.Errorf("cannot verify namespace %q exists: %w", namespace, err)
+		log.Warnf("cannot verify namespace %q exists (may lack RBAC permission): %v", namespace, err)
 	}
 	return nil
 }
@@ -137,7 +140,7 @@ func (o *ExportOptions) Run() error {
 		log.Errorf("cannot create kubernetes client: %#v", err)
 		return err
 	}
-	if err := validateExportNamespace(context.Background(), kubeClient, o.userSpecifiedNamespace); err != nil {
+	if err := validateExportNamespace(context.Background(), kubeClient, o.userSpecifiedNamespace, log); err != nil {
 		return err
 	}
 

--- a/cmd/export/export_test.go
+++ b/cmd/export/export_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -225,11 +226,12 @@ func TestNewExportCommand(t *testing.T) {
 
 func TestValidateExportNamespace(t *testing.T) {
 	t.Parallel()
+	log := logrus.New()
 
 	t.Run("missing namespace returns not found message", func(t *testing.T) {
 		t.Parallel()
 		client := fake.NewClientset()
-		err := validateExportNamespace(context.Background(), client, "non-existent-namespace")
+		err := validateExportNamespace(context.Background(), client, "non-existent-namespace", log)
 		if err == nil {
 			t.Fatal("expected error")
 		}
@@ -244,7 +246,7 @@ func TestValidateExportNamespace(t *testing.T) {
 		client := fake.NewClientset(&v1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{Name: "app-ns"},
 		})
-		if err := validateExportNamespace(context.Background(), client, "app-ns"); err != nil {
+		if err := validateExportNamespace(context.Background(), client, "app-ns", log); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -252,7 +254,7 @@ func TestValidateExportNamespace(t *testing.T) {
 	t.Run("empty namespace", func(t *testing.T) {
 		t.Parallel()
 		client := fake.NewClientset()
-		err := validateExportNamespace(context.Background(), client, "")
+		err := validateExportNamespace(context.Background(), client, "", log)
 		if err == nil {
 			t.Fatal("expected error")
 		}


### PR DESCRIPTION
## Summary

`crane export` now validates the target namespace and rejects a misleading `--namespace ""`:

1. **Missing namespace** — Before creating export dirs or listing resources, the command `GET`s the Namespace object. If it does not exist, the command fails with `namespaces "<name>" not found` and a non-zero exit (fixes silent “empty” exports on typos).
2. **Explicit empty `-n`** — `client-go` treats `--namespace ""` as “no override” and falls back to the context default, which is easy to misread. If the user actually passes an empty `--namespace` / `-n`, we now error: `namespace cannot be empty; omit -n/--namespace to use your kubeconfig context default`.

Fixes https://github.com/migtools/crane/issues/237

## Tests

- `TestValidateExportNamespace` — not found, existing, empty resolved namespace.
- `TestComplete_ExplicitEmptyNamespace` — `--namespace ""` after `ParseFlags`.

## How to verify

```bash
go test ./cmd/export/...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Export command now rejects an explicitly empty namespace and validates that a specified namespace exists before exporting, returning clear errors when missing or inaccessible.
  * Improved error handling during client initialization to surface failures instead of proceeding silently.

* **Tests**
  * Added tests covering explicit-empty-namespace handling and namespace validation success/failure paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->