### PR TITLE
:test_tube: Add unit tests for Progress type in transfer-pvc

### DIFF
--- a/cmd/transfer-pvc/progress_test.go
+++ b/cmd/transfer-pvc/progress_test.go
@@ -1,7 +1,9 @@
 package transfer_pvc
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -687,5 +689,47 @@ func TestProgressAsString_WithFailedFiles(t *testing.T) {
 	}
 	if !strings.Contains(errStr, "Permission denied") {
 		t.Errorf("AsString() err output missing 'Permission denied'")
+	}
+}
+
+func TestWriteProgressToFile_WriteValidFile(t *testing.T) {
+	resetGlobals()
+	tmpPath := t.TempDir() + "/test-progress.json"
+
+	pct := int64(50)
+	p := &Progress{
+		TransferPercentage: &pct,
+		TransferredFiles:   100,
+		startedAt:          time.Now(),
+	}
+
+	err := writeProgressToFile(tmpPath, p)
+	if err != nil {
+		t.Errorf("writeProgressToFile() error = %v", err)
+	}
+
+	data, err := os.ReadFile(tmpPath)
+	if err != nil {
+		t.Errorf("Failed to read written file: %v", err)
+	}
+
+	var readProgress Progress
+	if err := json.Unmarshal(data, &readProgress); err != nil {
+		t.Errorf("Failed to unmarshal progress: %v", err)
+	}
+
+	if readProgress.TransferredFiles != 100 {
+		t.Errorf("Written TransferredFiles = %v, want 100", readProgress.TransferredFiles)
+	}
+}
+
+func TestWriteProgressToFile_InvalidPath(t *testing.T) {
+	resetGlobals()
+	p := &Progress{
+		TransferredFiles: 100,
+	}
+	err := writeProgressToFile("/nonexistent/directory/file.json", p)
+	if err == nil {
+		t.Errorf("writeProgressToFile() with invalid path should return error")
 	}
 }

--- a/cmd/transfer-pvc/progress_test.go
+++ b/cmd/transfer-pvc/progress_test.go
@@ -2,8 +2,18 @@ package transfer_pvc
 
 import (
 	"fmt"
+	"strings"
 	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
 )
