### PR TITLE
[MTC-292] Add non-admin MongoDB migration test

### DIFF
--- a/e2e-tests/framework/kubectl.go
+++ b/e2e-tests/framework/kubectl.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"slices"
 )
 
 type KubectlRunner struct {
@@ -30,7 +31,11 @@ func (k KubectlRunner) RunWithStdin(stdin string, args ...string) (string, error
 func (k KubectlRunner) executeWithStdin(stdin string, args ...string) (string, error) {
 	finalArgs := append([]string{}, normalizeKubectlArgs(args...)...)
 	if k.Context != "" {
-		finalArgs = append(finalArgs, "--context", k.Context)
+		if idx := slices.Index(finalArgs, "--"); idx != -1 {
+			finalArgs = slices.Insert(finalArgs, idx, "--context", k.Context)
+		} else {
+			finalArgs = append(finalArgs, "--context", k.Context)
+		}
 	}
 	logVerboseCommand(k.Bin, finalArgs)
 	cmd := exec.Command(k.Bin, finalArgs...)

--- a/e2e-tests/framework/pipeline.go
+++ b/e2e-tests/framework/pipeline.go
@@ -53,6 +53,17 @@ func PrepareSourceApp(srcApp K8sDeployApp, kubectlSrc KubectlRunner) error {
 	return nil
 }
 
+// PrepareSourceAppNoQuiesce deploys and validates the source application without scaling it down.
+func PrepareSourceAppNoQuiesce(srcApp K8sDeployApp) error {
+	if err := srcApp.Deploy(); err != nil {
+		return err
+	}
+	if err := srcApp.Validate(); err != nil {
+		return err
+	}
+	return nil
+}
+
 // ApplyOutputToTarget creates namespace, validates, and applies rendered manifests.
 func ApplyOutputToTarget(kubectlTgt KubectlRunner, namespace string, outputDir string) error {
 	if err := kubectlTgt.CreateNamespace(namespace); err != nil {

--- a/e2e-tests/tests/mtc_292_mongodb_non_admin_test.go
+++ b/e2e-tests/tests/mtc_292_mongodb_non_admin_test.go
@@ -195,9 +195,9 @@ var _ = Describe("MongoDB Migration", func() {
 		log.Printf("Source deployment scaled down and pod terminated")
 
 		// todo: remove this once crane rsync pods support supplemental groups.
-		By("Fix source PVC permissions after scale-down")
-		Expect(fixPVCPermissionsViaJob(scenario.KubectlSrc, namespace, "mongodb-data", "/data/db")).NotTo(HaveOccurred())
-		log.Printf("Source PVC permissions fixed")
+		// By("Fix source PVC permissions after scale-down")
+		// Expect(fixPVCPermissionsViaJob(scenario.KubectlSrc, namespace, "mongodb-data", "/data/db")).NotTo(HaveOccurred())
+		// log.Printf("Source PVC permissions fixed")
 
 		By("Run crane export/transform/apply pipeline")
 		runner.WorkDir = paths.TempDir

--- a/e2e-tests/tests/mtc_292_mongodb_non_admin_test.go
+++ b/e2e-tests/tests/mtc_292_mongodb_non_admin_test.go
@@ -140,7 +140,7 @@ var _ = Describe("MongoDB Migration", func() {
 
 		By("Apply rendered manifests to target")
 		log.Printf("Applying rendered manifests on target namespace %s from %s", namespace, paths.OutputDir)
-		Expect(ApplyOutputToTargetNonAdmin(kubectlTgtNonAdmin, namespace, paths.OutputDir)).NotTo(HaveOccurred())
+		Expect(ApplyOutputToTargetNonAdmin(kubectlTgtNonAdmin, paths.OutputDir)).NotTo(HaveOccurred())
 
 		By("List PVCs and transfer to target")
 		pvcs, err := ListPVCs(namespace, "", srcApp.Context)

--- a/e2e-tests/tests/mtc_292_mongodb_non_admin_test.go
+++ b/e2e-tests/tests/mtc_292_mongodb_non_admin_test.go
@@ -109,10 +109,10 @@ var _ = Describe("MongoDB Migration", func() {
 		)
 
 		if scenario.KubectlSrcNonAdmin.Context == "" {
-			Skip("source-nonadmin-context is required for non-admin stateless migration test")
+			Skip("source-nonadmin-context is required for non-admin statelfull migration test")
 		}
 		if scenario.KubectlTgtNonAdmin.Context == "" {
-			Skip("target-nonadmin-context is required for non-admin stateless migration test")
+			Skip("target-nonadmin-context is required for non-admin statelfull migration test")
 		}
 		srcApp := scenario.SrcAppNonAdmin
 		tgtApp := scenario.TgtAppNonAdmin

--- a/e2e-tests/tests/mtc_292_mongodb_non_admin_test.go
+++ b/e2e-tests/tests/mtc_292_mongodb_non_admin_test.go
@@ -96,7 +96,7 @@ var _ = Describe("MongoDB Migration", func() {
 
 		By("Deploy and validate source MongoDB app")
 		log.Printf("Deploying %s in namespace %s on source cluster", appName, namespace)
-		Expect(PrepareSourceApp(srcApp, kubectlSrcNonAdmin)).NotTo(HaveOccurred())
+		Expect(PrepareSourceAppNoQuiesce(srcApp)).NotTo(HaveOccurred())
 		log.Printf("Source app deployed successfully")
 
 		paths, err := NewScenarioPaths("crane-export-*")

--- a/e2e-tests/tests/mtc_292_mongodb_non_admin_test.go
+++ b/e2e-tests/tests/mtc_292_mongodb_non_admin_test.go
@@ -51,6 +51,47 @@ func mongoDocumentCount(k KubectlRunner, namespace, podName string) (int, error)
 	return count, nil
 }
 
+// fixTargetPVCOwnership restores file ownership on the target PVC to uid/gid 999
+// (MongoDB's uid) after crane's rsync transfers them as uid 1000.
+// TODO: Remove once crane rsync pods support supplemental groups.
+func fixTargetPVCOwnership(k KubectlRunner, namespace, pvcName, mountPath string) error {
+	podName := fmt.Sprintf("fix-perms-%s", pvcName)
+	podSpec := fmt.Sprintf(`apiVersion: v1
+kind: Pod
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  restartPolicy: Never
+  containers:
+  - name: fix-perms
+    image: busybox
+    command: ["chown", "-R", "999:999", "%s"]
+    volumeMounts:
+    - name: data
+      mountPath: %s
+    securityContext:
+      runAsUser: 0
+  volumes:
+  - name: data
+    persistentVolumeClaim:
+      claimName: %s
+`, podName, namespace, mountPath, mountPath, pvcName)
+
+	_, err := k.RunWithStdin(podSpec, "apply", "-f", "-")
+	if err != nil {
+		return fmt.Errorf("failed to create fix-permissions pod: %w", err)
+	}
+	defer k.Run("delete", "pod", podName, "-n", namespace, "--ignore-not-found=true")
+
+	_, err = k.Run("wait", "pod", podName, "-n", namespace,
+		"--for=jsonpath={.status.phase}=Succeeded", "--timeout=60s")
+	if err != nil {
+		return fmt.Errorf("fix-permissions pod did not complete successfully: %w", err)
+	}
+	return nil
+}
+
 var _ = Describe("MongoDB Migration", func() {
 	It("[MTC-292] Should migrate a MongoDB resource with data intact as nonadmin user", Label("tier0"), func() {
 		appName := "mongodb"
@@ -167,6 +208,13 @@ var _ = Describe("MongoDB Migration", func() {
 			}
 			Expect(runner.TransferPVC(opts)).NotTo(HaveOccurred())
 			log.Printf("PVC %s transferred successfully", pvc.Name)
+		}
+
+		By("Fix target PVC ownership after transfer")
+		// TODO: Remove once crane rsync pods support supplemental groups.
+		for _, pvc := range pvcs {
+			Expect(fixTargetPVCOwnership(scenario.KubectlTgt, namespace, pvc.Name, "/data/db")).NotTo(HaveOccurred())
+			log.Printf("Target PVC %s ownership fixed", pvc.Name)
 		}
 
 		By("Scale up target MongoDB")

--- a/e2e-tests/tests/mtc_292_mongodb_non_admin_test.go
+++ b/e2e-tests/tests/mtc_292_mongodb_non_admin_test.go
@@ -96,7 +96,7 @@ var _ = Describe("MongoDB Migration", func() {
 
 		By("Deploy and validate source MongoDB app")
 		log.Printf("Deploying %s in namespace %s on source cluster", appName, namespace)
-		Expect(PrepareSourceAppNoQuiesce(srcApp, kubectlSrcNonAdmin)).NotTo(HaveOccurred())
+		Expect(PrepareSourceAppNoQuiesce(srcApp)).NotTo(HaveOccurred())
 		log.Printf("Source app deployed successfully")
 
 		paths, err := NewScenarioPaths("crane-export-*")

--- a/e2e-tests/tests/mtc_292_mongodb_non_admin_test.go
+++ b/e2e-tests/tests/mtc_292_mongodb_non_admin_test.go
@@ -96,7 +96,7 @@ func mongoDocumentCount(k KubectlRunner, namespace, podName string) (int, error)
 }
 
 var _ = Describe("MongoDB Migration", func() {
-	It("[BUG #213][MTC-292] Should migrate a MongoDB resource with data intact as nonadmin user", Label("tier0"), func() {
+	It("[BUG #213][MTC-292] Should migrate a MongoDB resource with data intact as nonadmin user", Label("BUG #213", "tier0"), func() {
 		appName := "mongodb"
 		namespace := appName
 		scenario := NewMigrationScenario(

--- a/e2e-tests/tests/mtc_292_mongodb_non_admin_test.go
+++ b/e2e-tests/tests/mtc_292_mongodb_non_admin_test.go
@@ -96,7 +96,7 @@ var _ = Describe("MongoDB Migration", func() {
 
 		By("Deploy and validate source MongoDB app")
 		log.Printf("Deploying %s in namespace %s on source cluster", appName, namespace)
-		Expect(PrepareSourceAppNoQuiesce(srcApp)).NotTo(HaveOccurred())
+		Expect(PrepareSourceAppNoQuiesce(srcApp, kubectlSrcNonAdmin)).NotTo(HaveOccurred())
 		log.Printf("Source app deployed successfully")
 
 		paths, err := NewScenarioPaths("crane-export-*")
@@ -147,7 +147,7 @@ var _ = Describe("MongoDB Migration", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(pvcs).NotTo(BeEmpty(), "expected at least one PVC in namespace %q", namespace)
 
-		tgtIP, err := GetClusterNodeIP(tgtApp.Context)
+		tgtIP, err := GetClusterNodeIP(scenario.TgtApp.Context)
 		Expect(err).NotTo(HaveOccurred())
 
 		for _, pvc := range pvcs {

--- a/e2e-tests/tests/mtc_292_mongodb_non_admin_test.go
+++ b/e2e-tests/tests/mtc_292_mongodb_non_admin_test.go
@@ -1,0 +1,140 @@
+package e2e
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("MongoDB Migration", func() {
+	It("[MTC-292] Should migrate a MongoDB resource with data intact as nonadmin user", Label("tier0"), func() {
+		appName := "mongodb"
+		namespace := appName
+		scenario := NewMigrationScenario(
+			appName,
+			namespace,
+			config.K8sDeployBin,
+			config.CraneBin,
+			config.SourceContext,
+			config.TargetContext,
+		)
+
+		if scenario.KubectlSrcNonAdmin.Context == "" {
+			Skip("source-nonadmin-context is required for non-admin stateless migration test")
+		}
+		if scenario.KubectlTgtNonAdmin.Context == "" {
+			Skip("target-nonadmin-context is required for non-admin stateless migration test")
+		}
+		srcApp := scenario.SrcAppNonAdmin
+		tgtApp := scenario.TgtAppNonAdmin
+		runner := scenario.CraneNonAdmin
+
+		srcApp.ExtraVars = map[string]string{
+			"non_admin_user": "true",
+		}
+		tgtApp.ExtraVars = map[string]string{
+			"non_admin_user": "true",
+		}
+
+		By("Grant namespace admin permissions to nonadmin user on source and target")
+		kubectlSrcNonAdmin, kubectlTgtNonAdmin, cleanup, err := SetupNamespaceAdminUsersForScenario(scenario, namespace)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			By("Delete test namespace on source and target (best effort)")
+			for _, k := range []KubectlRunner{scenario.KubectlSrc, scenario.KubectlTgt} {
+				if _, err := k.Run("delete", "namespace", namespace, "--ignore-not-found=true", "--wait=false"); err != nil {
+					log.Printf("cleanup: failed to delete namespace %q on context %q: %v", namespace, k.Context, err)
+				}
+			}
+		})
+		DeferCleanup(cleanup)
+		
+		By("Deploy and validate source MongoDB app")
+		log.Printf("Deploying %s in namespace %s on source cluster", appName, namespace)
+		Expect(PrepareSourceApp(srcApp, kubectlSrcNonAdmin)).NotTo(HaveOccurred())
+		log.Printf("Source app deployed successfully")
+		By("Seed test data into source MongoDB")
+		srcPodName, err := kubectlSrcNonAdmin.Run(
+			"get", "pod",
+			"-n", namespace,
+			"-l", "name=mongodb",
+			"-o", "jsonpath={.items[0].metadata.name}",
+		)
+		Expect(err).NotTo(HaveOccurred())
+		srcPodName = strings.TrimSpace(srcPodName)
+		log.Printf("Source pod: %s", srcPodName)
+ 
+		_, err = kubectlSrcNonAdmin.Run(
+			"exec", srcPodName, "-n", namespace, "--",
+			"mongosh", "sampledb",
+			"--eval", `db.test_db.insertMany([{"a":1,"b":2},{"c":3,"d":4}]); print("seeded:", db.test_db.countDocuments())`,
+			"--quiet",
+		)
+		Expect(err).NotTo(HaveOccurred())
+		log.Printf("Test data seeded into source MongoDB")
+
+		By("Fix source PVC permissions before transfer")
+		// TODO: Remove once crane rsync pods support supplemental groups.
+		Expect(fixPVCPermissions(kubectlSrcNonAdmin, namespace, "mongodb-data", "/data/db")).NotTo(HaveOccurred())
+		log.Printf("Source PVC permissions fixed")
+
+		By("Run crane export/transform/apply pipeline")
+		runner := scenario.Crane
+		runner.WorkDir = paths.TempDir
+		Expect(RunCranePipelineWithChecks(runner, namespace, paths)).NotTo(HaveOccurred())
+		log.Printf("Crane pipeline completed for namespace %s", namespace)
+
+		By("List PVCs and transfer to target")
+		pvcs, err := ListPVCs(namespace, "", srcApp.Context)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pvcs).NotTo(BeEmpty(), "expected at least one PVC in namespace %q", namespace)
+ 
+		tgtIP, err := GetClusterNodeIP(tgtApp.Context)
+		Expect(err).NotTo(HaveOccurred())
+
+		for _, pvc := range pvcs {
+			log.Printf("Transferring PVC %s", pvc.Name)
+			opts := TransferPVCOptions{
+				SourceContext:   srcApp.Context,
+				TargetContext:   tgtApp.Context,
+				PVCName:         pvc.Name,
+				PVCNamespaceMap: fmt.Sprintf("%s:%s", namespace, namespace),
+				Endpoint:        "nginx-ingress",
+				IngressClass:    "nginx",
+				Subdomain:       fmt.Sprintf("%s.%s.%s.nip.io", pvc.Name, namespace, tgtIP),
+			}
+			Expect(runner.TransferPVC(opts)).NotTo(HaveOccurred())
+			log.Printf("PVC %s transferred successfully", pvc.Name)
+		}
+
+		By("Validate target app is running")
+		Eventually(tgtApp.Validate, "2m", "10s").Should(Succeed())
+		log.Printf("Target app validated successfully")
+
+		By("Verify data integrity on destination")
+		tgtPodName, err := kubectlTgt.Run(
+			"get", "pod",
+			"-n", namespace,
+			"-l", "name=mongodb",
+			"-o", "jsonpath={.items[0].metadata.name}",
+		)
+		Expect(err).NotTo(HaveOccurred())
+		tgtPodName = strings.TrimSpace(tgtPodName)
+		log.Printf("Target pod: %s", tgtPodName)
+ 
+		Eventually(func() (int, error) {
+			return mongoDocumentCount(kubectlTgt, namespace, tgtPodName)
+		}, "2m", "10s").Should(BeNumerically(">=", 2),
+			"expected at least 2 documents on destination after migration")
+ 
+		tgtCount, err := mongoDocumentCount(kubectlTgt, namespace, tgtPodName)
+		Expect(err).NotTo(HaveOccurred())
+		log.Printf("Destination document count: %d — migration verified", tgtCount)
+
+	})
+})

--- a/e2e-tests/tests/mtc_292_mongodb_non_admin_test.go
+++ b/e2e-tests/tests/mtc_292_mongodb_non_admin_test.go
@@ -12,24 +12,68 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+// fixPVCPermissionsViaJob spawns a temporary busybox pod to make mountPath
+// world-readable/executable so that crane's rsync pod (uid 1000) can traverse
+// directories written by MongoDB (uid 999, mode 0700).
+//
+// This must run AFTER the MongoDB deployment is scaled to zero — the MongoDB
+// pod must not be running when this executes, because WiredTiger will write new
+// checkpoint files (e.g. WiredTiger.turtle) with mode 700 after the chmod if
+// MongoDB is still active, and rsync will silently skip those files.
+//
 // TODO: Remove once crane rsync pods support supplemental groups.
-// fixPVCPermissions makes mountPath world-readable/executable so that crane's
-// rsync pod (uid 1000) can traverse directories written by MongoDB (uid 999,
-// mode 0700). This is a temporary workaround until crane transfer-pvc supports
-// supplemental groups. See https://github.com/migtools/crane/issues/213.
-func fixPVCPermissions(k KubectlRunner, namespace, _ /* pvcName */, mountPath string) error {
-	podName, err := k.Run(
-		"get", "pod",
+// See https://github.com/migtools/crane/issues/213.
+func fixPVCPermissionsViaJob(k KubectlRunner, namespace, pvcName, mountPath string) error {
+	podSpec := fmt.Sprintf(`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: fix-pvc-perms
+  namespace: %s
+spec:
+  restartPolicy: Never
+  containers:
+  - name: fix
+    image: busybox
+    command: ["chmod", "-R", "o+rx", "%s"]
+    volumeMounts:
+    - name: data
+      mountPath: %s
+    securityContext:
+      runAsUser: 0
+  volumes:
+  - name: data
+    persistentVolumeClaim:
+      claimName: %s
+`, namespace, mountPath, mountPath, pvcName)
+
+	if err := k.ApplyYAMLSpec(podSpec, namespace); err != nil {
+		return fmt.Errorf("failed to create fix-pvc-perms pod: %w", err)
+	}
+	if _, err := k.Run(
+		"wait", "pod", "fix-pvc-perms",
 		"-n", namespace,
-		"-l", "name=mongodb",
-		"-o", "jsonpath={.items[0].metadata.name}",
+		"--for=jsonpath={.status.phase}=Succeeded",
+		"--timeout=60s",
+	); err != nil {
+		return fmt.Errorf("fix-pvc-perms pod did not succeed: %w", err)
+	}
+	// Verify it actually succeeded and didn't just time out in a non-Failed state
+	phase, err := k.Run(
+		"get", "pod", "fix-pvc-perms",
+		"-n", namespace,
+		"-o", "jsonpath={.status.phase}",
 	)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get fix-pvc-perms pod phase: %w", err)
 	}
-	podName = strings.TrimSpace(podName)
-	_, err = k.Run("exec", podName, "-n", namespace, "--", "chmod", "-R", "o+rx", mountPath)
-	return err
+	if strings.TrimSpace(phase) != "Succeeded" {
+		return fmt.Errorf("fix-pvc-perms pod ended in phase %q, expected Succeeded", phase)
+	}
+	if _, err := k.Run("delete", "pod", "fix-pvc-perms", "-n", namespace); err != nil {
+		return fmt.Errorf("failed to delete fix-pvc-perms pod: %w", err)
+	}
+	return nil
 }
 
 // mongoDocumentCount returns the number of documents in sampledb.test_db via
@@ -51,49 +95,8 @@ func mongoDocumentCount(k KubectlRunner, namespace, podName string) (int, error)
 	return count, nil
 }
 
-// fixTargetPVCOwnership restores file ownership on the target PVC to uid/gid 999
-// (MongoDB's uid) after crane's rsync transfers them as uid 1000.
-// TODO: Remove once crane rsync pods support supplemental groups.
-func fixTargetPVCOwnership(k KubectlRunner, namespace, pvcName, mountPath string) error {
-	podName := fmt.Sprintf("fix-perms-%s", pvcName)
-	podSpec := fmt.Sprintf(`apiVersion: v1
-kind: Pod
-metadata:
-  name: %s
-  namespace: %s
-spec:
-  restartPolicy: Never
-  containers:
-  - name: fix-perms
-    image: busybox
-    command: ["chown", "-R", "999:999", "%s"]
-    volumeMounts:
-    - name: data
-      mountPath: %s
-    securityContext:
-      runAsUser: 0
-  volumes:
-  - name: data
-    persistentVolumeClaim:
-      claimName: %s
-`, podName, namespace, mountPath, mountPath, pvcName)
-
-	_, err := k.RunWithStdin(podSpec, "apply", "-f", "-")
-	if err != nil {
-		return fmt.Errorf("failed to create fix-permissions pod: %w", err)
-	}
-	defer k.Run("delete", "pod", podName, "-n", namespace, "--ignore-not-found=true")
-
-	_, err = k.Run("wait", "pod", podName, "-n", namespace,
-		"--for=jsonpath={.status.phase}=Succeeded", "--timeout=60s")
-	if err != nil {
-		return fmt.Errorf("fix-permissions pod did not complete successfully: %w", err)
-	}
-	return nil
-}
-
 var _ = Describe("MongoDB Migration", func() {
-	It("[MTC-292] Should migrate a MongoDB resource with data intact as nonadmin user", Label("tier0"), func() {
+	It("[BUG #213][MTC-292] Should migrate a MongoDB resource with data intact as nonadmin user", Label("tier0"), func() {
 		appName := "mongodb"
 		namespace := appName
 		scenario := NewMigrationScenario(
@@ -125,6 +128,7 @@ var _ = Describe("MongoDB Migration", func() {
 		By("Grant namespace admin permissions to nonadmin user on source and target")
 		kubectlSrcNonAdmin, kubectlTgtNonAdmin, cleanup, err := SetupNamespaceAdminUsersForScenario(scenario, namespace)
 		Expect(err).NotTo(HaveOccurred())
+
 		DeferCleanup(func() {
 			By("Delete test namespace on source and target (best effort)")
 			for _, k := range []KubectlRunner{scenario.KubectlSrc, scenario.KubectlTgt} {
@@ -142,6 +146,7 @@ var _ = Describe("MongoDB Migration", func() {
 
 		paths, err := NewScenarioPaths("crane-export-*")
 		Expect(err).NotTo(HaveOccurred())
+		
 		DeferCleanup(func() {
 			By("Cleanup source and target resources")
 			if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
@@ -169,14 +174,26 @@ var _ = Describe("MongoDB Migration", func() {
 		Expect(err).NotTo(HaveOccurred())
 		log.Printf("Test data seeded into source MongoDB")
 
-		By("Fix source PVC permissions before transfer")
-		// TODO: Remove once crane rsync pods support supplemental groups.
-		Expect(fixPVCPermissions(kubectlSrcNonAdmin, namespace, "mongodb-data", "/data/db")).NotTo(HaveOccurred())
-		log.Printf("Source PVC permissions fixed")
-
 		By("Scale down source MongoDB deployment")
+		// Must scale down BEFORE fixing permissions — if MongoDB is still running
+		// after chmod, WiredTiger will write new checkpoint files (e.g.
+		// WiredTiger.turtle) with mode 700, which rsync (uid 1000) cannot read,
+		// causing a silent empty transfer.
 		Expect(kubectlSrcNonAdmin.ScaleDeploymentIfPresent(namespace, appName, 0)).NotTo(HaveOccurred())
-		log.Printf("Source deployment scaled down")
+
+		_, err = scenario.KubectlSrc.Run(
+			"wait", "pod",
+			"-n", namespace,
+			"-l", "name=mongodb",
+			"--for=delete",
+			"--timeout=60s",
+		)
+		Expect(err).NotTo(HaveOccurred())
+		log.Printf("Source deployment scaled down and pod terminated")
+
+		By("Fix source PVC permissions after scale-down")
+		Expect(fixPVCPermissionsViaJob(scenario.KubectlSrc, namespace, "mongodb-data", "/data/db")).NotTo(HaveOccurred())
+		log.Printf("Source PVC permissions fixed")
 
 		By("Run crane export/transform/apply pipeline")
 		runner.WorkDir = paths.TempDir
@@ -210,20 +227,20 @@ var _ = Describe("MongoDB Migration", func() {
 			log.Printf("PVC %s transferred successfully", pvc.Name)
 		}
 
-		By("Fix target PVC ownership after transfer")
-		// TODO: Remove once crane rsync pods support supplemental groups.
-		for _, pvc := range pvcs {
-			Expect(fixTargetPVCOwnership(scenario.KubectlTgt, namespace, pvc.Name, "/data/db")).NotTo(HaveOccurred())
-			log.Printf("Target PVC %s ownership fixed", pvc.Name)
-		}
-
-		By("Scale up target MongoDB")
+		By("Scale up target MongoDB deployment")
 		Expect(kubectlTgtNonAdmin.ScaleDeployment(namespace, appName, 1)).NotTo(HaveOccurred())
 		log.Printf("Target deployment scaled up")
 
-		By("Validate target app is running")
-		Eventually(tgtApp.Validate, "2m", "10s").Should(Succeed())
-		log.Printf("Target app validated successfully")
+		By("Wait for target MongoDB pod to be ready")
+		_, err = scenario.KubectlTgt.Run(
+			"wait", "pod",
+			"-n", namespace,
+			"-l", "name=mongodb",
+			"--for=condition=Ready",
+			"--timeout=2m",
+		)
+		Expect(err).NotTo(HaveOccurred())
+		log.Printf("Target MongoDB pod is ready")
 
 		By("Verify data integrity on destination")
 		tgtPodName, err := kubectlTgtNonAdmin.Run(

--- a/e2e-tests/tests/mtc_292_mongodb_non_admin_test.go
+++ b/e2e-tests/tests/mtc_292_mongodb_non_admin_test.go
@@ -133,6 +133,10 @@ var _ = Describe("MongoDB Migration", func() {
 		Expect(fixPVCPermissions(kubectlSrcNonAdmin, namespace, "mongodb-data", "/data/db")).NotTo(HaveOccurred())
 		log.Printf("Source PVC permissions fixed")
 
+		By("Scale down source MongoDB deployment")
+		Expect(kubectlSrcNonAdmin.ScaleDeploymentIfPresent(namespace, appName, 0)).NotTo(HaveOccurred())
+		log.Printf("Source deployment scaled down")
+
 		By("Run crane export/transform/apply pipeline")
 		runner.WorkDir = paths.TempDir
 		Expect(RunCranePipelineWithChecks(runner, namespace, paths)).NotTo(HaveOccurred())
@@ -164,6 +168,10 @@ var _ = Describe("MongoDB Migration", func() {
 			Expect(runner.TransferPVC(opts)).NotTo(HaveOccurred())
 			log.Printf("PVC %s transferred successfully", pvc.Name)
 		}
+
+		By("Scale up target MongoDB")
+		Expect(kubectlTgtNonAdmin.ScaleDeployment(namespace, appName, 1)).NotTo(HaveOccurred())
+		log.Printf("Target deployment scaled up")
 
 		By("Validate target app is running")
 		Eventually(tgtApp.Validate, "2m", "10s").Should(Succeed())

--- a/e2e-tests/tests/mtc_292_mongodb_non_admin_test.go
+++ b/e2e-tests/tests/mtc_292_mongodb_non_admin_test.go
@@ -173,6 +173,9 @@ var _ = Describe("MongoDB Migration", func() {
 		)
 		Expect(err).NotTo(HaveOccurred())
 		log.Printf("Test data seeded into source MongoDB")
+		srcCount, err := mongoDocumentCount(kubectlSrcNonAdmin, namespace, srcPodName)
+		Expect(err).NotTo(HaveOccurred())
+		log.Printf("Source document count: %d", srcCount)
 
 		By("Scale down source MongoDB deployment")
 		// Must scale down BEFORE fixing permissions — if MongoDB is still running
@@ -191,6 +194,7 @@ var _ = Describe("MongoDB Migration", func() {
 		Expect(err).NotTo(HaveOccurred())
 		log.Printf("Source deployment scaled down and pod terminated")
 
+		// todo: remove this once crane rsync pods support supplemental groups.
 		By("Fix source PVC permissions after scale-down")
 		Expect(fixPVCPermissionsViaJob(scenario.KubectlSrc, namespace, "mongodb-data", "/data/db")).NotTo(HaveOccurred())
 		log.Printf("Source PVC permissions fixed")
@@ -255,8 +259,8 @@ var _ = Describe("MongoDB Migration", func() {
 
 		Eventually(func() (int, error) {
 			return mongoDocumentCount(kubectlTgtNonAdmin, namespace, tgtPodName)
-		}, "2m", "10s").Should(BeNumerically("==", 4),
-			"expected 4 documents on destination after migration")
+		}, "2m", "10s").Should(BeNumerically("==", srcCount),
+			"expected destination document count to match source after migration")
 
 		tgtCount, err := mongoDocumentCount(kubectlTgtNonAdmin, namespace, tgtPodName)
 		Expect(err).NotTo(HaveOccurred())

--- a/e2e-tests/tests/mtc_292_mongodb_non_admin_test.go
+++ b/e2e-tests/tests/mtc_292_mongodb_non_admin_test.go
@@ -109,10 +109,10 @@ var _ = Describe("MongoDB Migration", func() {
 		)
 
 		if scenario.KubectlSrcNonAdmin.Context == "" {
-			Skip("source-nonadmin-context is required for non-admin statelfull migration test")
+			Skip("source-nonadmin-context is required for non-admin stateful migration test")
 		}
 		if scenario.KubectlTgtNonAdmin.Context == "" {
-			Skip("target-nonadmin-context is required for non-admin statelfull migration test")
+			Skip("target-nonadmin-context is required for non-admin stateful migration test")
 		}
 		srcApp := scenario.SrcAppNonAdmin
 		tgtApp := scenario.TgtAppNonAdmin
@@ -195,9 +195,9 @@ var _ = Describe("MongoDB Migration", func() {
 		log.Printf("Source deployment scaled down and pod terminated")
 
 		// todo: remove this once crane rsync pods support supplemental groups.
-		// By("Fix source PVC permissions after scale-down")
-		// Expect(fixPVCPermissionsViaJob(scenario.KubectlSrc, namespace, "mongodb-data", "/data/db")).NotTo(HaveOccurred())
-		// log.Printf("Source PVC permissions fixed")
+		By("[BUG #213] Fix source PVC permissions after scale-down")
+		Expect(fixPVCPermissionsViaJob(scenario.KubectlSrc, namespace, "mongodb-data", "/data/db")).NotTo(HaveOccurred())
+		log.Printf("Source PVC permissions fixed")
 
 		By("Run crane export/transform/apply pipeline")
 		runner.WorkDir = paths.TempDir

--- a/e2e-tests/tests/mtc_292_mongodb_non_admin_test.go
+++ b/e2e-tests/tests/mtc_292_mongodb_non_admin_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 
 	"github.com/konveyor/crane/e2e-tests/config"
@@ -10,6 +11,45 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+// TODO: Remove once crane rsync pods support supplemental groups.
+// fixPVCPermissions makes mountPath world-readable/executable so that crane's
+// rsync pod (uid 1000) can traverse directories written by MongoDB (uid 999,
+// mode 0700). This is a temporary workaround until crane transfer-pvc supports
+// supplemental groups. See https://github.com/migtools/crane/issues/213.
+func fixPVCPermissions(k KubectlRunner, namespace, _ /* pvcName */, mountPath string) error {
+	podName, err := k.Run(
+		"get", "pod",
+		"-n", namespace,
+		"-l", "name=mongodb",
+		"-o", "jsonpath={.items[0].metadata.name}",
+	)
+	if err != nil {
+		return err
+	}
+	podName = strings.TrimSpace(podName)
+	_, err = k.Run("exec", podName, "-n", namespace, "--", "chmod", "-R", "o+rx", mountPath)
+	return err
+}
+
+// mongoDocumentCount returns the number of documents in sampledb.test_db via
+// mongosh exec into the given pod.
+func mongoDocumentCount(k KubectlRunner, namespace, podName string) (int, error) {
+	out, err := k.Run(
+		"exec", podName, "-n", namespace, "--",
+		"mongosh", "sampledb",
+		"--eval", "db.test_db.countDocuments()",
+		"--quiet",
+	)
+	if err != nil {
+		return 0, err
+	}
+	count, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse document count %q: %w", strings.TrimSpace(out), err)
+	}
+	return count, nil
+}
 
 var _ = Describe("MongoDB Migration", func() {
 	It("[MTC-292] Should migrate a MongoDB resource with data intact as nonadmin user", Label("tier0"), func() {
@@ -53,11 +93,21 @@ var _ = Describe("MongoDB Migration", func() {
 			}
 		})
 		DeferCleanup(cleanup)
-		
+
 		By("Deploy and validate source MongoDB app")
 		log.Printf("Deploying %s in namespace %s on source cluster", appName, namespace)
 		Expect(PrepareSourceApp(srcApp, kubectlSrcNonAdmin)).NotTo(HaveOccurred())
 		log.Printf("Source app deployed successfully")
+
+		paths, err := NewScenarioPaths("crane-export-*")
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			By("Cleanup source and target resources")
+			if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
+				log.Printf("cleanup: %v", err)
+			}
+		})
+
 		By("Seed test data into source MongoDB")
 		srcPodName, err := kubectlSrcNonAdmin.Run(
 			"get", "pod",
@@ -68,7 +118,7 @@ var _ = Describe("MongoDB Migration", func() {
 		Expect(err).NotTo(HaveOccurred())
 		srcPodName = strings.TrimSpace(srcPodName)
 		log.Printf("Source pod: %s", srcPodName)
- 
+
 		_, err = kubectlSrcNonAdmin.Run(
 			"exec", srcPodName, "-n", namespace, "--",
 			"mongosh", "sampledb",
@@ -84,16 +134,19 @@ var _ = Describe("MongoDB Migration", func() {
 		log.Printf("Source PVC permissions fixed")
 
 		By("Run crane export/transform/apply pipeline")
-		runner := scenario.Crane
 		runner.WorkDir = paths.TempDir
 		Expect(RunCranePipelineWithChecks(runner, namespace, paths)).NotTo(HaveOccurred())
 		log.Printf("Crane pipeline completed for namespace %s", namespace)
+
+		By("Apply rendered manifests to target")
+		log.Printf("Applying rendered manifests on target namespace %s from %s", namespace, paths.OutputDir)
+		Expect(ApplyOutputToTargetNonAdmin(kubectlTgtNonAdmin, namespace, paths.OutputDir)).NotTo(HaveOccurred())
 
 		By("List PVCs and transfer to target")
 		pvcs, err := ListPVCs(namespace, "", srcApp.Context)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(pvcs).NotTo(BeEmpty(), "expected at least one PVC in namespace %q", namespace)
- 
+
 		tgtIP, err := GetClusterNodeIP(tgtApp.Context)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -117,7 +170,7 @@ var _ = Describe("MongoDB Migration", func() {
 		log.Printf("Target app validated successfully")
 
 		By("Verify data integrity on destination")
-		tgtPodName, err := kubectlTgt.Run(
+		tgtPodName, err := kubectlTgtNonAdmin.Run(
 			"get", "pod",
 			"-n", namespace,
 			"-l", "name=mongodb",
@@ -126,15 +179,14 @@ var _ = Describe("MongoDB Migration", func() {
 		Expect(err).NotTo(HaveOccurred())
 		tgtPodName = strings.TrimSpace(tgtPodName)
 		log.Printf("Target pod: %s", tgtPodName)
- 
+
 		Eventually(func() (int, error) {
-			return mongoDocumentCount(kubectlTgt, namespace, tgtPodName)
-		}, "2m", "10s").Should(BeNumerically(">=", 2),
-			"expected at least 2 documents on destination after migration")
- 
-		tgtCount, err := mongoDocumentCount(kubectlTgt, namespace, tgtPodName)
+			return mongoDocumentCount(kubectlTgtNonAdmin, namespace, tgtPodName)
+		}, "2m", "10s").Should(BeNumerically("==", 4),
+			"expected 4 documents on destination after migration")
+
+		tgtCount, err := mongoDocumentCount(kubectlTgtNonAdmin, namespace, tgtPodName)
 		Expect(err).NotTo(HaveOccurred())
 		log.Printf("Destination document count: %d — migration verified", tgtCount)
-
 	})
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * New end-to-end test for MongoDB migration using non-admin contexts: sets up non-admin users and namespace permissions, seeds data, applies a pod permission workaround, transfers PVCs, runs the migration pipeline, and verifies all documents are preserved on the target.
  * New helper to prepare source apps without quiescing deployments.

* **Bug Fixes**
  * Improved kube-context handling for command execution so the intended context is applied correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->