### PR TITLE
Add validate command for pre-apply cluster compatibility checking

### DIFF
--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -45,8 +45,8 @@ func (o *ValidateOptions) Validate() error {
 		return fmt.Errorf("export-dir %q is not a directory", o.exportDir)
 	}
 
-	if o.outputFormat != "table" && o.outputFormat != "json" {
-		return fmt.Errorf("--output must be \"table\" or \"json\", got %q", o.outputFormat)
+	if o.outputFormat != "yaml" && o.outputFormat != "json" {
+		return fmt.Errorf("--output must be \"yaml\" or \"json\", got %q", o.outputFormat)
 	}
 
 	return nil
@@ -74,34 +74,37 @@ func (o *ValidateOptions) Run() error {
 		return fmt.Errorf("matching against target cluster: %w", err)
 	}
 
-	switch o.outputFormat {
-	case "json":
-		if err := internalValidate.FormatJSON(o.Out, report); err != nil {
-			return fmt.Errorf("writing JSON report: %w", err)
-		}
-	default:
-		internalValidate.FormatTable(o.Out, report)
-	}
+	internalValidate.FormatTable(o.Out, report)
 
 	if err := os.MkdirAll(o.validateDir, 0700); err != nil {
 		return fmt.Errorf("creating validate directory: %w", err)
 	}
-	reportPath := filepath.Join(o.validateDir, "report.json")
+	reportExt := o.outputFormat
+	reportPath := filepath.Join(o.validateDir, "report."+reportExt)
 	reportFile, err := os.Create(reportPath)
 	if err != nil {
-		log.Warnf("error creating report file: %v", err)
-	} else {
-		if err := internalValidate.FormatJSON(reportFile, report); err != nil {
-			log.Warnf("error writing report file: %v", err)
-		}
-		reportFile.Close()
-		log.Infof("Wrote validation report to %s", reportPath)
+		return fmt.Errorf("creating validation report %q: %w", reportPath, err)
 	}
+	var writeErr error
+	switch o.outputFormat {
+	case "json":
+		writeErr = internalValidate.FormatJSON(reportFile, report)
+	default:
+		writeErr = internalValidate.FormatYAML(reportFile, report)
+	}
+	if writeErr != nil {
+		_ = reportFile.Close()
+		return fmt.Errorf("writing validation report %q: %w", reportPath, writeErr)
+	}
+	if err := reportFile.Close(); err != nil {
+		return fmt.Errorf("closing validation report %q: %w", reportPath, err)
+	}
+	log.Infof("Wrote validation report to %s", reportPath)
 
 	if report.HasIncompatible() {
 		failuresDir := filepath.Join(o.validateDir, "failures")
 		if err := internalValidate.WriteFailures(failuresDir, report, log); err != nil {
-			log.Warnf("error writing failures: %v", err)
+			return fmt.Errorf("writing validation failures to %q: %w", failuresDir, err)
 		}
 		return internalValidate.ErrValidationFailed
 	}
@@ -141,17 +144,32 @@ failed (or another error occurred).`,
 			}
 			return nil
 		},
-		PreRun: func(cmd *cobra.Command, args []string) {
-			viper.BindPFlags(cmd.Flags())
-			viper.Unmarshal(&o.globalFlags)
-			viper.Unmarshal(&o.configFlags)
-			viper.UnmarshalKey("export-dir", &o.exportDir)
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := viper.BindPFlags(cmd.Flags()); err != nil {
+				return fmt.Errorf("binding validate flags: %w", err)
+			}
+			if err := viper.Unmarshal(&o.globalFlags); err != nil {
+				return fmt.Errorf("loading global flags: %w", err)
+			}
+			if err := viper.Unmarshal(&o.configFlags); err != nil {
+				return fmt.Errorf("loading kube config flags: %w", err)
+			}
+			if err := viper.UnmarshalKey("export-dir", &o.exportDir); err != nil {
+				return fmt.Errorf("loading export-dir: %w", err)
+			}
+			if err := viper.UnmarshalKey("validate-dir", &o.validateDir); err != nil {
+				return fmt.Errorf("loading validate-dir: %w", err)
+			}
+			if err := viper.UnmarshalKey("output", &o.outputFormat); err != nil {
+				return fmt.Errorf("loading output: %w", err)
+			}
+			return nil
 		},
 	}
 
 	cmd.Flags().StringVarP(&o.exportDir, "export-dir", "e", "export", "The path to the exported resources directory")
 	cmd.Flags().StringVar(&o.validateDir, "validate-dir", "validate", "The path where validation results and failures are saved")
-	cmd.Flags().StringVarP(&o.outputFormat, "output", "o", "table", "Report format: table or json")
+	cmd.Flags().StringVarP(&o.outputFormat, "output", "o", "json", "Report file format: json or yaml")
 	o.configFlags.AddFlags(cmd.Flags())
 
 	return cmd

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -30,7 +30,7 @@ type ValidateOptions struct {
 func (o *ValidateOptions) Complete(c *cobra.Command, args []string) error {
 	_, err := o.configFlags.ToRawKubeConfigLoader().RawConfig()
 	if err != nil {
-		return err
+		return fmt.Errorf("loading kubeconfig for target cluster: %w", err)
 	}
 	return nil
 }
@@ -134,6 +134,7 @@ the validate-dir for auditability.
 
 Exit code 0 means all checks pass; exit code 1 means one or more checks
 failed (or another error occurred).`,
+		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := o.Complete(c, args); err != nil {

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -147,26 +147,10 @@ failed (or another error occurred).`,
 			}
 			return nil
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := viper.BindPFlags(cmd.Flags()); err != nil {
-				return fmt.Errorf("binding validate flags: %w", err)
-			}
-			if err := viper.Unmarshal(&o.globalFlags); err != nil {
-				return fmt.Errorf("loading global flags: %w", err)
-			}
-			if err := viper.Unmarshal(&o.configFlags); err != nil {
-				return fmt.Errorf("loading kube config flags: %w", err)
-			}
-			if err := viper.UnmarshalKey("input-dir", &o.inputDir); err != nil {
-				return fmt.Errorf("loading input-dir: %w", err)
-			}
-			if err := viper.UnmarshalKey("validate-dir", &o.validateDir); err != nil {
-				return fmt.Errorf("loading validate-dir: %w", err)
-			}
-			if err := viper.UnmarshalKey("output", &o.outputFormat); err != nil {
-				return fmt.Errorf("loading output: %w", err)
-			}
-			return nil
+		PreRun: func(cmd *cobra.Command, args []string) {
+			viper.BindPFlags(cmd.Flags())
+			viper.Unmarshal(&o.globalFlags)
+			viper.Unmarshal(&o.configFlags)
 		},
 	}
 

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -19,7 +19,7 @@ type ValidateOptions struct {
 	cobraGlobalFlags *flags.GlobalFlags
 	globalFlags      *flags.GlobalFlags
 
-	exportDir    string
+	inputDir     string
 	validateDir  string
 	outputFormat string
 
@@ -37,12 +37,12 @@ func (o *ValidateOptions) Complete(c *cobra.Command, args []string) error {
 
 // Validate checks that flags have valid values.
 func (o *ValidateOptions) Validate() error {
-	info, err := os.Stat(o.exportDir)
+	info, err := os.Stat(o.inputDir)
 	if err != nil {
-		return fmt.Errorf("export-dir %q: %w", o.exportDir, err)
+		return fmt.Errorf("input-dir %q: %w", o.inputDir, err)
 	}
 	if !info.IsDir() {
-		return fmt.Errorf("export-dir %q is not a directory", o.exportDir)
+		return fmt.Errorf("input-dir %q is not a directory", o.inputDir)
 	}
 
 	if o.outputFormat != "yaml" && o.outputFormat != "json" {
@@ -56,7 +56,7 @@ func (o *ValidateOptions) Validate() error {
 func (o *ValidateOptions) Run() error {
 	log := o.globalFlags.GetLogger()
 
-	entries, err := internalValidate.ScanManifests(internalValidate.ScanOptions{Dirs: []string{o.exportDir}}, log)
+	entries, err := internalValidate.ScanManifests(internalValidate.ScanOptions{Dirs: []string{o.inputDir}}, log)
 	if err != nil {
 		return fmt.Errorf("scanning manifests: %w", err)
 	}
@@ -121,10 +121,13 @@ func NewValidateCommand(streams genericclioptions.IOStreams, f *flags.GlobalFlag
 	}
 	cmd := &cobra.Command{
 		Use:   "validate",
-		Short: "Validate exported manifests against a target cluster",
-		Long: `Validate checks exported Kubernetes manifests for compatibility with a
-target cluster. Currently it verifies that every apiVersion+kind in the
-export is served by the target cluster's API surface (strict GVK matching).
+		Short: "Validate final manifests against a target cluster",
+		Long: `Validate checks the final rendered manifests (from crane apply's output)
+for compatibility with a target cluster. It verifies that every
+apiVersion+kind is served by the target cluster's API surface (strict
+GVK matching).
+
+Pipeline: export → transform → apply → validate
 
 Incompatible resources are written to a failures/ directory under
 the validate-dir for auditability.
@@ -154,8 +157,8 @@ failed (or another error occurred).`,
 			if err := viper.Unmarshal(&o.configFlags); err != nil {
 				return fmt.Errorf("loading kube config flags: %w", err)
 			}
-			if err := viper.UnmarshalKey("export-dir", &o.exportDir); err != nil {
-				return fmt.Errorf("loading export-dir: %w", err)
+			if err := viper.UnmarshalKey("input-dir", &o.inputDir); err != nil {
+				return fmt.Errorf("loading input-dir: %w", err)
 			}
 			if err := viper.UnmarshalKey("validate-dir", &o.validateDir); err != nil {
 				return fmt.Errorf("loading validate-dir: %w", err)
@@ -167,7 +170,7 @@ failed (or another error occurred).`,
 		},
 	}
 
-	cmd.Flags().StringVarP(&o.exportDir, "export-dir", "e", "export", "The path to the exported resources directory")
+	cmd.Flags().StringVarP(&o.inputDir, "input-dir", "i", "output", "The path to the apply output directory containing final manifests")
 	cmd.Flags().StringVar(&o.validateDir, "validate-dir", "validate", "The path where validation results and failures are saved")
 	cmd.Flags().StringVarP(&o.outputFormat, "output", "o", "json", "Report file format: json or yaml")
 	o.configFlags.AddFlags(cmd.Flags())

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -1,0 +1,158 @@
+package validate
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/konveyor/crane/internal/flags"
+	internalValidate "github.com/konveyor/crane/internal/validate"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+// ValidateOptions holds CLI flags and runtime state for a validate run.
+type ValidateOptions struct {
+	configFlags *genericclioptions.ConfigFlags
+
+	cobraGlobalFlags *flags.GlobalFlags
+	globalFlags      *flags.GlobalFlags
+
+	exportDir    string
+	validateDir  string
+	outputFormat string
+
+	genericclioptions.IOStreams
+}
+
+// Complete loads the kubeconfig to ensure the target cluster is reachable.
+func (o *ValidateOptions) Complete(c *cobra.Command, args []string) error {
+	_, err := o.configFlags.ToRawKubeConfigLoader().RawConfig()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Validate checks that flags have valid values.
+func (o *ValidateOptions) Validate() error {
+	info, err := os.Stat(o.exportDir)
+	if err != nil {
+		return fmt.Errorf("export-dir %q: %w", o.exportDir, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("export-dir %q is not a directory", o.exportDir)
+	}
+
+	if o.outputFormat != "table" && o.outputFormat != "json" {
+		return fmt.Errorf("--output must be \"table\" or \"json\", got %q", o.outputFormat)
+	}
+
+	return nil
+}
+
+// Run performs the scan, match, and report steps.
+func (o *ValidateOptions) Run() error {
+	log := o.globalFlags.GetLogger()
+
+	entries, err := internalValidate.ScanManifests(internalValidate.ScanOptions{Dirs: []string{o.exportDir}}, log)
+	if err != nil {
+		return fmt.Errorf("scanning manifests: %w", err)
+	}
+
+	log.Infof("Scanned %d distinct GVK+namespace tuples", len(entries))
+
+	discoveryClient, err := o.configFlags.ToDiscoveryClient()
+	if err != nil {
+		return fmt.Errorf("creating discovery client: %w", err)
+	}
+	discoveryClient.Invalidate()
+
+	report, err := internalValidate.MatchResults(entries, internalValidate.MatchOptions{DiscoveryClient: discoveryClient}, log)
+	if err != nil {
+		return fmt.Errorf("matching against target cluster: %w", err)
+	}
+
+	switch o.outputFormat {
+	case "json":
+		if err := internalValidate.FormatJSON(o.Out, report); err != nil {
+			return fmt.Errorf("writing JSON report: %w", err)
+		}
+	default:
+		internalValidate.FormatTable(o.Out, report)
+	}
+
+	if err := os.MkdirAll(o.validateDir, 0700); err != nil {
+		return fmt.Errorf("creating validate directory: %w", err)
+	}
+	reportPath := filepath.Join(o.validateDir, "report.json")
+	reportFile, err := os.Create(reportPath)
+	if err != nil {
+		log.Warnf("error creating report file: %v", err)
+	} else {
+		if err := internalValidate.FormatJSON(reportFile, report); err != nil {
+			log.Warnf("error writing report file: %v", err)
+		}
+		reportFile.Close()
+		log.Infof("Wrote validation report to %s", reportPath)
+	}
+
+	if report.HasIncompatible() {
+		failuresDir := filepath.Join(o.validateDir, "failures")
+		if err := internalValidate.WriteFailures(failuresDir, report, log); err != nil {
+			log.Warnf("error writing failures: %v", err)
+		}
+		return internalValidate.ErrValidationFailed
+	}
+
+	return nil
+}
+
+// NewValidateCommand builds the cobra validate command with flags and viper wiring.
+func NewValidateCommand(streams genericclioptions.IOStreams, f *flags.GlobalFlags) *cobra.Command {
+	o := &ValidateOptions{
+		configFlags:      genericclioptions.NewConfigFlags(true),
+		IOStreams:         streams,
+		cobraGlobalFlags: f,
+	}
+	cmd := &cobra.Command{
+		Use:   "validate",
+		Short: "Validate exported manifests against a target cluster",
+		Long: `Validate checks exported Kubernetes manifests for compatibility with a
+target cluster. Currently it verifies that every apiVersion+kind in the
+export is served by the target cluster's API surface (strict GVK matching).
+
+Incompatible resources are written to a failures/ directory under
+the validate-dir for auditability.
+
+Exit code 0 means all checks pass; exit code 1 means one or more checks
+failed (or another error occurred).`,
+		SilenceUsage: true,
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := o.Complete(c, args); err != nil {
+				return err
+			}
+			if err := o.Validate(); err != nil {
+				return err
+			}
+			if err := o.Run(); err != nil {
+				return err
+			}
+			return nil
+		},
+		PreRun: func(cmd *cobra.Command, args []string) {
+			viper.BindPFlags(cmd.Flags())
+			viper.Unmarshal(&o.globalFlags)
+			viper.Unmarshal(&o.configFlags)
+			viper.UnmarshalKey("export-dir", &o.exportDir)
+		},
+	}
+
+	cmd.Flags().StringVarP(&o.exportDir, "export-dir", "e", "export", "The path to the exported resources directory")
+	cmd.Flags().StringVar(&o.validateDir, "validate-dir", "validate", "The path where validation results and failures are saved")
+	cmd.Flags().StringVarP(&o.outputFormat, "output", "o", "table", "Report format: table or json")
+	o.configFlags.AddFlags(cmd.Flags())
+
+	return cmd
+}

--- a/cmd/validate/validate_test.go
+++ b/cmd/validate/validate_test.go
@@ -1,0 +1,137 @@
+package validate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+func TestNewValidateCommand(t *testing.T) {
+	streams := genericclioptions.NewTestIOStreamsDiscard()
+	cmd := NewValidateCommand(streams, nil)
+
+	if cmd.Use != "validate" {
+		t.Fatalf("Use = %q, want %q", cmd.Use, "validate")
+	}
+
+	expectedFlags := []string{"export-dir", "validate-dir", "output"}
+	for _, name := range expectedFlags {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Errorf("flag %q not registered on validate command", name)
+		}
+	}
+
+	if d := cmd.Flags().Lookup("export-dir").DefValue; d != "export" {
+		t.Errorf("export-dir default = %q, want %q", d, "export")
+	}
+	if d := cmd.Flags().Lookup("output").DefValue; d != "table" {
+		t.Errorf("output default = %q, want %q", d, "table")
+	}
+	if d := cmd.Flags().Lookup("validate-dir").DefValue; d != "validate" {
+		t.Errorf("validate-dir default = %q, want %q", d, "validate")
+	}
+}
+
+func TestValidate_Flags(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T) *ValidateOptions
+		wantErr  bool
+		errMatch string
+	}{
+		{
+			name: "missing export-dir",
+			setup: func(t *testing.T) *ValidateOptions {
+				return &ValidateOptions{
+					exportDir:    "/nonexistent/path/validate-test",
+					outputFormat: "table",
+				}
+			},
+			wantErr:  true,
+			errMatch: "export-dir",
+		},
+		{
+			name: "export-dir is a file",
+			setup: func(t *testing.T) *ValidateOptions {
+				dir := t.TempDir()
+				f := filepath.Join(dir, "afile")
+				if err := os.WriteFile(f, []byte("x"), 0600); err != nil {
+					t.Fatal(err)
+				}
+				return &ValidateOptions{
+					exportDir:    f,
+					outputFormat: "table",
+				}
+			},
+			wantErr:  true,
+			errMatch: "not a directory",
+		},
+		{
+			name: "invalid output format",
+			setup: func(t *testing.T) *ValidateOptions {
+				return &ValidateOptions{
+					exportDir:    t.TempDir(),
+					outputFormat: "xml",
+				}
+			},
+			wantErr:  true,
+			errMatch: "table",
+		},
+		{
+			name: "valid table format",
+			setup: func(t *testing.T) *ValidateOptions {
+				return &ValidateOptions{
+					exportDir:    t.TempDir(),
+					outputFormat: "table",
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid json format",
+			setup: func(t *testing.T) *ValidateOptions {
+				return &ValidateOptions{
+					exportDir:    t.TempDir(),
+					outputFormat: "json",
+				}
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := tt.setup(t)
+			err := o.Validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.errMatch != "" {
+					if got := err.Error(); !contains(got, tt.errMatch) {
+						t.Fatalf("error = %q, want substring %q", got, tt.errMatch)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsSubstring(s, sub))
+}
+
+func containsSubstring(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/validate/validate_test.go
+++ b/cmd/validate/validate_test.go
@@ -17,15 +17,15 @@ func TestNewValidateCommand(t *testing.T) {
 		t.Fatalf("Use = %q, want %q", cmd.Use, "validate")
 	}
 
-	expectedFlags := []string{"export-dir", "validate-dir", "output"}
+	expectedFlags := []string{"input-dir", "validate-dir", "output"}
 	for _, name := range expectedFlags {
 		if cmd.Flags().Lookup(name) == nil {
 			t.Errorf("flag %q not registered on validate command", name)
 		}
 	}
 
-	if d := cmd.Flags().Lookup("export-dir").DefValue; d != "export" {
-		t.Errorf("export-dir default = %q, want %q", d, "export")
+	if d := cmd.Flags().Lookup("input-dir").DefValue; d != "output" {
+		t.Errorf("input-dir default = %q, want %q", d, "output")
 	}
 	if d := cmd.Flags().Lookup("output").DefValue; d != "json" {
 		t.Errorf("output default = %q, want %q", d, "json")
@@ -43,18 +43,18 @@ func TestValidate_Flags(t *testing.T) {
 		errMatch string
 	}{
 		{
-			name: "missing export-dir",
+			name: "missing input-dir",
 			setup: func(t *testing.T) *ValidateOptions {
 				return &ValidateOptions{
-					exportDir:    "/nonexistent/path/validate-test",
+					inputDir:    "/nonexistent/path/validate-test",
 					outputFormat: "yaml",
 				}
 			},
 			wantErr:  true,
-			errMatch: "export-dir",
+			errMatch: "input-dir",
 		},
 		{
-			name: "export-dir is a file",
+			name: "input-dir is a file",
 			setup: func(t *testing.T) *ValidateOptions {
 				dir := t.TempDir()
 				f := filepath.Join(dir, "afile")
@@ -62,7 +62,7 @@ func TestValidate_Flags(t *testing.T) {
 					t.Fatal(err)
 				}
 				return &ValidateOptions{
-					exportDir:    f,
+					inputDir:    f,
 					outputFormat: "yaml",
 				}
 			},
@@ -73,7 +73,7 @@ func TestValidate_Flags(t *testing.T) {
 			name: "invalid output format",
 			setup: func(t *testing.T) *ValidateOptions {
 				return &ValidateOptions{
-					exportDir:    t.TempDir(),
+					inputDir:    t.TempDir(),
 					outputFormat: "xml",
 				}
 			},
@@ -84,7 +84,7 @@ func TestValidate_Flags(t *testing.T) {
 			name: "valid yaml format",
 			setup: func(t *testing.T) *ValidateOptions {
 				return &ValidateOptions{
-					exportDir:    t.TempDir(),
+					inputDir:    t.TempDir(),
 					outputFormat: "yaml",
 				}
 			},
@@ -94,7 +94,7 @@ func TestValidate_Flags(t *testing.T) {
 			name: "valid json format",
 			setup: func(t *testing.T) *ValidateOptions {
 				return &ValidateOptions{
-					exportDir:    t.TempDir(),
+					inputDir:    t.TempDir(),
 					outputFormat: "json",
 				}
 			},

--- a/cmd/validate/validate_test.go
+++ b/cmd/validate/validate_test.go
@@ -3,6 +3,7 @@ package validate
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -26,8 +27,8 @@ func TestNewValidateCommand(t *testing.T) {
 	if d := cmd.Flags().Lookup("export-dir").DefValue; d != "export" {
 		t.Errorf("export-dir default = %q, want %q", d, "export")
 	}
-	if d := cmd.Flags().Lookup("output").DefValue; d != "table" {
-		t.Errorf("output default = %q, want %q", d, "table")
+	if d := cmd.Flags().Lookup("output").DefValue; d != "json" {
+		t.Errorf("output default = %q, want %q", d, "json")
 	}
 	if d := cmd.Flags().Lookup("validate-dir").DefValue; d != "validate" {
 		t.Errorf("validate-dir default = %q, want %q", d, "validate")
@@ -46,7 +47,7 @@ func TestValidate_Flags(t *testing.T) {
 			setup: func(t *testing.T) *ValidateOptions {
 				return &ValidateOptions{
 					exportDir:    "/nonexistent/path/validate-test",
-					outputFormat: "table",
+					outputFormat: "yaml",
 				}
 			},
 			wantErr:  true,
@@ -62,7 +63,7 @@ func TestValidate_Flags(t *testing.T) {
 				}
 				return &ValidateOptions{
 					exportDir:    f,
-					outputFormat: "table",
+					outputFormat: "yaml",
 				}
 			},
 			wantErr:  true,
@@ -77,14 +78,14 @@ func TestValidate_Flags(t *testing.T) {
 				}
 			},
 			wantErr:  true,
-			errMatch: "table",
+			errMatch: "yaml",
 		},
 		{
-			name: "valid table format",
+			name: "valid yaml format",
 			setup: func(t *testing.T) *ValidateOptions {
 				return &ValidateOptions{
 					exportDir:    t.TempDir(),
-					outputFormat: "table",
+					outputFormat: "yaml",
 				}
 			},
 			wantErr: false,
@@ -110,7 +111,7 @@ func TestValidate_Flags(t *testing.T) {
 					t.Fatal("expected error, got nil")
 				}
 				if tt.errMatch != "" {
-					if got := err.Error(); !contains(got, tt.errMatch) {
+					if got := err.Error(); !strings.Contains(got, tt.errMatch) {
 						t.Fatalf("error = %q, want substring %q", got, tt.errMatch)
 					}
 				}
@@ -123,15 +124,3 @@ func TestValidate_Flags(t *testing.T) {
 	}
 }
 
-func contains(s, sub string) bool {
-	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsSubstring(s, sub))
-}
-
-func containsSubstring(s, sub string) bool {
-	for i := 0; i <= len(s)-len(sub); i++ {
-		if s[i:i+len(sub)] == sub {
-			return true
-		}
-	}
-	return false
-}

--- a/cmd/validate/validate_test.go
+++ b/cmd/validate/validate_test.go
@@ -45,8 +45,9 @@ func TestValidate_Flags(t *testing.T) {
 		{
 			name: "missing input-dir",
 			setup: func(t *testing.T) *ValidateOptions {
+				missingDir := filepath.Join(t.TempDir(), "missing")
 				return &ValidateOptions{
-					inputDir:    "/nonexistent/path/validate-test",
+					inputDir:     missingDir,
 					outputFormat: "yaml",
 				}
 			},
@@ -121,6 +122,19 @@ func TestValidate_Flags(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 		})
+	}
+}
+
+func TestValidateCommand_RejectsArgs(t *testing.T) {
+	streams := genericclioptions.NewTestIOStreamsDiscard()
+	cmd := NewValidateCommand(streams, nil)
+	cmd.SetArgs([]string{"./manifests"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for positional args, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown command") {
+		t.Fatalf("expected 'unknown command' error, got: %v", err)
 	}
 }
 

--- a/internal/validate/matcher.go
+++ b/internal/validate/matcher.go
@@ -1,0 +1,154 @@
+package validate
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery"
+)
+
+// MatchOptions configures the target-cluster discovery used by MatchResults.
+type MatchOptions struct {
+	DiscoveryClient discovery.DiscoveryInterface
+}
+
+// MatchResults compares each ManifestEntry against the target cluster's
+// discovery information and returns a report indicating which GVKs are
+// compatible and which are not.
+func MatchResults(entries []ManifestEntry, opts MatchOptions, log logrus.FieldLogger) (*ValidationReport, error) {
+	index, err := buildDiscoveryIndex(opts.DiscoveryClient, log)
+	if err != nil {
+		return nil, err
+	}
+
+	kindIndex := buildKindIndex(index)
+
+	results := make([]ValidationResult, 0, len(entries))
+	for _, entry := range entries {
+		result := matchEntry(entry, index)
+		if result.Status == StatusIncompatible {
+			addSuggestion(&result, entry, kindIndex)
+		}
+		results = append(results, result)
+	}
+
+	compatible, incompatible := 0, 0
+	for _, r := range results {
+		if r.Status == StatusOK {
+			compatible++
+		} else {
+			incompatible++
+		}
+	}
+
+	return &ValidationReport{
+		Results:      results,
+		TotalScanned: len(results),
+		Compatible:   compatible,
+		Incompatible: incompatible,
+	}, nil
+}
+
+// discoveryEntry stores one APIResource with its group/version context.
+type discoveryEntry struct {
+	Resource metav1.APIResource
+}
+
+// buildDiscoveryIndex fetches all served group-versions from the target cluster
+// and builds a two-level lookup: groupVersion -> kind -> discoveryEntry.
+func buildDiscoveryIndex(client discovery.DiscoveryInterface, log logrus.FieldLogger) (map[string]map[string]discoveryEntry, error) {
+	_, lists, err := client.ServerGroupsAndResources()
+	if err != nil {
+		if discovery.IsGroupDiscoveryFailedError(err) {
+			if len(lists) == 0 {
+				return nil, fmt.Errorf("discovery failed with no usable results: %w", err)
+			}
+			log.Warnf("partial discovery failure, continuing with available groups: %v", err)
+		} else {
+			return nil, fmt.Errorf("discovery failed: %w", err)
+		}
+	}
+
+	index := map[string]map[string]discoveryEntry{}
+	for _, list := range lists {
+		gv := list.GroupVersion
+		if _, ok := index[gv]; !ok {
+			index[gv] = map[string]discoveryEntry{}
+		}
+		for _, res := range list.APIResources {
+			if strings.Contains(res.Name, "/") {
+				continue
+			}
+			index[gv][res.Kind] = discoveryEntry{Resource: res}
+		}
+	}
+	return index, nil
+}
+
+// matchEntry checks a single ManifestEntry against the discovery index.
+func matchEntry(entry ManifestEntry, index map[string]map[string]discoveryEntry) ValidationResult {
+	result := ValidationResult{
+		APIVersion: entry.APIVersion,
+		Kind:       entry.Kind,
+		Namespace:  entry.Namespace,
+	}
+
+	gvKey := entry.APIVersion
+	kinds, gvFound := index[gvKey]
+	if !gvFound {
+		result.Status = StatusIncompatible
+		result.Reason = fmt.Sprintf("API version %s not available on target cluster", entry.APIVersion)
+		return result
+	}
+
+	de, kindFound := kinds[entry.Kind]
+	if !kindFound {
+		result.Status = StatusIncompatible
+		result.Reason = fmt.Sprintf("kind %s not found in API version %s on target cluster", entry.Kind, entry.APIVersion)
+		return result
+	}
+
+	result.Status = StatusOK
+	result.ResourcePlural = de.Resource.Name
+	return result
+}
+
+// buildKindIndex creates a reverse lookup: kind -> list of groupVersion strings
+// that serve it. Used to suggest alternatives for incompatible resources.
+func buildKindIndex(index map[string]map[string]discoveryEntry) map[string][]string {
+	kindIdx := map[string][]string{}
+	for gv, kinds := range index {
+		for kind := range kinds {
+			kindIdx[kind] = append(kindIdx[kind], gv)
+		}
+	}
+	return kindIdx
+}
+
+// addSuggestion checks whether the same kind is available under a different
+// apiVersion on the target and populates the Suggestion field.
+func addSuggestion(result *ValidationResult, entry ManifestEntry, kindIndex map[string][]string) {
+	alternatives := kindIndex[entry.Kind]
+	if len(alternatives) == 0 {
+		return
+	}
+
+	var available []string
+	for _, gv := range alternatives {
+		if gv != entry.APIVersion {
+			available = append(available, gv)
+		}
+	}
+	if len(available) == 0 {
+		return
+	}
+
+	sort.Strings(available)
+	suggestion := fmt.Sprintf("available as %s", strings.Join(available, ", "))
+	result.Suggestion = suggestion
+	result.Reason = fmt.Sprintf("%s (%s)", result.Reason, suggestion)
+}
+

--- a/internal/validate/matcher_test.go
+++ b/internal/validate/matcher_test.go
@@ -1,0 +1,231 @@
+package validate
+
+import (
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+func fakeDiscovery(resources []*metav1.APIResourceList) *fakediscovery.FakeDiscovery {
+	fake := &fakediscovery.FakeDiscovery{
+		Fake: &clienttesting.Fake{},
+	}
+	fake.Resources = resources
+	return fake
+}
+
+func TestMatchResults_AllOK(t *testing.T) {
+	disc := fakeDiscovery([]*metav1.APIResourceList{
+		{
+			GroupVersion: "apps/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "deployments", Kind: "Deployment"},
+			},
+		},
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "configmaps", Kind: "ConfigMap"},
+			},
+		},
+	})
+
+	entries := []ManifestEntry{
+		{APIVersion: "apps/v1", Kind: "Deployment", Group: "apps", Version: "v1", Namespace: "prod"},
+		{APIVersion: "v1", Kind: "ConfigMap", Group: "", Version: "v1", Namespace: "prod"},
+	}
+
+	report, err := MatchResults(entries, MatchOptions{DiscoveryClient: disc}, testLogger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.Incompatible != 0 {
+		t.Fatalf("Incompatible = %d, want 0", report.Incompatible)
+	}
+	if report.Compatible != 2 {
+		t.Fatalf("Compatible = %d, want 2", report.Compatible)
+	}
+	for _, r := range report.Results {
+		if r.Status != StatusOK {
+			t.Fatalf("result %+v has status %s, want OK", r, r.Status)
+		}
+	}
+}
+
+func TestMatchResults_MissingGroupVersion(t *testing.T) {
+	disc := fakeDiscovery([]*metav1.APIResourceList{
+		{
+			GroupVersion: "apps/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "deployments", Kind: "Deployment"},
+			},
+		},
+	})
+
+	entries := []ManifestEntry{
+		{APIVersion: "route.openshift.io/v1", Kind: "Route", Group: "route.openshift.io", Version: "v1", Namespace: "prod"},
+	}
+
+	report, err := MatchResults(entries, MatchOptions{DiscoveryClient: disc}, testLogger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.Incompatible != 1 {
+		t.Fatalf("Incompatible = %d, want 1", report.Incompatible)
+	}
+	if report.Results[0].Reason == "" {
+		t.Fatal("expected non-empty reason for incompatible result")
+	}
+}
+
+func TestMatchResults_GroupVersionPresentKindMissing(t *testing.T) {
+	disc := fakeDiscovery([]*metav1.APIResourceList{
+		{
+			GroupVersion: "apps/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "deployments", Kind: "Deployment"},
+			},
+		},
+	})
+
+	entries := []ManifestEntry{
+		{APIVersion: "apps/v1", Kind: "StatefulSet", Group: "apps", Version: "v1", Namespace: "prod"},
+	}
+
+	report, err := MatchResults(entries, MatchOptions{DiscoveryClient: disc}, testLogger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.Incompatible != 1 {
+		t.Fatalf("Incompatible = %d, want 1", report.Incompatible)
+	}
+	r := report.Results[0]
+	if r.Status != StatusIncompatible {
+		t.Fatalf("status = %s, want Incompatible", r.Status)
+	}
+	if r.Reason == "" {
+		t.Fatal("expected non-empty reason")
+	}
+}
+
+func TestMatchResults_MixedResults(t *testing.T) {
+	disc := fakeDiscovery([]*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "configmaps", Kind: "ConfigMap"},
+			},
+		},
+	})
+
+	entries := []ManifestEntry{
+		{APIVersion: "v1", Kind: "ConfigMap", Group: "", Version: "v1", Namespace: "prod"},
+		{APIVersion: "route.openshift.io/v1", Kind: "Route", Group: "route.openshift.io", Version: "v1", Namespace: "prod"},
+	}
+
+	report, err := MatchResults(entries, MatchOptions{DiscoveryClient: disc}, testLogger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.Compatible != 1 || report.Incompatible != 1 {
+		t.Fatalf("Compatible=%d Incompatible=%d, want 1/1", report.Compatible, report.Incompatible)
+	}
+}
+
+func TestMatchResults_SuggestionWhenAlternativeExists(t *testing.T) {
+	disc := fakeDiscovery([]*metav1.APIResourceList{
+		{
+			GroupVersion: "apps/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "deployments", Kind: "Deployment"},
+			},
+		},
+	})
+
+	entries := []ManifestEntry{
+		{APIVersion: "extensions/v1beta1", Kind: "Deployment", Group: "extensions", Version: "v1beta1", Namespace: "prod"},
+	}
+
+	report, err := MatchResults(entries, MatchOptions{DiscoveryClient: disc}, testLogger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.Incompatible != 1 {
+		t.Fatalf("Incompatible = %d, want 1", report.Incompatible)
+	}
+	r := report.Results[0]
+	if r.Suggestion == "" {
+		t.Fatal("expected non-empty suggestion when alternative GV exists")
+	}
+	if !strings.Contains(r.Suggestion, "apps/v1") {
+		t.Fatalf("Suggestion = %q, expected it to mention apps/v1", r.Suggestion)
+	}
+	if !strings.Contains(r.Reason, "available as") {
+		t.Fatalf("Reason = %q, expected it to contain suggestion hint", r.Reason)
+	}
+}
+
+func TestMatchResults_NoSuggestionWhenKindNotOnTarget(t *testing.T) {
+	disc := fakeDiscovery([]*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "configmaps", Kind: "ConfigMap"},
+			},
+		},
+	})
+
+	entries := []ManifestEntry{
+		{APIVersion: "route.openshift.io/v1", Kind: "Route", Group: "route.openshift.io", Version: "v1", Namespace: "prod"},
+	}
+
+	report, err := MatchResults(entries, MatchOptions{DiscoveryClient: disc}, testLogger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	r := report.Results[0]
+	if r.Suggestion != "" {
+		t.Fatalf("expected empty suggestion when kind is entirely absent, got %q", r.Suggestion)
+	}
+}
+
+func TestMatchResults_EmptyEntries(t *testing.T) {
+	disc := fakeDiscovery([]*metav1.APIResourceList{})
+
+	report, err := MatchResults([]ManifestEntry{}, MatchOptions{DiscoveryClient: disc}, testLogger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.TotalScanned != 0 {
+		t.Fatalf("TotalScanned = %d, want 0", report.TotalScanned)
+	}
+	if report.HasIncompatible() {
+		t.Fatal("empty report should not be incompatible")
+	}
+}
+
+func TestMatchResults_ResourcePluralPopulated(t *testing.T) {
+	disc := fakeDiscovery([]*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "services", Kind: "Service"},
+			},
+		},
+	})
+
+	entries := []ManifestEntry{
+		{APIVersion: "v1", Kind: "Service", Group: "", Version: "v1", Namespace: "prod"},
+	}
+
+	report, err := MatchResults(entries, MatchOptions{DiscoveryClient: disc}, testLogger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.Results[0].ResourcePlural != "services" {
+		t.Fatalf("ResourcePlural = %q, want %q", report.Results[0].ResourcePlural, "services")
+	}
+}

--- a/internal/validate/report.go
+++ b/internal/validate/report.go
@@ -43,6 +43,11 @@ func FormatTable(w io.Writer, report *ValidationReport) {
 	table.Render()
 	fmt.Fprintf(w, "\nSummary: %d scanned, %d compatible, %d incompatible\n",
 		report.TotalScanned, report.Compatible, report.Incompatible)
+	if report.HasIncompatible() {
+		fmt.Fprintf(w, "Result: FAILED — %d resource(s) incompatible with target cluster\n", report.Incompatible)
+	} else {
+		fmt.Fprintf(w, "Result: PASSED — all resources compatible with target cluster\n")
+	}
 }
 
 // FormatJSON writes the report as indented JSON to w.

--- a/internal/validate/report.go
+++ b/internal/validate/report.go
@@ -112,7 +112,27 @@ func failureFileName(r ValidationResult) string {
 	if ns == "" {
 		ns = "clusterscoped"
 	}
-	return strings.Join([]string{r.Kind, group, version, ns}, "_") + ".yaml"
+	return strings.Join([]string{
+		safeFilePart(r.Kind),
+		safeFilePart(group),
+		safeFilePart(version),
+		safeFilePart(ns),
+	}, "_") + ".yaml"
+}
+
+func safeFilePart(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '.' || r == '-' {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('_')
+		}
+	}
+	if b.Len() == 0 {
+		return "unknown"
+	}
+	return b.String()
 }
 
 // parseAPIVersion splits "apps/v1" into ("apps","v1") and "v1" into ("","v1").

--- a/internal/validate/report.go
+++ b/internal/validate/report.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/sirupsen/logrus"
+	sigsyaml "sigs.k8s.io/yaml"
 )
 
 // FormatTable writes a human-readable table to w.
@@ -51,6 +52,16 @@ func FormatJSON(w io.Writer, report *ValidationReport) error {
 	return enc.Encode(report)
 }
 
+// FormatYAML writes the report as YAML to w.
+func FormatYAML(w io.Writer, report *ValidationReport) error {
+	data, err := sigsyaml.Marshal(report)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(data)
+	return err
+}
+
 // WriteFailures writes incompatible results as individual YAML files under
 // failuresDir, following the same pattern used by the export command's
 // failures/ directory. Each file is named by apiVersion-kind-namespace.yaml.
@@ -71,7 +82,7 @@ func WriteFailures(failuresDir string, report *ValidationReport, log logrus.Fiel
 		filename := failureFileName(r)
 		path := filepath.Join(failuresDir, filename)
 
-		data, err := json.MarshalIndent(r, "", "  ")
+		data, err := sigsyaml.Marshal(r)
 		if err != nil {
 			log.Warnf("error marshaling failure for %s/%s: %v", r.APIVersion, r.Kind, err)
 			continue

--- a/internal/validate/report.go
+++ b/internal/validate/report.go
@@ -1,0 +1,109 @@
+package validate
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/sirupsen/logrus"
+)
+
+// FormatTable writes a human-readable table to w.
+func FormatTable(w io.Writer, report *ValidationReport) {
+	table := tablewriter.NewWriter(w)
+	table.SetHeader([]string{"APIVERSION", "KIND", "NAMESPACE", "RESOURCE", "STATUS", "REASON", "SUGGESTION"})
+	table.SetAutoWrapText(false)
+	table.SetBorder(false)
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("")
+	table.SetHeaderLine(false)
+	table.SetTablePadding("  ")
+	table.SetNoWhiteSpace(true)
+
+	for _, r := range report.Results {
+		table.Append([]string{
+			r.APIVersion,
+			r.Kind,
+			r.Namespace,
+			r.ResourcePlural,
+			string(r.Status),
+			r.Reason,
+			r.Suggestion,
+		})
+	}
+
+	table.Render()
+	fmt.Fprintf(w, "\nSummary: %d scanned, %d compatible, %d incompatible\n",
+		report.TotalScanned, report.Compatible, report.Incompatible)
+}
+
+// FormatJSON writes the report as indented JSON to w.
+func FormatJSON(w io.Writer, report *ValidationReport) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(report)
+}
+
+// WriteFailures writes incompatible results as individual YAML files under
+// failuresDir, following the same pattern used by the export command's
+// failures/ directory. Each file is named by apiVersion-kind-namespace.yaml.
+func WriteFailures(failuresDir string, report *ValidationReport, log logrus.FieldLogger) error {
+	incompatible := report.IncompatibleResults()
+	if len(incompatible) == 0 {
+		return nil
+	}
+
+	if err := os.RemoveAll(failuresDir); err != nil {
+		return fmt.Errorf("clear validate failures directory %q: %w", failuresDir, err)
+	}
+	if err := os.MkdirAll(failuresDir, 0700); err != nil {
+		return fmt.Errorf("create validate failures directory %q: %w", failuresDir, err)
+	}
+
+	for _, r := range incompatible {
+		filename := failureFileName(r)
+		path := filepath.Join(failuresDir, filename)
+
+		data, err := json.MarshalIndent(r, "", "  ")
+		if err != nil {
+			log.Warnf("error marshaling failure for %s/%s: %v", r.APIVersion, r.Kind, err)
+			continue
+		}
+
+		if err := os.WriteFile(path, data, 0600); err != nil {
+			log.Warnf("error writing failure file %s: %v", path, err)
+			continue
+		}
+		log.Debugf("wrote validation failure: %s", path)
+	}
+
+	log.Infof("Wrote %d validation failure(s) to %s", len(incompatible), failuresDir)
+	return nil
+}
+
+// failureFileName builds a stable filename from a ValidationResult.
+// Format: Kind_group_version_namespace.yaml (matching export's naming pattern).
+func failureFileName(r ValidationResult) string {
+	group, version := parseAPIVersion(r.APIVersion)
+	ns := r.Namespace
+	if ns == "" {
+		ns = "clusterscoped"
+	}
+	return strings.Join([]string{r.Kind, group, version, ns}, "_") + ".yaml"
+}
+
+// parseAPIVersion splits "apps/v1" into ("apps","v1") and "v1" into ("","v1").
+func parseAPIVersion(apiVersion string) (string, string) {
+	parts := strings.SplitN(apiVersion, "/", 2)
+	if len(parts) == 1 {
+		return "", parts[0]
+	}
+	return parts[0], parts[1]
+}

--- a/internal/validate/report_test.go
+++ b/internal/validate/report_test.go
@@ -1,0 +1,126 @@
+package validate
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestFormatTable(t *testing.T) {
+	report := &ValidationReport{
+		Results: []ValidationResult{
+			{APIVersion: "apps/v1", Kind: "Deployment", Namespace: "prod", ResourcePlural: "deployments", Status: StatusOK},
+			{APIVersion: "route.openshift.io/v1", Kind: "Route", Namespace: "prod", Status: StatusIncompatible, Reason: "API version route.openshift.io/v1 not available on target cluster"},
+		},
+		TotalScanned: 2,
+		Compatible:   1,
+		Incompatible: 1,
+	}
+
+	var buf bytes.Buffer
+	FormatTable(&buf, report)
+	output := buf.String()
+
+	expectedColumns := []string{"APIVERSION", "KIND", "NAMESPACE", "RESOURCE", "STATUS", "REASON", "SUGGESTION"}
+	for _, col := range expectedColumns {
+		if !strings.Contains(output, col) {
+			t.Errorf("table output missing column header %q", col)
+		}
+	}
+
+	if !strings.Contains(output, "apps/v1") {
+		t.Error("table output missing apps/v1")
+	}
+	if !strings.Contains(output, "route.openshift.io/v1") {
+		t.Error("table output missing route.openshift.io/v1")
+	}
+	if !strings.Contains(output, "OK") {
+		t.Error("table output missing OK status")
+	}
+	if !strings.Contains(output, "Incompatible") {
+		t.Error("table output missing Incompatible status")
+	}
+	if !strings.Contains(output, "2 scanned, 1 compatible, 1 incompatible") {
+		t.Errorf("table output missing summary line, got:\n%s", output)
+	}
+}
+
+func TestFormatTable_EmptyReport(t *testing.T) {
+	report := &ValidationReport{}
+	var buf bytes.Buffer
+	FormatTable(&buf, report)
+	output := buf.String()
+
+	if !strings.Contains(output, "0 scanned, 0 compatible, 0 incompatible") {
+		t.Errorf("empty report summary incorrect, got:\n%s", output)
+	}
+}
+
+func TestFormatJSON(t *testing.T) {
+	report := &ValidationReport{
+		Results: []ValidationResult{
+			{APIVersion: "v1", Kind: "ConfigMap", Namespace: "prod", ResourcePlural: "configmaps", Status: StatusOK},
+			{APIVersion: "route.openshift.io/v1", Kind: "Route", Namespace: "prod", Status: StatusIncompatible, Reason: "API version route.openshift.io/v1 not available on target cluster"},
+		},
+		TotalScanned: 2,
+		Compatible:   1,
+		Incompatible: 1,
+	}
+
+	var buf bytes.Buffer
+	if err := FormatJSON(&buf, report); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var decoded ValidationReport
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("JSON output is not valid: %v", err)
+	}
+	if decoded.TotalScanned != 2 {
+		t.Fatalf("TotalScanned = %d, want 2", decoded.TotalScanned)
+	}
+	if decoded.Compatible != 1 {
+		t.Fatalf("Compatible = %d, want 1", decoded.Compatible)
+	}
+	if decoded.Incompatible != 1 {
+		t.Fatalf("Incompatible = %d, want 1", decoded.Incompatible)
+	}
+	if len(decoded.Results) != 2 {
+		t.Fatalf("got %d results, want 2", len(decoded.Results))
+	}
+	if decoded.Results[0].Status != StatusOK {
+		t.Fatalf("result[0].Status = %s, want OK", decoded.Results[0].Status)
+	}
+	if decoded.Results[1].Status != StatusIncompatible {
+		t.Fatalf("result[1].Status = %s, want Incompatible", decoded.Results[1].Status)
+	}
+}
+
+func TestFormatJSON_RoundTrip(t *testing.T) {
+	original := &ValidationReport{
+		Results: []ValidationResult{
+			{APIVersion: "apps/v1", Kind: "Deployment", Namespace: "default", ResourcePlural: "deployments", Status: StatusOK},
+		},
+		TotalScanned: 1,
+		Compatible:   1,
+		Incompatible: 0,
+	}
+
+	var buf bytes.Buffer
+	if err := FormatJSON(&buf, original); err != nil {
+		t.Fatalf("FormatJSON: %v", err)
+	}
+
+	var decoded ValidationReport
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if decoded.TotalScanned != original.TotalScanned ||
+		decoded.Compatible != original.Compatible ||
+		decoded.Incompatible != original.Incompatible ||
+		len(decoded.Results) != len(original.Results) {
+		t.Fatalf("round-trip mismatch: got %+v, want %+v", decoded, *original)
+	}
+}

--- a/internal/validate/scanner.go
+++ b/internal/validate/scanner.go
@@ -55,16 +55,29 @@ func ScanManifests(opts ScanOptions, log logrus.FieldLogger) ([]ManifestEntry, e
 				return fmt.Errorf("read %s: %w", path, err)
 			}
 
-			documents := splitDocuments(data)
-			for docIdx, doc := range documents {
+			docDecoder := yaml.NewDocumentDecoder(io.NopCloser(bytes.NewReader(data)))
+			docIdx := 0
+			for {
+				buf := make([]byte, len(data)+256)
+				n, err := docDecoder.Read(buf)
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					log.Warnf("skipping unparseable document #%d in %s: %v", docIdx+1, path, err)
+					docIdx++
+					continue
+				}
+				doc := buf[:n]
+				docIdx++
 				if len(bytes.TrimSpace(doc)) == 0 {
 					continue
 				}
-				decoder := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(doc), len(doc)+256)
+				decoder := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(doc), n+256)
 				var meta manifestMeta
 				if err := decoder.Decode(&meta); err != nil {
 					if err != io.EOF {
-						log.Warnf("skipping unparseable document #%d in %s: %v", docIdx+1, path, err)
+						log.Warnf("skipping unparseable document #%d in %s: %v", docIdx, path, err)
 					}
 					continue
 				}
@@ -119,11 +132,3 @@ func ScanManifests(opts ScanOptions, log logrus.FieldLogger) ([]ManifestEntry, e
 	return entries, nil
 }
 
-var yamlDocSeparator = []byte("\n---")
-
-func splitDocuments(data []byte) [][]byte {
-	if bytes.HasPrefix(bytes.TrimLeftFunc(data, func(r rune) bool { return r == ' ' || r == '\t' || r == '\n' || r == '\r' }), []byte("{")) {
-		return [][]byte{data}
-	}
-	return bytes.Split(data, yamlDocSeparator)
-}

--- a/internal/validate/scanner.go
+++ b/internal/validate/scanner.go
@@ -55,15 +55,18 @@ func ScanManifests(opts ScanOptions, log logrus.FieldLogger) ([]ManifestEntry, e
 				return fmt.Errorf("read %s: %w", path, err)
 			}
 
-			decoder := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), 4096)
-			for {
+			documents := splitDocuments(data)
+			for docIdx, doc := range documents {
+				if len(bytes.TrimSpace(doc)) == 0 {
+					continue
+				}
+				decoder := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(doc), len(doc)+256)
 				var meta manifestMeta
 				if err := decoder.Decode(&meta); err != nil {
-					if err == io.EOF {
-						break
+					if err != io.EOF {
+						log.Warnf("skipping unparseable document #%d in %s: %v", docIdx+1, path, err)
 					}
-					log.Warnf("skipping unparseable document in %s: %v", path, err)
-					break
+					continue
 				}
 				if meta.APIVersion == "" || meta.Kind == "" {
 					continue
@@ -114,4 +117,13 @@ func ScanManifests(opts ScanOptions, log logrus.FieldLogger) ([]ManifestEntry, e
 	})
 
 	return entries, nil
+}
+
+var yamlDocSeparator = []byte("\n---")
+
+func splitDocuments(data []byte) [][]byte {
+	if bytes.HasPrefix(bytes.TrimLeftFunc(data, func(r rune) bool { return r == ' ' || r == '\t' || r == '\n' || r == '\r' }), []byte("{")) {
+		return [][]byte{data}
+	}
+	return bytes.Split(data, yamlDocSeparator)
 }

--- a/internal/validate/scanner.go
+++ b/internal/validate/scanner.go
@@ -1,0 +1,117 @@
+package validate
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+// ScanOptions configures which directories to scan for Kubernetes manifests.
+type ScanOptions struct {
+	Dirs []string
+}
+
+// manifestMeta holds the minimal fields we unmarshal from each YAML document.
+type manifestMeta struct {
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+	Metadata   struct {
+		Namespace string `json:"namespace"`
+	} `json:"metadata"`
+}
+
+// ScanManifests walks the given directories, parses YAML/JSON manifests
+// (including multi-document YAML), and returns deduplicated ManifestEntry
+// values sorted by group/version/kind/namespace.
+func ScanManifests(opts ScanOptions, log logrus.FieldLogger) ([]ManifestEntry, error) {
+	index := map[string]*ManifestEntry{}
+
+	for _, dir := range opts.Dirs {
+		if err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				if d.Name() == "failures" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			ext := strings.ToLower(filepath.Ext(path))
+			if ext != ".yaml" && ext != ".yml" && ext != ".json" {
+				return nil
+			}
+
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return fmt.Errorf("read %s: %w", path, err)
+			}
+
+			decoder := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), 4096)
+			for {
+				var meta manifestMeta
+				if err := decoder.Decode(&meta); err != nil {
+					if err == io.EOF {
+						break
+					}
+					log.Warnf("skipping unparseable document in %s: %v", path, err)
+					break
+				}
+				if meta.APIVersion == "" || meta.Kind == "" {
+					continue
+				}
+
+				gv, err := schema.ParseGroupVersion(meta.APIVersion)
+				if err != nil {
+					log.Warnf("skipping invalid apiVersion %q in %s: %v", meta.APIVersion, path, err)
+					continue
+				}
+
+				key := fmt.Sprintf("%s/%s/%s/%s", gv.Group, gv.Version, meta.Kind, meta.Metadata.Namespace)
+				if entry, ok := index[key]; ok {
+					entry.SourceFiles = append(entry.SourceFiles, path)
+				} else {
+					index[key] = &ManifestEntry{
+						APIVersion:  meta.APIVersion,
+						Kind:        meta.Kind,
+						Group:       gv.Group,
+						Version:     gv.Version,
+						Namespace:   meta.Metadata.Namespace,
+						SourceFiles: []string{path},
+					}
+				}
+			}
+			return nil
+		}); err != nil {
+			return nil, fmt.Errorf("walking %s: %w", dir, err)
+		}
+	}
+
+	entries := make([]ManifestEntry, 0, len(index))
+	for _, e := range index {
+		entries = append(entries, *e)
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		a, b := entries[i], entries[j]
+		if a.Group != b.Group {
+			return a.Group < b.Group
+		}
+		if a.Version != b.Version {
+			return a.Version < b.Version
+		}
+		if a.Kind != b.Kind {
+			return a.Kind < b.Kind
+		}
+		return a.Namespace < b.Namespace
+	})
+
+	return entries, nil
+}

--- a/internal/validate/scanner_test.go
+++ b/internal/validate/scanner_test.go
@@ -1,0 +1,244 @@
+package validate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func testLogger() *logrus.Logger {
+	l := logrus.New()
+	l.SetOutput(os.Stderr)
+	l.SetLevel(logrus.DebugLevel)
+	return l
+}
+
+func TestScanManifests_SingleDoc(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "deploy.yaml"), `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: prod
+`)
+	entries, err := ScanManifests(ScanOptions{Dirs: []string{dir}}, testLogger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(entries))
+	}
+	e := entries[0]
+	if e.Group != "apps" || e.Version != "v1" || e.Kind != "Deployment" || e.Namespace != "prod" {
+		t.Fatalf("unexpected entry: %+v", e)
+	}
+	if e.APIVersion != "apps/v1" {
+		t.Fatalf("APIVersion = %q, want %q", e.APIVersion, "apps/v1")
+	}
+}
+
+func TestScanManifests_MultiDoc(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "multi.yaml"), `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cfg
+  namespace: prod
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: s1
+  namespace: prod
+`)
+	entries, err := ScanManifests(ScanOptions{Dirs: []string{dir}}, testLogger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("got %d entries, want 2", len(entries))
+	}
+}
+
+func TestScanManifests_NestedDirs(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	if err := os.MkdirAll(sub, 0700); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(dir, "a.yaml"), `
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc
+  namespace: default
+`)
+	writeFile(t, filepath.Join(sub, "b.yaml"), `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+  namespace: default
+`)
+	entries, err := ScanManifests(ScanOptions{Dirs: []string{dir}}, testLogger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("got %d entries, want 2", len(entries))
+	}
+}
+
+func TestScanManifests_SkipsFailuresDir(t *testing.T) {
+	dir := t.TempDir()
+	failDir := filepath.Join(dir, "failures")
+	if err := os.MkdirAll(failDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(failDir, "bad.yaml"), `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: should-skip
+`)
+	writeFile(t, filepath.Join(dir, "good.yaml"), `
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc
+  namespace: default
+`)
+	entries, err := ScanManifests(ScanOptions{Dirs: []string{dir}}, testLogger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1 (failures should be skipped)", len(entries))
+	}
+}
+
+func TestScanManifests_NonYAMLIgnored(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "readme.txt"), "not yaml")
+	writeFile(t, filepath.Join(dir, "data.csv"), "a,b,c")
+	writeFile(t, filepath.Join(dir, "valid.yaml"), `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cfg
+`)
+	entries, err := ScanManifests(ScanOptions{Dirs: []string{dir}}, testLogger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(entries))
+	}
+}
+
+func TestScanManifests_Deduplication(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a.yaml"), `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cfg1
+  namespace: prod
+`)
+	writeFile(t, filepath.Join(dir, "b.yaml"), `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cfg2
+  namespace: prod
+`)
+	entries, err := ScanManifests(ScanOptions{Dirs: []string{dir}}, testLogger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1 (deduped by group/version/kind/namespace)", len(entries))
+	}
+	if len(entries[0].SourceFiles) != 2 {
+		t.Fatalf("got %d source files, want 2", len(entries[0].SourceFiles))
+	}
+}
+
+func TestScanManifests_CoreGroupParsing(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "pod.yaml"), `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: p
+  namespace: default
+`)
+	entries, err := ScanManifests(ScanOptions{Dirs: []string{dir}}, testLogger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(entries))
+	}
+	if entries[0].Group != "" {
+		t.Fatalf("Group = %q, want empty string for core API", entries[0].Group)
+	}
+	if entries[0].Version != "v1" {
+		t.Fatalf("Version = %q, want %q", entries[0].Version, "v1")
+	}
+}
+
+func TestScanManifests_NamedGroupParsing(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "deploy.yaml"), `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: default
+`)
+	entries, err := ScanManifests(ScanOptions{Dirs: []string{dir}}, testLogger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(entries))
+	}
+	if entries[0].Group != "apps" {
+		t.Fatalf("Group = %q, want %q", entries[0].Group, "apps")
+	}
+	if entries[0].Version != "v1" {
+		t.Fatalf("Version = %q, want %q", entries[0].Version, "v1")
+	}
+}
+
+func TestScanManifests_ClusterScoped(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "crb.yaml"), `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: my-binding
+`)
+	entries, err := ScanManifests(ScanOptions{Dirs: []string{dir}}, testLogger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(entries))
+	}
+	if entries[0].Namespace != "" {
+		t.Fatalf("Namespace = %q, want empty for cluster-scoped", entries[0].Namespace)
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/validate/types.go
+++ b/internal/validate/types.go
@@ -1,0 +1,58 @@
+package validate
+
+import "fmt"
+
+// ManifestEntry is one distinct apiVersion+kind+namespace tuple from scanned files.
+type ManifestEntry struct {
+	APIVersion  string
+	Kind        string
+	Group       string   // parsed from APIVersion (e.g. "apps" from "apps/v1")
+	Version     string   // parsed from APIVersion (e.g. "v1")
+	Namespace   string   // from metadata.namespace; empty for cluster-scoped
+	SourceFiles []string // which files contributed this entry
+}
+
+// ValidationStatus indicates whether a GVK is compatible with the target cluster.
+type ValidationStatus string
+
+const (
+	StatusOK           ValidationStatus = "OK"
+	StatusIncompatible ValidationStatus = "Incompatible"
+)
+
+// ValidationResult is one row in the final report.
+type ValidationResult struct {
+	APIVersion     string           `json:"apiVersion"`
+	Kind           string           `json:"kind"`
+	Namespace      string           `json:"namespace,omitempty"`
+	ResourcePlural string           `json:"resourcePlural,omitempty"`
+	Status         ValidationStatus `json:"status"`
+	Reason         string           `json:"reason,omitempty"`
+	Suggestion     string           `json:"suggestion,omitempty"`
+}
+
+// ValidationReport is the complete output.
+type ValidationReport struct {
+	Results      []ValidationResult `json:"results"`
+	TotalScanned int                `json:"totalScanned"`
+	Compatible   int                `json:"compatible"`
+	Incompatible int                `json:"incompatible"`
+}
+
+// HasIncompatible returns true if any resources are incompatible with the target.
+func (r *ValidationReport) HasIncompatible() bool { return r.Incompatible > 0 }
+
+// IncompatibleResults returns only the results with Incompatible status.
+func (r *ValidationReport) IncompatibleResults() []ValidationResult {
+	var out []ValidationResult
+	for _, res := range r.Results {
+		if res.Status == StatusIncompatible {
+			out = append(out, res)
+		}
+	}
+	return out
+}
+
+// ErrValidationFailed is returned when one or more validation checks fail,
+// giving CI/CD pipelines a non-zero exit code.
+var ErrValidationFailed = fmt.Errorf("validation failed: one or more resources are incompatible with the target cluster")

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	transfer_pvc "github.com/konveyor/crane/cmd/transfer-pvc"
 	"github.com/konveyor/crane/cmd/transform"
 	tunnel_api "github.com/konveyor/crane/cmd/tunnel-api"
+	"github.com/konveyor/crane/cmd/validate"
 	"github.com/konveyor/crane/cmd/version"
 	"github.com/konveyor/crane/internal/flags"
 	"github.com/spf13/cobra"
@@ -34,6 +35,7 @@ func main() {
 	root.AddCommand(plugin_manager.NewPluginManagerCommand(f))
 	root.AddCommand(version.NewVersionCommand(f))
 	root.AddCommand(runfn.NewFnRunCommand(f))
+	root.AddCommand(validate.NewValidateCommand(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}, f))
 	if err := root.Execute(); err != nil {
 		os.Exit(1)
 	}


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                
                                                                                                                                                                                                                            
  Adds `crane validate` — a post-apply compatibility check that verifies final rendered manifests against a target cluster's API surface. Catches incompatible apiVersions (e.g., `extensions/v1beta1` on a cluster that    
  only serves `apps/v1`) and suggests alternatives when available.                                                                                                                                                          
                                                                                                                                                                                                                            
  **Pipeline: export → transform → apply → validate**                                                                                                                                                                       
   
  ### What it does                                                                                                                                                                                                          
                                                                      
  - Scans `--input-dir` (defaults to `output/`, i.e. crane apply's output) for YAML/JSON manifests, with per-document resilience for multi-doc files, deduplicates by GVK+namespace                                         
  - Queries target cluster discovery (`ServerGroupsAndResources`) — only requires basic authentication, no special RBAC needed
  - Always prints a human-readable table to the terminal                                                                                                                                                                    
  - Persists a report file to `--validate-dir` in JSON (default) or YAML (`-o yaml`)                                                                                                                                        
  - Suggests alternative GroupVersions when available (e.g., "available as apps/v1")                                                                                                                                        
  - Writes per-resource `failures/*.yaml` (YAML-encoded) to `--validate-dir`                                                                                                                                                
  - Exits non-zero on incompatibility (CI/CD friendly)                                                                                                                                                                      
  - All artifact write errors are returned (not silently swallowed)   

  ### Files changed

  | File | |
  |------|--|
  | `main.go` | +2 lines: register validate subcommand |
  | `cmd/validate/validate.go` | Cobra command: flags, Complete/Validate/Run, PreRunE with full Viper error handling |                                                                                                      
  | `cmd/validate/validate_test.go` | Flag registration and validation tests |                                                                                                                                              
  | `internal/validate/types.go` | Data types: ManifestEntry, ValidationResult, ValidationReport |                                                                                                                          
  | `internal/validate/scanner.go` | Recursive dir walker + per-document multi-doc YAML parser + dedup |                                                                                                                    
  | `internal/validate/scanner_test.go` | 10 tests |                                                                                                                                                                        
  | `internal/validate/matcher.go` | Discovery index, GVK matching, suggestion engine |                                                                                                                                     
  | `internal/validate/matcher_test.go` | 8 tests |                                                                                                                                                                         
  | `internal/validate/report.go` | Table/JSON/YAML formatters + WriteFailures (YAML-encoded) to disk |
  | `internal/validate/report_test.go` | 4 tests |                                                                                                                                                                          
                                                                                                                                                                                                                            
  ### Demo
                                                                                                                                                                                                                            
  $ crane validate -i output/ --context target-cluster                

  Scanned 3 distinct GVK+namespace tuples
  APIVERSION              KIND        NAMESPACE  RESOURCE     STATUS        REASON                                                                                  SUGGESTION
  apps/v1                 Deployment  prod       deployments  OK                                                                                                                                                            
  extensions/v1beta1      Deployment  prod                    Incompatible  API version extensions/v1beta1 not available on target cluster (available as apps/v1)   available as apps/v1
  route.openshift.io/v1   Route       prod                    Incompatible  API version route.openshift.io/v1 not available on target cluster                                                                               
                                                                      
  Summary: 3 scanned, 1 compatible, 2 incompatible                                                                                                                                                                          
  Wrote validation report to validate/report.json                     
  Wrote 2 validation failure(s) to validate/failures                                                                                                                                                                        
  Error: validation failed: one or more resources are incompatible with the target cluster
                                                                                                                                                                                                                            
  Output on disk:                                                     
  validate/                                                                                                                                                                                                                 
  ├── report.json          # or report.yaml with -o yaml              
  └── failures/                                                                                                                                                                                                             
      ├── Deployment_extensions_v1beta1_prod.yaml                     
      └── Route_route.openshift.io_v1_prod.yaml                                                                                                                                                                             
   
  ## Test plan                                                                                                                                                                                                              
                                                                      
  - [x] `go build ./...`                                                                                                                                                                                                    
  - [x] `go test ./cmd/validate/ ./internal/validate/...` — 22 unit tests pass
  - [x] Verified on minikube: compatible resources → exit 0; `extensions/v1beta1` + `route.openshift.io/v1` → exit 1 with suggestions                                                                                       
  - [x] Validate reads from apply's output directory (`--input-dir`, default `output/`)                                                                                                                                     
  - [x] Report file format controlled by `-o json` (default) or `-o yaml`                                                                                                                                                   
  - [x] Failure files are YAML-encoded matching their `.yaml` extension                                                                                                                                                     
  - [x] Only requires basic cluster authentication (discovery API) — no special RBAC needed                                                                                                                                 
                                                                                                                                                                                                                            
  Tested on source and target minikube in local env, with around 20 e2e test cases.              

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `validate` command to validate Kubernetes manifests against a target cluster
  * Generates comprehensive compatibility reports in JSON or YAML format
  * Identifies incompatible resources with detailed failure information written to disk
  * Displays validation results in a human-readable table with summary statistics
  * Supports validation across multiple input directories with automatic deduplication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->