### PR TITLE
docs: remove broken documentation link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ---
 
 ## Intro
-[Crane](https://konveyor.github.io/crane/overview/) is a migration tool under the [Konveyor](https://www.konveyor.io/) community that helps application owners migrate Kubernetes workloads and their state between clusters.
+Crane is a migration tool under the [Konveyor](https://www.konveyor.io/) community that helps application owners migrate Kubernetes workloads and their state between clusters.
 
 ## YouTube Demo
 [![Alt text](https://img.youtube.com/vi/PoSivlgVLf8/0.jpg)](https://www.youtube.com/watch?v=PoSivlgVLf8)


### PR DESCRIPTION
## Summary
Removes the broken link to `https://konveyor.github.io/crane/overview/` from the README intro section. The documentation site currently returns 404.

## Impact
**Severity:** Low
**Components:** Documentation
**Breaking changes:** No
**Backward compatible:** Yes

## Changes
- `README.md:8` - Removed hyperlink from "Crane" text while preserving the Konveyor community link

## Before/After
**Before:**
```markdown
[Crane](https://konveyor.github.io/crane/overview/) is a migration tool...
```

**After:**
```markdown
Crane is a migration tool under the [Konveyor](https://www.konveyor.io/) community...
```

## Test Plan
- [x] Link removed successfully
- [x] Markdown renders correctly
- [x] Konveyor link still functional
- [x] No other documentation links broken

## Review Focus Areas
- Verify the link should be removed vs. fixed to point elsewhere
- Confirm no other references to the broken URL exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved the README introduction section with updated formatting for enhanced readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->