+
+// resetGlobals resets global variables between tests for isolation
+func resetGlobals() {
+	pastAttempts = Progress{}
+	failedFiles = nil
+}
 
 func intEqual(a, b *int64) (string, string, bool) {
 	if a != nil && b != nil && *a == *b {
@@ -176,5 +186,506 @@ total size is 8.67G  speedup is 1.00`,
 				t.Errorf("parseRsyncLogs() unprocessed = %v, want %v", unprocessed, tt.wantUnProcessed)
 			}
 		})
+	}
+}
+
+func TestNewProgress(t *testing.T) {
+	name := types.NamespacedName{Namespace: "test-ns", Name: "test-pvc"}
+	p := NewProgress(name)
+
+	if p.PVC != name {
+		t.Errorf("NewProgress() PVC = %v, want %v", p.PVC, name)
+	}
+	if p.FailedFiles == nil || len(p.FailedFiles) != 0 {
+		t.Errorf("NewProgress() FailedFiles should be empty slice")
+	}
+	if p.Errors == nil || len(p.Errors) != 0 {
+		t.Errorf("NewProgress() Errors should be empty slice")
+	}
+	if p.startedAt.IsZero() {
+		t.Errorf("NewProgress() startedAt should not be zero")
+	}
+}
+
+func TestProgressStatus_ExitCodeZero(t *testing.T) {
+	resetGlobals()
+	exitCode := int32(0)
+	p := &Progress{
+		ExitCode: &exitCode,
+	}
+	got := p.Status()
+	if got != succeeded {
+		t.Errorf("Progress.Status() = %v, want %v", got, succeeded)
+	}
+	if p.TransferPercentage == nil || *p.TransferPercentage != 100 {
+		t.Errorf("Progress.TransferPercentage = %v, want 100", p.TransferPercentage)
+	}
+}
+
+func TestProgressStatus_ExitCodeNonZeroNoData(t *testing.T) {
+	resetGlobals()
+	exitCode := int32(1)
+	p := &Progress{
+		ExitCode:         &exitCode,
+		TransferredFiles: 0,
+		TransferredData:  &dataSize{val: 0, unit: "bytes"},
+		TotalFiles:       nil,
+	}
+	got := p.Status()
+	if got != failed {
+		t.Errorf("Progress.Status() = %v, want %v", got, failed)
+	}
+}
+
+func TestProgressStatus_ExitCodeNonZeroWithData(t *testing.T) {
+	resetGlobals()
+	exitCode := int32(1)
+	p := &Progress{
+		ExitCode:         &exitCode,
+		TransferredFiles: 10,
+		TransferredData:  &dataSize{val: 100.0, unit: "M"},
+	}
+	got := p.Status()
+	if got != partiallyFailed {
+		t.Errorf("Progress.Status() = %v, want %v", got, partiallyFailed)
+	}
+}
+
+func TestProgressStatus_NilExitCodeNilPercentage(t *testing.T) {
+	resetGlobals()
+	p := &Progress{
+		ExitCode:           nil,
+		TransferPercentage: nil,
+	}
+	got := p.Status()
+	if got != preparing {
+		t.Errorf("Progress.Status() = %v, want %v", got, preparing)
+	}
+}
+
+func TestProgressStatus_PercentageGreaterThanOrEqual100(t *testing.T) {
+	resetGlobals()
+	pct := int64(100)
+	p := &Progress{
+		ExitCode:           nil,
+		TransferPercentage: &pct,
+	}
+	got := p.Status()
+	if got != finishingUp {
+		t.Errorf("Progress.Status() = %v, want %v", got, finishingUp)
+	}
+}
+
+func TestProgressStatus_PercentageLessThan100(t *testing.T) {
+	resetGlobals()
+	pct := int64(50)
+	p := &Progress{
+		ExitCode:           nil,
+		TransferPercentage: &pct,
+	}
+	got := p.Status()
+	if got != transferInProgress {
+		t.Errorf("Progress.Status() = %v, want %v", got, transferInProgress)
+	}
+}
+
+func TestProgressMerge_BasicFields(t *testing.T) {
+	resetGlobals()
+	totalFiles := int64(150)
+	p := &Progress{
+		TransferredFiles: 10,
+		TotalFiles:       nil,
+		FailedFiles:      []FailedFile{},
+		Errors:           []string{},
+	}
+	in := &Progress{
+		TransferredFiles: 20,
+		TotalFiles:       &totalFiles,
+		FailedFiles:      []FailedFile{},
+		Errors:           []string{},
+	}
+	p.Merge(in)
+	if p.TransferredFiles != 30 {
+		t.Errorf("Merge() TransferredFiles = %v, want 30", p.TransferredFiles)
+	}
+	if p.TotalFiles == nil || *p.TotalFiles != 150 {
+		t.Errorf("Merge() TotalFiles = %v, want 150", p.TotalFiles)
+	}
+}
+
+func TestProgressMerge_PercentageAggregation(t *testing.T) {
+	resetGlobals()
+	pct1 := int64(50)
+	pct2 := int64(40)
+	p := &Progress{
+		TransferPercentage: &pct1,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	in := &Progress{
+		TransferPercentage: &pct2,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	p.Merge(in)
+	if p.TransferPercentage == nil {
+		t.Errorf("Merge() TransferPercentage = nil, want non-nil")
+	}
+}
+
+func TestProgressMerge_PercentageBasicUpdate(t *testing.T) {
+	resetGlobals()
+	inPct := int64(40)
+	p := &Progress{
+		TransferPercentage: nil,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	in := &Progress{
+		TransferPercentage: &inPct,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	p.Merge(in)
+	if p.TransferPercentage == nil {
+		t.Errorf("Merge() TransferPercentage = nil, want 40")
+		return
+	}
+	if *p.TransferPercentage != 40 {
+		t.Errorf("Merge() TransferPercentage = %d, want 40", *p.TransferPercentage)
+	}
+}
+
+func TestProgressMerge_PercentageAccumulationWithPastAttempts(t *testing.T) {
+	resetGlobals()
+	pastPct := int64(30)
+	pastAttempts = Progress{
+		TransferPercentage: &pastPct,
+	}
+	inPct := int64(20)
+	p := &Progress{
+		TransferPercentage: nil,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	in := &Progress{
+		TransferPercentage: &inPct,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	p.Merge(in)
+	if p.TransferPercentage == nil {
+		t.Errorf("Merge() TransferPercentage = nil, want 50")
+		return
+	}
+	if *p.TransferPercentage != 50 {
+		t.Errorf("Merge() TransferPercentage = %d, want 50 (pastAttempts 30 + in 20)", *p.TransferPercentage)
+	}
+}
+
+func TestProgressMerge_PercentageCapAt100(t *testing.T) {
+	resetGlobals()
+	pastPct := int64(80)
+	pastAttempts = Progress{
+		TransferPercentage: &pastPct,
+	}
+	pPct := int64(75)
+	inPct := int64(30)
+	p := &Progress{
+		TransferPercentage: &pPct,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	in := &Progress{
+		TransferPercentage: &inPct,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	p.Merge(in)
+	if p.TransferPercentage == nil {
+		t.Errorf("Merge() TransferPercentage = nil, want 75")
+		return
+	}
+	// pastAttempts(80) + in(30) = 110, which exceeds 100
+	// so p.TransferPercentage should remain at original value (75)
+	if *p.TransferPercentage != 75 {
+		t.Errorf("Merge() TransferPercentage = %d, want 75 (should not update when total > 100)", *p.TransferPercentage)
+	}
+}
+
+func TestProgressMerge_PercentageOnlyUpdateIfHigher(t *testing.T) {
+	resetGlobals()
+	pastPct := int64(40)
+	pastAttempts = Progress{
+		TransferPercentage: &pastPct,
+	}
+	pPct := int64(40)
+	inPct := int64(20)
+	p := &Progress{
+		TransferPercentage: &pPct,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	in := &Progress{
+		TransferPercentage: &inPct,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	p.Merge(in)
+	if p.TransferPercentage == nil {
+		t.Errorf("Merge() TransferPercentage = nil, want 60")
+		return
+	}
+	// pastAttempts(40) + in(20) = 60, which is higher than p(40)
+	if *p.TransferPercentage != 60 {
+		t.Errorf("Merge() TransferPercentage = %d, want 60 (pastAttempts 40 + in 20)", *p.TransferPercentage)
+	}
+}
+
+func TestProgressMerge_PercentageDontUpdateIfLower(t *testing.T) {
+	resetGlobals()
+	pPct := int64(50)
+	inPct := int64(30)
+	p := &Progress{
+		TransferPercentage: &pPct,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	in := &Progress{
+		TransferPercentage: &inPct,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	p.Merge(in)
+	if p.TransferPercentage == nil {
+		t.Errorf("Merge() TransferPercentage = nil, want 50")
+		return
+	}
+	// in(30) is lower than p(50), so p should stay at 50
+	if *p.TransferPercentage != 50 {
+		t.Errorf("Merge() TransferPercentage = %d, want 50 (should not update when incoming is lower)", *p.TransferPercentage)
+	}
+}
+
+func TestProgressMerge_PercentageResetWithRetries(t *testing.T) {
+	resetGlobals()
+	pPct := int64(60)
+	inPct := int64(10)
+	retryCount := 1
+	p := &Progress{
+		TransferPercentage: &pPct,
+		TransferredFiles:   100,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	in := &Progress{
+		TransferPercentage: &inPct,
+		retries:            &retryCount,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	p.Merge(in)
+	// When in.retries is set, pastAttempts should be updated with p's state
+	if pastAttempts.TransferPercentage == nil {
+		t.Errorf("pastAttempts.TransferPercentage = nil after retry, want non-nil")
+		return
+	}
+	if *pastAttempts.TransferPercentage != 60 {
+		t.Errorf("pastAttempts.TransferPercentage = %d, want 60", *pastAttempts.TransferPercentage)
+	}
+	if pastAttempts.TransferredFiles != 100 {
+		t.Errorf("pastAttempts.TransferredFiles = %d, want 100", pastAttempts.TransferredFiles)
+	}
+	if p.retries == nil || *p.retries != 1 {
+		t.Errorf("p.retries should be 1 after merge")
+	}
+}
+
+// TestProgressMerge_DataSizeAggregation tests that Merge aggregates transferred data
+// when using pastAttempts (retry scenario).
+func TestProgressMerge_DataSizeAggregation(t *testing.T) {
+	resetGlobals()
+	// First, set up pastAttempts to simulate a retry scenario
+	pastAttempts = Progress{
+		TransferredData: &dataSize{val: 100.0, unit: "M"},
+	}
+	p := &Progress{
+		TransferredData: nil,
+		FailedFiles:     []FailedFile{},
+		Errors:          []string{},
+	}
+	in := &Progress{
+		TransferredData: &dataSize{val: 50.0, unit: "M"},
+		FailedFiles:     []FailedFile{},
+		Errors:          []string{},
+	}
+	p.Merge(in)
+	if p.TransferredData == nil {
+		t.Errorf("Merge() TransferredData = nil, want non-nil")
+		return
+	}
+	// pastAttempts(100M) + in(50M) = 150M, which should update p.TransferredData
+	if p.TransferredData.val != 150.0 {
+		t.Errorf("Merge() TransferredData.val = %v, want 150.0", p.TransferredData.val)
+	}
+}
+
+func TestProgressMerge_ErrorAndFailedFileAppending(t *testing.T) {
+	resetGlobals()
+	p := &Progress{
+		Errors:      []string{"error1"},
+		FailedFiles: []FailedFile{{Name: "file1", Err: "err1"}},
+	}
+	in := &Progress{
+		Errors:      []string{"error2", "error3"},
+		FailedFiles: []FailedFile{{Name: "file2", Err: "err2"}, {Name: "file3", Err: "err3"}},
+	}
+	p.Merge(in)
+	if len(p.Errors) != 3 {
+		t.Errorf("Merge() len(Errors) = %v, want 3", len(p.Errors))
+	}
+	if len(p.FailedFiles) != 3 {
+		t.Errorf("Merge() len(FailedFiles) = %v, want 3", len(p.FailedFiles))
+	}
+}
+
+func TestProgressAsString_BasicFormat(t *testing.T) {
+	resetGlobals()
+	pct := int64(50)
+	p := &Progress{
+		TransferPercentage: &pct,
+		TransferredData:    &dataSize{val: 100.0, unit: "M"},
+		startedAt:          time.Now(),
+	}
+	out, _ := p.AsString()
+	if !strings.Contains(out, "Status:") {
+		t.Errorf("AsString() missing 'Status:'")
+	}
+	if !strings.Contains(out, "Progress:") {
+		t.Errorf("AsString() missing 'Progress:'")
+	}
+	if !strings.Contains(out, "Percentage:") {
+		t.Errorf("AsString() missing 'Percentage:'")
+	}
+}
+
+func TestProgressAsString_WithAllFields(t *testing.T) {
+	resetGlobals()
+	pct := int64(100)
+	exitCode := int32(0)
+	totalFiles := int64(49961)
+	retries := 2
+	p := &Progress{
+		ExitCode:           &exitCode,
+		TransferPercentage: &pct,
+		TransferRate:       &dataSize{val: 88.19, unit: "MB/s"},
+		TransferredData:    &dataSize{val: 8.67, unit: "G"},
+		TotalFiles:         &totalFiles,
+		TransferredFiles:   49948,
+		retries:            &retries,
+		startedAt:          time.Now(),
+	}
+	out, _ := p.AsString()
+	if !strings.Contains(out, "Retries:") {
+		t.Errorf("AsString() missing 'Retries:'")
+	}
+	if !strings.Contains(out, "88.19 MB/s") {
+		t.Errorf("AsString() missing '88.19 MB/s'")
+	}
+	if !strings.Contains(out, "8.67 G") {
+		t.Errorf("AsString() missing '8.67 G'")
+	}
+}
+
+func TestProgressAsString_WithNilFields(t *testing.T) {
+	resetGlobals()
+	p := &Progress{
+		TransferPercentage: nil,
+		TransferRate:       nil,
+		startedAt:          time.Now(),
+	}
+	out, _ := p.AsString()
+	if !strings.Contains(out, "<unavailable>") {
+		t.Errorf("AsString() missing '<unavailable>'")
+	}
+}
+
+func TestProgressAsString_WhenCompleted(t *testing.T) {
+	resetGlobals()
+	exitCode := int32(0)
+	totalFiles := int64(100)
+	p := &Progress{
+		ExitCode:         &exitCode,
+		TransferredFiles: 100,
+		TotalFiles:       &totalFiles,
+		startedAt:        time.Now(),
+	}
+	out, _ := p.AsString()
+	if !strings.Contains(out, "Files:") {
+		t.Errorf("AsString() missing 'Files:'")
+	}
+	if !strings.Contains(out, "Sent:") {
+		t.Errorf("AsString() missing 'Sent:'")
+	}
+	if !strings.Contains(out, "Total:") {
+		t.Errorf("AsString() missing 'Total:'")
+	}
+}
+
+// TestProgressAsString_WithErrors tests that AsString includes error output when
+// completed with errors. This test exposes the variable shadowing bug on line 262
+// where 'errors :=' declares a new variable instead of assigning to the outer 'errors'.
+func TestProgressAsString_WithErrors(t *testing.T) {
+	t.Skip("Skipping: known variable shadowing bug on line 262")
+	resetGlobals()
+	exitCode := int32(1)
+	p := &Progress{
+		ExitCode:         &exitCode,
+		TransferredFiles: 10,
+		TransferredData:  &dataSize{val: 100.0, unit: "M"},
+		Errors:           []string{"disk full", "permission denied"},
+		FailedFiles:      []FailedFile{},
+		startedAt:        time.Now(),
+	}
+	_, errStr := p.AsString()
+	// Due to the variable shadowing bug on line 262, errStr will be empty
+	// even though there are errors. When the bug is fixed, this test should pass.
+	if !strings.Contains(errStr, "Errors:") {
+		t.Errorf("AsString() err output missing 'Errors:' - possible variable shadowing bug")
+	}
+	if !strings.Contains(errStr, "disk full") {
+		t.Errorf("AsString() err output missing 'disk full'")
+	}
+	if !strings.Contains(errStr, "permission denied") {
+		t.Errorf("AsString() err output missing 'permission denied'")
+	}
+}
+
+func TestProgressAsString_WithFailedFiles(t *testing.T) {
+	resetGlobals()
+	exitCode := int32(1)
+	p := &Progress{
+		ExitCode:         &exitCode,
+		TransferredFiles: 10,
+		TransferredData:  &dataSize{val: 100.0, unit: "M"},
+		Errors:           []string{},
+		FailedFiles: []FailedFile{
+			{Name: "/tmp/file1", Err: "Permission denied (13)"},
+			{Name: "/tmp/file2", Err: "No such file (2)"},
+		},
+		startedAt: time.Now(),
+	}
+	_, errStr := p.AsString()
+	if !strings.Contains(errStr, "Failed files:") {
+		t.Errorf("AsString() err output missing 'Failed files:'")
+	}
+	if !strings.Contains(errStr, "/tmp/file1") {
+		t.Errorf("AsString() err output missing '/tmp/file1'")
+	}
+	if !strings.Contains(errStr, "/tmp/file2") {
+		t.Errorf("AsString() err output missing '/tmp/file2'")
+	}
+	if !strings.Contains(errStr, "Permission denied") {
+		t.Errorf("AsString() err output missing 'Permission denied'")
 	}
 }

--- a/cmd/transfer-pvc/progress_test.go
+++ b/cmd/transfer-pvc/progress_test.go
@@ -1,7 +1,9 @@
 package transfer_pvc
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -616,5 +618,47 @@ func TestProgressMerge_ErrorAndFailedFileAppending(t *testing.T) {
 	}
 	if len(p.FailedFiles) != 3 {
 		t.Errorf("Merge() len(FailedFiles) = %v, want 3", len(p.FailedFiles))
+	}
+}
+
+func TestWriteProgressToFile_WriteValidFile(t *testing.T) {
+	resetGlobals()
+	tmpPath := t.TempDir() + "/test-progress.json"
+
+	pct := int64(50)
+	p := &Progress{
+		TransferPercentage: &pct,
+		TransferredFiles:   100,
+		startedAt:          time.Now(),
+	}
+
+	err := writeProgressToFile(tmpPath, p)
+	if err != nil {
+		t.Errorf("writeProgressToFile() error = %v", err)
+	}
+
+	data, err := os.ReadFile(tmpPath)
+	if err != nil {
+		t.Errorf("Failed to read written file: %v", err)
+	}
+
+	var readProgress Progress
+	if err := json.Unmarshal(data, &readProgress); err != nil {
+		t.Errorf("Failed to unmarshal progress: %v", err)
+	}
+
+	if readProgress.TransferredFiles != 100 {
+		t.Errorf("Written TransferredFiles = %v, want 100", readProgress.TransferredFiles)
+	}
+}
+
+func TestWriteProgressToFile_InvalidPath(t *testing.T) {
+	resetGlobals()
+	p := &Progress{
+		TransferredFiles: 100,
+	}
+	err := writeProgressToFile("/nonexistent/directory/file.json", p)
+	if err == nil {
+		t.Errorf("writeProgressToFile() with invalid path should return error")
 	}
 }

--- a/cmd/transfer-pvc/progress_test.go
+++ b/cmd/transfer-pvc/progress_test.go
@@ -5,7 +5,15 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/types"
 )
+
+// resetGlobals resets global variables between tests for isolation
+func resetGlobals() {
+	pastAttempts = Progress{}
+	failedFiles = nil
+}
 
 func intEqual(a, b *int64) (string, string, bool) {
 	if a != nil && b != nil && *a == *b {
@@ -181,6 +189,24 @@ total size is 8.67G  speedup is 1.00`,
 	}
 }
 
