### PR TITLE
Removed e2e test framework files from code coverage report

### DIFF
--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -37,7 +37,7 @@ jobs:
           PR_NUMBER=$(cat pr-number.txt)
           TOTAL=$(go tool cover -func=coverage.out | grep '^total:' | awk '{print $3}')
 
-          PKG_COVERAGE=$(go tool cover -func=coverage.out | grep -v '^total:' | \
+          PKG_COVERAGE=$(go tool cover -func=coverage.out | grep -v '^total:' | grep -v '/e2e-tests/' | \
             awk -F'\t+' '{
               split($1, parts, "/")
               file = parts[length(parts)]

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -39,7 +39,7 @@ jobs:
           GOPROXY: "https://proxy.golang.org"
         run: |
           cd main
-          go test -v -coverprofile=coverage.out -covermode=atomic $(go list ./... | grep -v '/e2e-tests/tests')
+          go test -v -coverprofile=coverage.out -covermode=atomic $(go list ./... | grep -v '/e2e-tests/')
           echo "## Coverage Summary" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           go tool cover -func=coverage.out | tail -1 >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                
  - Exclude `e2e-tests/framework` and `e2e-tests/utils` packages from code coverage reporting
  - Updated `go.yml` to broaden the grep filter from `/e2e-tests/tests` to `/e2e-tests/`, excluding all e2e packages from the test run and coverage profile                                                                 
  - Updated `coverage-comment.yml` to filter out any `/e2e-tests/` packages from the per-package coverage table posted on PRs                                                                                               
                                                                                                                                                                                                                            
  ## Test plan                                                                                                                                                                                                              
  - [x] Verify `go list ./... | grep -v '/e2e-tests/'` excludes `framework`, `utils`, and `tests` packages                                                                                                                  
  - [x] Confirm coverage comment on a test PR no longer lists `e2e-tests/framework` or `e2e-tests/utils`                                                                                                                    
  - [x] Verify existing unit test coverage is unaffected                                                         