### PR TITLE
Added basic olm resources whiteout test

### DIFF
--- a/e2e-tests/framework/kubectl.go
+++ b/e2e-tests/framework/kubectl.go
@@ -45,6 +45,12 @@ func (k KubectlRunner) executeWithStdin(stdin string, args ...string) (string, e
 	return strings.TrimSpace(string(out)), nil
 }
 
+// OLMAPIAvailable reports whether core OLM CRDs are registered on the cluster.
+func (k KubectlRunner) OLMAPIAvailable() bool {
+	_, err := k.Run("get", "crd", "subscriptions.operators.coreos.com")
+	return err == nil
+}
+
 // normalizeKubectlArgs accepts either tokenized args
 // (Run("get","po","-n","ns")) or a single command string
 // (Run("get po -n ns")) and converts to tokens.

--- a/e2e-tests/framework/kubectl.go
+++ b/e2e-tests/framework/kubectl.go
@@ -51,7 +51,7 @@ func (k KubectlRunner) OLMAPIAvailable() (bool, error) {
 	if err == nil {
 		return true, nil
 	}
-	if strings.Contains(err.Error(), "NotFound") || strings.Contains(err.Error(), "not found") {
+	if strings.Contains(err.Error(), "Error from server (NotFound)") {
 		return false, nil
 	}
 	return false, fmt.Errorf("check OLM CRD subscriptions.operators.coreos.com: %w", err)

--- a/e2e-tests/framework/kubectl.go
+++ b/e2e-tests/framework/kubectl.go
@@ -45,10 +45,16 @@ func (k KubectlRunner) executeWithStdin(stdin string, args ...string) (string, e
 	return strings.TrimSpace(string(out)), nil
 }
 
-// OLMAPIAvailable reports whether core OLM CRDs are registered on the cluster.
-func (k KubectlRunner) OLMAPIAvailable() bool {
+// OLMAPIAvailable reports whether the Subscription CRD is registered on the cluster.
+func (k KubectlRunner) OLMAPIAvailable() (bool, error) {
 	_, err := k.Run("get", "crd", "subscriptions.operators.coreos.com")
-	return err == nil
+	if err == nil {
+		return true, nil
+	}
+	if strings.Contains(err.Error(), "NotFound") || strings.Contains(err.Error(), "not found") {
+		return false, nil
+	}
+	return false, fmt.Errorf("check OLM CRD subscriptions.operators.coreos.com: %w", err)
 }
 
 // normalizeKubectlArgs accepts either tokenized args

--- a/e2e-tests/tests/olm_whiteout_test.go
+++ b/e2e-tests/tests/olm_whiteout_test.go
@@ -139,6 +139,7 @@ var _ = Describe("OLM whiteout", func() {
 			By("Run crane export/transform/apply pipeline")
 			log.Printf("Running crane pipeline for namespace %s\n", srcApp.Namespace)
 			Expect(RunCranePipelineWithChecks(runner, srcApp.Namespace, paths)).NotTo(HaveOccurred())
+			log.Printf("Crane pipeline completed for namespace %s", srcApp.Namespace)
 
 			By("Verify output directory does not contain OLM whiteout kinds")
 			Expect(assertNoOLMWhiteoutKindsInOutput(paths.OutputDir)).NotTo(HaveOccurred())

--- a/e2e-tests/tests/olm_whiteout_test.go
+++ b/e2e-tests/tests/olm_whiteout_test.go
@@ -33,31 +33,29 @@ func assertNoOLMWhiteoutKindsInOutput(root string) error {
 	for _, k := range olmWhiteoutKinds {
 		denyKind[k] = struct{}{}
 	}
-	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if info.IsDir() {
-			return nil
-		}
-		rel, relErr := filepath.Rel(root, path)
-		if relErr != nil {
-			rel = path
-		}
+
+	files, err := utils.ListFilesRecursivelyAsList(root)
+	if err != nil {
+		return err
+	}
+
+	for _, rel := range files {
 		for _, kind := range olmWhiteoutKinds {
 			if strings.Contains(rel, kind) {
 				return fmt.Errorf("output path %q contains forbidden OLM kind substring %q", rel, kind)
 			}
 		}
-		if !utils.LooksLikeYAMLFile(path) {
-			return nil
+
+		absPath := filepath.Join(root, rel)
+		if !utils.LooksLikeYAMLFile(absPath) {
+			continue
 		}
-		data, err := os.ReadFile(path)
+		data, err := os.ReadFile(absPath)
 		if err != nil {
 			return err
 		}
 		if len(strings.TrimSpace(string(data))) == 0 {
-			return nil
+			continue
 		}
 		dec := yaml.NewDecoder(strings.NewReader(string(data)))
 		for {
@@ -80,13 +78,13 @@ func assertNoOLMWhiteoutKindsInOutput(root string) error {
 				return fmt.Errorf("%s: document kind %q must not appear in crane output", rel, kindVal)
 			}
 		}
-		return nil
-	})
+	}
+	return nil
 }
 
 var _ = Describe("OLM whiteout", func() {
 	Describe("Baseline full OLM graph", func() {
-		It("should omit OLM kinds from crane apply output", Label("olm"), func() {
+		It("should omit OLM kinds from crane apply output", Label("olm", "tier0"), func() {
 			kubectlPreflight := KubectlRunner{Bin: "kubectl", Context: config.SourceContext}
 			olmAvailable, err := kubectlPreflight.OLMAPIAvailable()
 			Expect(err).NotTo(HaveOccurred())

--- a/e2e-tests/tests/test_olm_whiteout.go
+++ b/e2e-tests/tests/test_olm_whiteout.go
@@ -88,7 +88,9 @@ var _ = Describe("OLM whiteout", func() {
 	Describe("Baseline full OLM graph", func() {
 		It("should omit OLM kinds from crane apply output", Label("olm"), func() {
 			kubectlPreflight := KubectlRunner{Bin: "kubectl", Context: config.SourceContext}
-			if !kubectlPreflight.OLMAPIAvailable() {
+			olmAvailable, err := kubectlPreflight.OLMAPIAvailable()
+			Expect(err).NotTo(HaveOccurred())
+			if !olmAvailable {
 				Skip("OLM APIs not installed (subscriptions.operators.coreos.com CRD missing)")
 			}
 

--- a/e2e-tests/tests/test_olm_whiteout.go
+++ b/e2e-tests/tests/test_olm_whiteout.go
@@ -1,0 +1,164 @@
+package e2e
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	"github.com/konveyor/crane/e2e-tests/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
+)
+
+// olmWhiteoutKinds lists Kubernetes object kinds that crane-lib whiteouts for OLM migration.
+var olmWhiteoutKinds = []string{
+	"Subscription",
+	"CatalogSource",
+	"ClusterServiceVersion",
+	"InstallPlan",
+	"OperatorGroup",
+	"OperatorCondition",
+}
+
+// assertNoOLMWhiteoutKindsInOutput walks root (e.g. crane apply output) and fails if any
+// manifest has a denied kind or if a file path suggests an OLM whiteout resource (same idea as MTC-127).
+func assertNoOLMWhiteoutKindsInOutput(root string) error {
+	denyKind := make(map[string]struct{}, len(olmWhiteoutKinds))
+	for _, k := range olmWhiteoutKinds {
+		denyKind[k] = struct{}{}
+	}
+	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			rel = path
+		}
+		for _, kind := range olmWhiteoutKinds {
+			if strings.Contains(rel, kind) {
+				return fmt.Errorf("output path %q contains forbidden OLM kind substring %q", rel, kind)
+			}
+		}
+		if !utils.LooksLikeYAMLFile(path) {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if len(strings.TrimSpace(string(data))) == 0 {
+			return nil
+		}
+		dec := yaml.NewDecoder(strings.NewReader(string(data)))
+		for {
+			var doc map[string]interface{}
+			err := dec.Decode(&doc)
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return fmt.Errorf("%s: parse yaml: %w", rel, err)
+			}
+			if doc == nil {
+				continue
+			}
+			kindVal, _ := doc["kind"].(string)
+			if kindVal == "" {
+				continue
+			}
+			if _, bad := denyKind[kindVal]; bad {
+				return fmt.Errorf("%s: document kind %q must not appear in crane output", rel, kindVal)
+			}
+		}
+		return nil
+	})
+}
+
+var _ = Describe("OLM whiteout", func() {
+	Describe("Baseline full OLM graph", func() {
+		It("should omit OLM kinds from crane apply output", Label("olm"), func() {
+			kubectlPreflight := KubectlRunner{Bin: "kubectl", Context: config.SourceContext}
+			if !kubectlPreflight.OLMAPIAvailable() {
+				Skip("OLM APIs not installed (subscriptions.operators.coreos.com CRD missing)")
+			}
+
+			appName := "olm-baseline"
+			namespace := appName
+			scenario := NewMigrationScenario(
+				appName,
+				namespace,
+				config.K8sDeployBin,
+				config.CraneBin,
+				config.SourceContext,
+				config.TargetContext,
+			)
+			srcApp := scenario.SrcApp
+			tgtApp := scenario.TgtApp
+			kubectlSrc := scenario.KubectlSrc
+			kubectlTgt := scenario.KubectlTgt
+
+			By("Prepare source app (olm-baseline k8sdeploy: namespace, RBAC, OperatorGroup, CatalogSource, Subscription)")
+			log.Printf("Preparing source app %s in namespace %s\n", srcApp.Name, srcApp.Namespace)
+			Expect(PrepareSourceApp(srcApp, kubectlSrc)).NotTo(HaveOccurred())
+
+			paths, err := NewScenarioPaths("crane-export-*")
+			Expect(err).NotTo(HaveOccurred())
+
+			DeferCleanup(func() {
+				By("Cleanup source and target resources")
+				if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
+					log.Printf("cleanup: %v", err)
+				}
+			})
+
+			By("Wait for OLM to create InstallPlan and ClusterServiceVersion")
+			Eventually(func(g Gomega) {
+				out, err := kubectlSrc.Run("get", "installplan", "-n", namespace)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(strings.TrimSpace(out)).NotTo(ContainSubstring("No resources found"))
+			}, "12m", "15s").Should(Succeed())
+			Eventually(func(g Gomega) {
+				out, err := kubectlSrc.Run("get", "csv", "-n", namespace)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(strings.TrimSpace(out)).NotTo(ContainSubstring("No resources found"))
+			}, "12m", "15s").Should(Succeed())
+
+			runner := scenario.Crane
+			runner.WorkDir = paths.TempDir
+
+			By("Run crane export/transform/apply pipeline")
+			log.Printf("Running crane pipeline for namespace %s\n", srcApp.Namespace)
+			Expect(RunCranePipelineWithChecks(runner, srcApp.Namespace, paths)).NotTo(HaveOccurred())
+
+			By("Verify output directory does not contain OLM whiteout kinds")
+			Expect(assertNoOLMWhiteoutKindsInOutput(paths.OutputDir)).NotTo(HaveOccurred())
+
+			By("Apply rendered manifests to target")
+			Expect(ApplyOutputToTarget(kubectlTgt, namespace, paths.OutputDir)).NotTo(HaveOccurred())
+
+			By("Verify OLM objects from baseline setup are not present on target")
+			for _, res := range []struct {
+				kind string
+				name string
+			}{
+				{"subscription", "olm-whiteout-subscription"},
+				{"catalogsource", "olm-whiteout-catalog"},
+				{"operatorgroup", "olm-whiteout-og"},
+			} {
+				_, err := kubectlTgt.Run("get", res.kind, res.name, "-n", namespace)
+				Expect(err).To(HaveOccurred(), "%s %s should not exist on target", res.kind, res.name)
+				Expect(err.Error()).To(ContainSubstring("NotFound"))
+			}
+		})
+	})
+})

--- a/e2e-tests/utils/utils.go
+++ b/e2e-tests/utils/utils.go
@@ -87,3 +87,14 @@ func ReadTestdataFile(filename string) (string, error) {
 
 	return string(b), nil
 }
+
+// LooksLikeYAMLFile returns true for paths that look like YAML (by extension or no extension, e.g. output fragments).
+func LooksLikeYAMLFile(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case ".yaml", ".yml":
+		return true
+	default:
+		return ext == ""
+	}
+}


### PR DESCRIPTION
## Summary

Adds an end-to-end Ginkgo spec **OLM whiteout** that verifies Crane’s export → transform → apply pipeline does **not** emit OLM resources that are whiteouted in crane-lib (Subscription, CatalogSource, ClusterServiceVersion, InstallPlan, OperatorGroup, OperatorCondition), and that those objects are not recreated on the target after applying rendered output.

## What’s included

- **`e2e-tests/tests/test_olm_whiteout.go`**
  - Label: `olm`.
  - Deploys the **`olm-baseline`** app via **k8sdeploy** (namespace `olm-baseline`, RBAC + OperatorGroup + CatalogSource + Subscription from the k8s-apps-deployer role).
  - Waits for InstallPlan and CSV on the source, runs the Crane pipeline, asserts output has no forbidden OLM kinds (walk + YAML `kind` check + path substring guard), applies output to the target cluster, and asserts named OLM objects are absent on the target (`NotFound`).
  - Helpers local to this test: `olmWhiteoutKinds`, `assertNoOLMWhiteoutKindsInOutput` (uses `utils.LooksLikeYAMLFile` for file-type filtering).

- **`e2e-tests/framework/kubectl.go`**
  - **`(KubectlRunner) OLMAPIAvailable()`** — skips the spec when OLM CRDs are missing (`subscriptions.operators.coreos.com`).

- **`e2e-tests/utils/utils.go`**
  - **`LooksLikeYAMLFile(path)`** — shared helper for treating paths as YAML when scanning output trees.

- **Removed** inline OLM testdata under `e2e-tests/testdata/olm/baseline/` in favor of the **`olm-baseline`** k8s-apps-deployer application.

## Prerequisites

- **k8s-apps-deployer** must include the **`olm-baseline`** role (merged separately).
- Clusters need **OLM** installed.
- For a meaningful “target” assertion, use **distinct** source and target kube contexts (e.g. minikube `src` / `tgt`); same-context runs can false-pass because OLM objects already exist from setup.

## How to run (example)

```bash
go build -o /tmp/crane .
ginkgo run -v --focus="OLM whiteout" e2e-tests/tests -- \
  --crane-bin=/tmp/crane \
  --source-context=src \
  --target-context=tgt \
  --k8sdeploy-bin=/path/to/k8sdeploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end test that verifies OLM-related Kubernetes kinds are omitted from exported/transformed manifests and not applied to the target cluster.

* **Tests**
  * Added a helper to scan rendered output for forbidden kinds and validate multi-document YAML files.

* **Chores**
  * Added a runtime check to detect OLM API availability and skip the test when OLM is not present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->