+func TestNewProgress(t *testing.T) {
+	name := types.NamespacedName{Namespace: "test-ns", Name: "test-pvc"}
+	p := NewProgress(name)
+
+	if p.PVC != name {
+		t.Errorf("NewProgress() PVC = %v, want %v", p.PVC, name)
+	}
+	if p.FailedFiles == nil || len(p.FailedFiles) != 0 {
+		t.Errorf("NewProgress() FailedFiles should be empty slice")
+	}
+	if p.Errors == nil || len(p.Errors) != 0 {
+		t.Errorf("NewProgress() Errors should be empty slice")
+	}
+	if p.startedAt.IsZero() {
+		t.Errorf("NewProgress() startedAt should not be zero")
+	}
+}
+
 func TestStatus(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -339,5 +365,256 @@ func TestStatus_NilTransferredData(t *testing.T) {
 	s := p.Status()
 	if s != failed {
 		t.Errorf("Status() = %q, want %q", s, failed)
+	}
+}
+
+func TestProgressMerge_BasicFields(t *testing.T) {
+	resetGlobals()
+	totalFiles := int64(150)
+	p := &Progress{
+		TransferredFiles: 10,
+		TotalFiles:       nil,
+		FailedFiles:      []FailedFile{},
+		Errors:           []string{},
+	}
+	in := &Progress{
+		TransferredFiles: 20,
+		TotalFiles:       &totalFiles,
+		FailedFiles:      []FailedFile{},
+		Errors:           []string{},
+	}
+	p.Merge(in)
+	if p.TransferredFiles != 30 {
+		t.Errorf("Merge() TransferredFiles = %v, want 30", p.TransferredFiles)
+	}
+	if p.TotalFiles == nil || *p.TotalFiles != 150 {
+		t.Errorf("Merge() TotalFiles = %v, want 150", p.TotalFiles)
+	}
+}
+
+func TestProgressMerge_PercentageAggregation(t *testing.T) {
+	resetGlobals()
+	pct1 := int64(50)
+	pct2 := int64(40)
+	p := &Progress{
+		TransferPercentage: &pct1,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	in := &Progress{
+		TransferPercentage: &pct2,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	p.Merge(in)
+	if p.TransferPercentage == nil {
+		t.Errorf("Merge() TransferPercentage = nil, want non-nil")
+	}
+}
+
+func TestProgressMerge_PercentageBasicUpdate(t *testing.T) {
+	resetGlobals()
+	inPct := int64(40)
+	p := &Progress{
+		TransferPercentage: nil,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	in := &Progress{
+		TransferPercentage: &inPct,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	p.Merge(in)
+	if p.TransferPercentage == nil {
+		t.Errorf("Merge() TransferPercentage = nil, want 40")
+		return
+	}
+	if *p.TransferPercentage != 40 {
+		t.Errorf("Merge() TransferPercentage = %d, want 40", *p.TransferPercentage)
+	}
+}
+
+func TestProgressMerge_PercentageAccumulationWithPastAttempts(t *testing.T) {
+	resetGlobals()
+	pastPct := int64(30)
+	pastAttempts = Progress{
+		TransferPercentage: &pastPct,
+	}
+	inPct := int64(20)
+	p := &Progress{
+		TransferPercentage: nil,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	in := &Progress{
+		TransferPercentage: &inPct,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	p.Merge(in)
+	if p.TransferPercentage == nil {
+		t.Errorf("Merge() TransferPercentage = nil, want 50")
+		return
+	}
+	if *p.TransferPercentage != 50 {
+		t.Errorf("Merge() TransferPercentage = %d, want 50 (pastAttempts 30 + in 20)", *p.TransferPercentage)
+	}
+}
+
+func TestProgressMerge_PercentageCapAt100(t *testing.T) {
+	resetGlobals()
+	pastPct := int64(80)
+	pastAttempts = Progress{
+		TransferPercentage: &pastPct,
+	}
+	pPct := int64(75)
+	inPct := int64(30)
+	p := &Progress{
+		TransferPercentage: &pPct,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	in := &Progress{
+		TransferPercentage: &inPct,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	p.Merge(in)
+	if p.TransferPercentage == nil {
+		t.Errorf("Merge() TransferPercentage = nil, want 75")
+		return
+	}
+	if *p.TransferPercentage != 75 {
+		t.Errorf("Merge() TransferPercentage = %d, want 75 (should not update when total > 100)", *p.TransferPercentage)
+	}
+}
+
+func TestProgressMerge_PercentageOnlyUpdateIfHigher(t *testing.T) {
+	resetGlobals()
+	pastPct := int64(40)
+	pastAttempts = Progress{
+		TransferPercentage: &pastPct,
+	}
+	pPct := int64(40)
+	inPct := int64(20)
+	p := &Progress{
+		TransferPercentage: &pPct,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	in := &Progress{
+		TransferPercentage: &inPct,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	p.Merge(in)
+	if p.TransferPercentage == nil {
+		t.Errorf("Merge() TransferPercentage = nil, want 60")
+		return
+	}
+	if *p.TransferPercentage != 60 {
+		t.Errorf("Merge() TransferPercentage = %d, want 60 (pastAttempts 40 + in 20)", *p.TransferPercentage)
+	}
+}
+
+func TestProgressMerge_PercentageDontUpdateIfLower(t *testing.T) {
+	resetGlobals()
+	pPct := int64(50)
+	inPct := int64(30)
+	p := &Progress{
+		TransferPercentage: &pPct,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	in := &Progress{
+		TransferPercentage: &inPct,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	p.Merge(in)
+	if p.TransferPercentage == nil {
+		t.Errorf("Merge() TransferPercentage = nil, want 50")
+		return
+	}
+	if *p.TransferPercentage != 50 {
+		t.Errorf("Merge() TransferPercentage = %d, want 50 (should not update when incoming is lower)", *p.TransferPercentage)
+	}
+}
+
+func TestProgressMerge_PercentageResetWithRetries(t *testing.T) {
+	resetGlobals()
+	pPct := int64(60)
+	inPct := int64(10)
+	retryCount := 1
+	p := &Progress{
+		TransferPercentage: &pPct,
+		TransferredFiles:   100,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	in := &Progress{
+		TransferPercentage: &inPct,
+		retries:            &retryCount,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	p.Merge(in)
+	if pastAttempts.TransferPercentage == nil {
+		t.Errorf("pastAttempts.TransferPercentage = nil after retry, want non-nil")
+		return
+	}
+	if *pastAttempts.TransferPercentage != 60 {
+		t.Errorf("pastAttempts.TransferPercentage = %d, want 60", *pastAttempts.TransferPercentage)
+	}
+	if pastAttempts.TransferredFiles != 100 {
+		t.Errorf("pastAttempts.TransferredFiles = %d, want 100", pastAttempts.TransferredFiles)
+	}
+	if p.retries == nil || *p.retries != 1 {
+		t.Errorf("p.retries should be 1 after merge")
+	}
+}
+
+func TestProgressMerge_DataSizeAggregation(t *testing.T) {
+	resetGlobals()
+	pastAttempts = Progress{
+		TransferredData: &dataSize{val: 100.0, unit: "M"},
+	}
+	p := &Progress{
+		TransferredData: nil,
+		FailedFiles:     []FailedFile{},
+		Errors:          []string{},
+	}
+	in := &Progress{
+		TransferredData: &dataSize{val: 50.0, unit: "M"},
+		FailedFiles:     []FailedFile{},
+		Errors:          []string{},
+	}
+	p.Merge(in)
+	if p.TransferredData == nil {
+		t.Errorf("Merge() TransferredData = nil, want non-nil")
+		return
+	}
+	if p.TransferredData.val != 150.0 {
+		t.Errorf("Merge() TransferredData.val = %v, want 150.0", p.TransferredData.val)
+	}
+}
+
+func TestProgressMerge_ErrorAndFailedFileAppending(t *testing.T) {
+	resetGlobals()
+	p := &Progress{
+		Errors:      []string{"error1"},
+		FailedFiles: []FailedFile{{Name: "file1", Err: "err1"}},
+	}
+	in := &Progress{
+		Errors:      []string{"error2", "error3"},
+		FailedFiles: []FailedFile{{Name: "file2", Err: "err2"}, {Name: "file3", Err: "err3"}},
+	}
+	p.Merge(in)
+	if len(p.Errors) != 3 {
+		t.Errorf("Merge() len(Errors) = %v, want 3", len(p.Errors))
+	}
+	if len(p.FailedFiles) != 3 {
+		t.Errorf("Merge() len(FailedFiles) = %v, want 3", len(p.FailedFiles))
 	}
 }

--- a/cmd/transfer-pvc/progress_test.go
+++ b/cmd/transfer-pvc/progress_test.go
@@ -394,26 +394,6 @@ func TestProgressMerge_BasicFields(t *testing.T) {
 	}
 }
 
-func TestProgressMerge_PercentageAggregation(t *testing.T) {
-	resetGlobals()
-	pct1 := int64(50)
-	pct2 := int64(40)
-	p := &Progress{
-		TransferPercentage: &pct1,
-		FailedFiles:        []FailedFile{},
-		Errors:             []string{},
-	}
-	in := &Progress{
-		TransferPercentage: &pct2,
-		FailedFiles:        []FailedFile{},
-		Errors:             []string{},
-	}
-	p.Merge(in)
-	if p.TransferPercentage == nil {
-		t.Errorf("Merge() TransferPercentage = nil, want non-nil")
-	}
-}
-
 func TestProgressMerge_PercentageBasicUpdate(t *testing.T) {
 	resetGlobals()
 	inPct := int64(40)


### PR DESCRIPTION
## Add unit tests for Progress type in transfer-pvc

### Summary

- Adds comprehensive unit test coverage for the Progress type in `cmd/transfer-pvc/progress.go`
- Introduces `resetGlobals()` helper to isolate tests from shared global state (`pastAttempts`, `failedFiles`)

### What's covered

- `parseRsyncLogs`: parsing stdout/stderr from rsync, extracting transfer stats and failed files
- `NewProgress`: initialization with PVC name
- `Status()`: all status transitions (exit codes, percentages, completion states)
- `Merge()`: field merging, percentage aggregation across retries, capping at 100%, pastAttempts accumulation
- `AsString()`: output formatting with various field combinations
- `writeProgressToFile`: JSON output to file and error handling for invalid paths
  
### Also documents

- Variable shadowing bug on line 262 via skipped test `TestProgressAsString_WithErrors` — errors never appear in output because `:=` shadows the outer variable 
(see #286)

### Test plan

```
go test ./cmd/transfer-pvc/... -v -run "TestProgress|Test_parseRsyncLogs|TestWriteProgressToFile"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for transfer progress initialization and aggregation.
  * Added validation for percentage updates, retry handling, data-size tracking, and error or failed-file collection.
  * Added coverage for saving progress as JSON, including invalid-path error handling.
  * Improved test isolation by resetting shared progress state between test cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->