### PR TITLE
Added support for offline validation without a live cluster availability

### DIFF
--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -19,15 +19,20 @@ type ValidateOptions struct {
 	cobraGlobalFlags *flags.GlobalFlags
 	globalFlags      *flags.GlobalFlags
 
-	inputDir     string
-	validateDir  string
-	outputFormat string
+	inputDir         string
+	validateDir      string
+	outputFormat     string
+	apiResourcesFile string
 
 	genericclioptions.IOStreams
 }
 
 // Complete loads the kubeconfig to ensure the target cluster is reachable.
+// Skipped in offline mode (--api-resources).
 func (o *ValidateOptions) Complete(c *cobra.Command, args []string) error {
+	if o.apiResourcesFile != "" {
+		return nil
+	}
 	_, err := o.configFlags.ToRawKubeConfigLoader().RawConfig()
 	if err != nil {
 		return fmt.Errorf("loading kubeconfig for target cluster: %w", err)
@@ -49,6 +54,18 @@ func (o *ValidateOptions) Validate() error {
 		return fmt.Errorf("--output must be \"yaml\" or \"json\", got %q", o.outputFormat)
 	}
 
+	if o.apiResourcesFile != "" {
+		if o.configFlags.Context != nil && *o.configFlags.Context != "" {
+			return fmt.Errorf("--api-resources and --context are mutually exclusive; use --api-resources for offline validation or --context for live validation")
+		}
+		if o.configFlags.KubeConfig != nil && *o.configFlags.KubeConfig != "" {
+			return fmt.Errorf("--api-resources and --kubeconfig are mutually exclusive; use --api-resources for offline validation or --kubeconfig for live validation")
+		}
+		if _, err := os.Stat(o.apiResourcesFile); err != nil {
+			return fmt.Errorf("api-resources file %q: %w", o.apiResourcesFile, err)
+		}
+	}
+
 	return nil
 }
 
@@ -63,15 +80,31 @@ func (o *ValidateOptions) Run() error {
 
 	log.Infof("Scanned %d distinct GVK+namespace tuples", len(entries))
 
-	discoveryClient, err := o.configFlags.ToDiscoveryClient()
-	if err != nil {
-		return fmt.Errorf("creating discovery client: %w", err)
-	}
-	discoveryClient.Invalidate()
+	var report *internalValidate.ValidationReport
 
-	report, err := internalValidate.MatchResults(entries, internalValidate.MatchOptions{DiscoveryClient: discoveryClient}, log)
-	if err != nil {
-		return fmt.Errorf("matching against target cluster: %w", err)
+	if o.apiResourcesFile != "" {
+		index, err := internalValidate.ParseAPIResourcesJSON(o.apiResourcesFile)
+		if err != nil {
+			return fmt.Errorf("loading api-resources: %w", err)
+		}
+		report = internalValidate.MatchResultsFromIndex(entries, index)
+		report.Mode = "offline"
+		report.APIResourcesSource = o.apiResourcesFile
+	} else {
+		discoveryClient, err := o.configFlags.ToDiscoveryClient()
+		if err != nil {
+			return fmt.Errorf("creating discovery client: %w", err)
+		}
+		discoveryClient.Invalidate()
+
+		report, err = internalValidate.MatchResults(entries, internalValidate.MatchOptions{DiscoveryClient: discoveryClient}, log)
+		if err != nil {
+			return fmt.Errorf("matching against target cluster: %w", err)
+		}
+		report.Mode = "live"
+		if o.configFlags.Context != nil && *o.configFlags.Context != "" {
+			report.ClusterContext = *o.configFlags.Context
+		}
 	}
 
 	internalValidate.FormatTable(o.Out, report)
@@ -129,6 +162,10 @@ GVK matching).
 
 Pipeline: export → transform → apply → validate
 
+Use --api-resources to validate offline against the JSON output of
+'kubectl api-resources -o json' when the target cluster is not directly
+reachable. Otherwise, supply kubeconfig/context flags for live validation.
+
 Incompatible resources are written to a failures/ directory under
 the validate-dir for auditability.
 
@@ -158,6 +195,7 @@ failed (or another error occurred).`,
 	cmd.Flags().StringVarP(&o.inputDir, "input-dir", "i", "output", "The path to the apply output directory containing final manifests")
 	cmd.Flags().StringVar(&o.validateDir, "validate-dir", "validate", "The path where validation results and failures are saved")
 	cmd.Flags().StringVarP(&o.outputFormat, "output", "o", "json", "Report file format: json or yaml")
+	cmd.Flags().StringVar(&o.apiResourcesFile, "api-resources", "", "Path to kubectl api-resources -o json output for offline validation (mutually exclusive with --context/--kubeconfig)")
 	o.configFlags.AddFlags(cmd.Flags())
 
 	return cmd

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -162,9 +162,10 @@ GVK matching).
 
 Pipeline: export → transform → apply → validate
 
-Use --api-resources to validate offline against the JSON output of
-'kubectl api-resources -o json' when the target cluster is not directly
-reachable. Otherwise, supply kubeconfig/context flags for live validation.
+Use --api-resources to validate offline against a captured API surface
+JSON file (produced by scripts/capture-api-surface.sh) when the target
+cluster is not directly reachable. Otherwise, supply kubeconfig/context
+flags for live validation.
 
 Incompatible resources are written to a failures/ directory under
 the validate-dir for auditability.
@@ -195,7 +196,7 @@ failed (or another error occurred).`,
 	cmd.Flags().StringVarP(&o.inputDir, "input-dir", "i", "output", "The path to the apply output directory containing final manifests")
 	cmd.Flags().StringVar(&o.validateDir, "validate-dir", "validate", "The path where validation results and failures are saved")
 	cmd.Flags().StringVarP(&o.outputFormat, "output", "o", "json", "Report file format: json or yaml")
-	cmd.Flags().StringVar(&o.apiResourcesFile, "api-resources", "", "Path to kubectl api-resources -o json output for offline validation (mutually exclusive with --context/--kubeconfig)")
+	cmd.Flags().StringVar(&o.apiResourcesFile, "api-resources", "", "Path to API surface JSON file from capture-api-surface.sh for offline validation (mutually exclusive with --context/--kubeconfig)")
 	o.configFlags.AddFlags(cmd.Flags())
 
 	return cmd

--- a/cmd/validate/validate_test.go
+++ b/cmd/validate/validate_test.go
@@ -17,7 +17,7 @@ func TestNewValidateCommand(t *testing.T) {
 		t.Fatalf("Use = %q, want %q", cmd.Use, "validate")
 	}
 
-	expectedFlags := []string{"input-dir", "validate-dir", "output"}
+	expectedFlags := []string{"input-dir", "validate-dir", "output", "api-resources"}
 	for _, name := range expectedFlags {
 		if cmd.Flags().Lookup(name) == nil {
 			t.Errorf("flag %q not registered on validate command", name)
@@ -32,6 +32,9 @@ func TestNewValidateCommand(t *testing.T) {
 	}
 	if d := cmd.Flags().Lookup("validate-dir").DefValue; d != "validate" {
 		t.Errorf("validate-dir default = %q, want %q", d, "validate")
+	}
+	if d := cmd.Flags().Lookup("api-resources").DefValue; d != "" {
+		t.Errorf("api-resources default = %q, want empty", d)
 	}
 }
 
@@ -97,6 +100,78 @@ func TestValidate_Flags(t *testing.T) {
 				return &ValidateOptions{
 					inputDir:    t.TempDir(),
 					outputFormat: "json",
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "api-resources file not found",
+			setup: func(t *testing.T) *ValidateOptions {
+				return &ValidateOptions{
+					configFlags:      genericclioptions.NewConfigFlags(true),
+					inputDir:         t.TempDir(),
+					outputFormat:     "json",
+					apiResourcesFile: "/nonexistent/api-resources.json",
+				}
+			},
+			wantErr:  true,
+			errMatch: "api-resources file",
+		},
+		{
+			name: "api-resources with context is mutually exclusive",
+			setup: func(t *testing.T) *ValidateOptions {
+				dir := t.TempDir()
+				f := filepath.Join(dir, "api-resources.json")
+				if err := os.WriteFile(f, []byte(`{}`), 0600); err != nil {
+					t.Fatal(err)
+				}
+				ctx := "some-context"
+				cf := genericclioptions.NewConfigFlags(true)
+				cf.Context = &ctx
+				return &ValidateOptions{
+					configFlags:      cf,
+					inputDir:         dir,
+					outputFormat:     "json",
+					apiResourcesFile: f,
+				}
+			},
+			wantErr:  true,
+			errMatch: "mutually exclusive",
+		},
+		{
+			name: "api-resources with kubeconfig is mutually exclusive",
+			setup: func(t *testing.T) *ValidateOptions {
+				dir := t.TempDir()
+				f := filepath.Join(dir, "api-resources.json")
+				if err := os.WriteFile(f, []byte(`{}`), 0600); err != nil {
+					t.Fatal(err)
+				}
+				kc := "/some/kubeconfig"
+				cf := genericclioptions.NewConfigFlags(true)
+				cf.KubeConfig = &kc
+				return &ValidateOptions{
+					configFlags:      cf,
+					inputDir:         dir,
+					outputFormat:     "json",
+					apiResourcesFile: f,
+				}
+			},
+			wantErr:  true,
+			errMatch: "mutually exclusive",
+		},
+		{
+			name: "api-resources valid file accepted",
+			setup: func(t *testing.T) *ValidateOptions {
+				dir := t.TempDir()
+				f := filepath.Join(dir, "api-resources.json")
+				if err := os.WriteFile(f, []byte(`{}`), 0600); err != nil {
+					t.Fatal(err)
+				}
+				return &ValidateOptions{
+					configFlags:      genericclioptions.NewConfigFlags(true),
+					inputDir:         dir,
+					outputFormat:     "json",
+					apiResourcesFile: f,
 				}
 			},
 			wantErr: false,

--- a/internal/validate/api_resources.go
+++ b/internal/validate/api_resources.go
@@ -1,0 +1,65 @@
+package validate
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// apiResourceListJSON matches the JSON structure of `kubectl api-resources -o json`.
+type apiResourceListJSON struct {
+	Kind       string                 `json:"kind"`
+	APIVersion string                 `json:"apiVersion"`
+	Resources  []apiResourceEntryJSON `json:"resources"`
+}
+
+// apiResourceEntryJSON is one resource entry in the kubectl JSON output.
+// Group and version are separate fields; core resources omit group.
+type apiResourceEntryJSON struct {
+	Name       string   `json:"name"`
+	Namespaced bool     `json:"namespaced"`
+	Group      string   `json:"group,omitempty"`
+	Version    string   `json:"version"`
+	Kind       string   `json:"kind"`
+	Verbs      []string `json:"verbs,omitempty"`
+}
+
+// ParseAPIResourcesJSON reads the JSON output of `kubectl api-resources -o json`
+// and builds a DiscoveryIndex suitable for offline validation.
+func ParseAPIResourcesJSON(path string) (DiscoveryIndex, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading api-resources file %q: %w", path, err)
+	}
+
+	var resourceList apiResourceListJSON
+	if err := json.Unmarshal(data, &resourceList); err != nil {
+		return nil, fmt.Errorf("parsing api-resources JSON from %q: %w", path, err)
+	}
+
+	if len(resourceList.Resources) == 0 {
+		return nil, fmt.Errorf("api-resources file %q contains no resources", path)
+	}
+
+	index := DiscoveryIndex{}
+	for _, res := range resourceList.Resources {
+		gv := res.Version
+		if res.Group != "" {
+			gv = res.Group + "/" + res.Version
+		}
+
+		if _, ok := index[gv]; !ok {
+			index[gv] = map[string]discoveryEntry{}
+		}
+		index[gv][res.Kind] = discoveryEntry{
+			Resource: metav1.APIResource{
+				Name:       res.Name,
+				Kind:       res.Kind,
+				Namespaced: res.Namespaced,
+			},
+		}
+	}
+	return index, nil
+}

--- a/internal/validate/api_resources.go
+++ b/internal/validate/api_resources.go
@@ -9,61 +9,52 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// apiResourceListJSON matches the JSON structure of `kubectl api-resources -o json`.
-type apiResourceListJSON struct {
-	Kind       string                 `json:"kind"`
-	APIVersion string                 `json:"apiVersion"`
-	Resources  []apiResourceEntryJSON `json:"resources"`
+// apiSurfaceJSON is the wrapper format produced by the capture-api-surface.sh script.
+// It contains an array of native Kubernetes APIResourceList objects, one per
+// served group-version — the same data ServerGroupsAndResources() returns.
+type apiSurfaceJSON struct {
+	APIResourceLists []metav1.APIResourceList `json:"apiResourceLists"`
 }
 
-// apiResourceEntryJSON is one resource entry in the kubectl JSON output.
-// Group and version are separate fields; core resources omit group.
-type apiResourceEntryJSON struct {
-	Name       string   `json:"name"`
-	Namespaced bool     `json:"namespaced"`
-	Group      string   `json:"group,omitempty"`
-	Version    string   `json:"version"`
-	Kind       string   `json:"kind"`
-	Verbs      []string `json:"verbs,omitempty"`
-}
-
-// ParseAPIResourcesJSON reads the JSON output of `kubectl api-resources -o json`
+// ParseAPIResourcesJSON reads the JSON output of capture-api-surface.sh
 // and builds a DiscoveryIndex suitable for offline validation.
+// The file format is: {"apiResourceLists": [ <APIResourceList>, ... ]}
+// where each APIResourceList has a groupVersion field and a resources array.
 func ParseAPIResourcesJSON(path string) (DiscoveryIndex, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading api-resources file %q: %w", path, err)
 	}
 
-	var resourceList apiResourceListJSON
-	if err := json.Unmarshal(data, &resourceList); err != nil {
+	var surface apiSurfaceJSON
+	if err := json.Unmarshal(data, &surface); err != nil {
 		return nil, fmt.Errorf("parsing api-resources JSON from %q: %w", path, err)
 	}
 
-	if len(resourceList.Resources) == 0 {
-		return nil, fmt.Errorf("api-resources file %q contains no resources", path)
+	if len(surface.APIResourceLists) == 0 {
+		return nil, fmt.Errorf("api-resources file %q contains no API resource lists", path)
 	}
 
 	index := DiscoveryIndex{}
-	for _, res := range resourceList.Resources {
-		if strings.Contains(res.Name, "/") {
+	for _, list := range surface.APIResourceLists {
+		gv := list.GroupVersion
+		if gv == "" {
 			continue
 		}
-		gv := res.Version
-		if res.Group != "" {
-			gv = res.Group + "/" + res.Version
-		}
-
 		if _, ok := index[gv]; !ok {
 			index[gv] = map[string]discoveryEntry{}
 		}
-		index[gv][res.Kind] = discoveryEntry{
-			Resource: metav1.APIResource{
-				Name:       res.Name,
-				Kind:       res.Kind,
-				Namespaced: res.Namespaced,
-			},
+		for _, res := range list.APIResources {
+			if strings.Contains(res.Name, "/") {
+				continue
+			}
+			index[gv][res.Kind] = discoveryEntry{Resource: res}
 		}
 	}
+
+	if len(index) == 0 {
+		return nil, fmt.Errorf("api-resources file %q contains no usable resources", path)
+	}
+
 	return index, nil
 }

--- a/internal/validate/api_resources.go
+++ b/internal/validate/api_resources.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -45,6 +46,9 @@ func ParseAPIResourcesJSON(path string) (DiscoveryIndex, error) {
 
 	index := DiscoveryIndex{}
 	for _, res := range resourceList.Resources {
+		if strings.Contains(res.Name, "/") {
+			continue
+		}
 		gv := res.Version
 		if res.Group != "" {
 			gv = res.Group + "/" + res.Version

--- a/internal/validate/api_resources_test.go
+++ b/internal/validate/api_resources_test.go
@@ -1,0 +1,269 @@
+package validate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseAPIResourcesJSON_Valid(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "api-resources.json")
+	writeFile(t, path, `{
+  "kind": "APIResourceList",
+  "apiVersion": "v1",
+  "resources": [
+    {
+      "name": "deployments",
+      "namespaced": true,
+      "group": "apps",
+      "version": "v1",
+      "kind": "Deployment"
+    },
+    {
+      "name": "services",
+      "namespaced": true,
+      "version": "v1",
+      "kind": "Service"
+    },
+    {
+      "name": "namespaces",
+      "namespaced": false,
+      "version": "v1",
+      "kind": "Namespace"
+    }
+  ]
+}`)
+
+	index, err := ParseAPIResourcesJSON(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// apps/v1 should have Deployment
+	if kinds, ok := index["apps/v1"]; !ok {
+		t.Fatal("expected apps/v1 in index")
+	} else if _, ok := kinds["Deployment"]; !ok {
+		t.Fatal("expected Deployment in apps/v1")
+	}
+
+	// v1 should have Service and Namespace
+	if kinds, ok := index["v1"]; !ok {
+		t.Fatal("expected v1 in index")
+	} else {
+		if _, ok := kinds["Service"]; !ok {
+			t.Fatal("expected Service in v1")
+		}
+		if _, ok := kinds["Namespace"]; !ok {
+			t.Fatal("expected Namespace in v1")
+		}
+	}
+}
+
+func TestParseAPIResourcesJSON_CoreResources(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "api-resources.json")
+	writeFile(t, path, `{
+  "kind": "APIResourceList",
+  "apiVersion": "v1",
+  "resources": [
+    {
+      "name": "pods",
+      "namespaced": true,
+      "version": "v1",
+      "kind": "Pod"
+    }
+  ]
+}`)
+
+	index, err := ParseAPIResourcesJSON(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Core resources have no group, so groupVersion = "v1"
+	if _, ok := index["v1"]["Pod"]; !ok {
+		t.Fatal("expected Pod under groupVersion v1 (core resource)")
+	}
+}
+
+func TestParseAPIResourcesJSON_NonCoreResources(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "api-resources.json")
+	writeFile(t, path, `{
+  "kind": "APIResourceList",
+  "apiVersion": "v1",
+  "resources": [
+    {
+      "name": "routes",
+      "namespaced": true,
+      "group": "route.openshift.io",
+      "version": "v1",
+      "kind": "Route"
+    }
+  ]
+}`)
+
+	index, err := ParseAPIResourcesJSON(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := index["route.openshift.io/v1"]["Route"]; !ok {
+		t.Fatal("expected Route under groupVersion route.openshift.io/v1")
+	}
+}
+
+func TestParseAPIResourcesJSON_ResourcePlural(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "api-resources.json")
+	writeFile(t, path, `{
+  "kind": "APIResourceList",
+  "apiVersion": "v1",
+  "resources": [
+    {
+      "name": "deployments",
+      "namespaced": true,
+      "group": "apps",
+      "version": "v1",
+      "kind": "Deployment"
+    }
+  ]
+}`)
+
+	index, err := ParseAPIResourcesJSON(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	de := index["apps/v1"]["Deployment"]
+	if de.Resource.Name != "deployments" {
+		t.Fatalf("Resource.Name = %q, want %q", de.Resource.Name, "deployments")
+	}
+	if !de.Resource.Namespaced {
+		t.Fatal("expected Deployment to be namespaced")
+	}
+}
+
+func TestParseAPIResourcesJSON_EmptyResources(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "api-resources.json")
+	writeFile(t, path, `{
+  "kind": "APIResourceList",
+  "apiVersion": "v1",
+  "resources": []
+}`)
+
+	_, err := ParseAPIResourcesJSON(path)
+	if err == nil {
+		t.Fatal("expected error for empty resources, got nil")
+	}
+}
+
+func TestParseAPIResourcesJSON_MalformedJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "api-resources.json")
+	writeFile(t, path, `{not valid json`)
+
+	_, err := ParseAPIResourcesJSON(path)
+	if err == nil {
+		t.Fatal("expected error for malformed JSON, got nil")
+	}
+}
+
+func TestParseAPIResourcesJSON_FileNotFound(t *testing.T) {
+	_, err := ParseAPIResourcesJSON("/nonexistent/file.json")
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}
+
+func TestParseAPIResourcesJSON_DuplicateKindAcrossGroups(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "api-resources.json")
+	// Event exists in both v1 and events.k8s.io/v1
+	writeFile(t, path, `{
+  "kind": "APIResourceList",
+  "apiVersion": "v1",
+  "resources": [
+    {
+      "name": "events",
+      "namespaced": true,
+      "version": "v1",
+      "kind": "Event"
+    },
+    {
+      "name": "events",
+      "namespaced": true,
+      "group": "events.k8s.io",
+      "version": "v1",
+      "kind": "Event"
+    }
+  ]
+}`)
+
+	index, err := ParseAPIResourcesJSON(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := index["v1"]["Event"]; !ok {
+		t.Fatal("expected Event in v1")
+	}
+	if _, ok := index["events.k8s.io/v1"]["Event"]; !ok {
+		t.Fatal("expected Event in events.k8s.io/v1")
+	}
+}
+
+func TestParseAPIResourcesJSON_VerifyNamespaced(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "api-resources.json")
+	writeFile(t, path, `{
+  "kind": "APIResourceList",
+  "apiVersion": "v1",
+  "resources": [
+    {
+      "name": "namespaces",
+      "namespaced": false,
+      "version": "v1",
+      "kind": "Namespace"
+    },
+    {
+      "name": "pods",
+      "namespaced": true,
+      "version": "v1",
+      "kind": "Pod"
+    }
+  ]
+}`)
+
+	index, err := ParseAPIResourcesJSON(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if index["v1"]["Namespace"].Resource.Namespaced {
+		t.Fatal("expected Namespace to be cluster-scoped (namespaced=false)")
+	}
+	if !index["v1"]["Pod"].Resource.Namespaced {
+		t.Fatal("expected Pod to be namespaced (namespaced=true)")
+	}
+}
+
+func writeAPIResourcesFile(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "api-resources.json")
+	content := `{
+  "kind": "APIResourceList",
+  "apiVersion": "v1",
+  "resources": [
+    {"name": "deployments", "namespaced": true, "group": "apps", "version": "v1", "kind": "Deployment"},
+    {"name": "services", "namespaced": true, "version": "v1", "kind": "Service"},
+    {"name": "configmaps", "namespaced": true, "version": "v1", "kind": "ConfigMap"}
+  ]
+}`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/internal/validate/api_resources_test.go
+++ b/internal/validate/api_resources_test.go
@@ -1,7 +1,6 @@
 package validate
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 )
@@ -250,20 +249,3 @@ func TestParseAPIResourcesJSON_VerifyNamespaced(t *testing.T) {
 	}
 }
 
-func writeAPIResourcesFile(t *testing.T, dir string) string {
-	t.Helper()
-	path := filepath.Join(dir, "api-resources.json")
-	content := `{
-  "kind": "APIResourceList",
-  "apiVersion": "v1",
-  "resources": [
-    {"name": "deployments", "namespaced": true, "group": "apps", "version": "v1", "kind": "Deployment"},
-    {"name": "services", "namespaced": true, "version": "v1", "kind": "Service"},
-    {"name": "configmaps", "namespaced": true, "version": "v1", "kind": "ConfigMap"}
-  ]
-}`
-	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
-		t.Fatal(err)
-	}
-	return path
-}

--- a/internal/validate/api_resources_test.go
+++ b/internal/validate/api_resources_test.go
@@ -7,29 +7,25 @@ import (
 
 func TestParseAPIResourcesJSON_Valid(t *testing.T) {
 	dir := t.TempDir()
-	path := filepath.Join(dir, "api-resources.json")
+	path := filepath.Join(dir, "api-surface.json")
 	writeFile(t, path, `{
-  "kind": "APIResourceList",
-  "apiVersion": "v1",
-  "resources": [
+  "apiResourceLists": [
     {
-      "name": "deployments",
-      "namespaced": true,
-      "group": "apps",
-      "version": "v1",
-      "kind": "Deployment"
+      "kind": "APIResourceList",
+      "apiVersion": "v1",
+      "groupVersion": "apps/v1",
+      "resources": [
+        {"name": "deployments", "namespaced": true, "kind": "Deployment", "verbs": ["get","list"]}
+      ]
     },
     {
-      "name": "services",
-      "namespaced": true,
-      "version": "v1",
-      "kind": "Service"
-    },
-    {
-      "name": "namespaces",
-      "namespaced": false,
-      "version": "v1",
-      "kind": "Namespace"
+      "kind": "APIResourceList",
+      "apiVersion": "v1",
+      "groupVersion": "v1",
+      "resources": [
+        {"name": "services", "namespaced": true, "kind": "Service", "verbs": ["get","list"]},
+        {"name": "namespaces", "namespaced": false, "kind": "Namespace", "verbs": ["get","list"]}
+      ]
     }
   ]
 }`)
@@ -39,14 +35,12 @@ func TestParseAPIResourcesJSON_Valid(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// apps/v1 should have Deployment
 	if kinds, ok := index["apps/v1"]; !ok {
 		t.Fatal("expected apps/v1 in index")
 	} else if _, ok := kinds["Deployment"]; !ok {
 		t.Fatal("expected Deployment in apps/v1")
 	}
 
-	// v1 should have Service and Namespace
 	if kinds, ok := index["v1"]; !ok {
 		t.Fatal("expected v1 in index")
 	} else {
@@ -61,16 +55,16 @@ func TestParseAPIResourcesJSON_Valid(t *testing.T) {
 
 func TestParseAPIResourcesJSON_CoreResources(t *testing.T) {
 	dir := t.TempDir()
-	path := filepath.Join(dir, "api-resources.json")
+	path := filepath.Join(dir, "api-surface.json")
 	writeFile(t, path, `{
-  "kind": "APIResourceList",
-  "apiVersion": "v1",
-  "resources": [
+  "apiResourceLists": [
     {
-      "name": "pods",
-      "namespaced": true,
-      "version": "v1",
-      "kind": "Pod"
+      "kind": "APIResourceList",
+      "apiVersion": "v1",
+      "groupVersion": "v1",
+      "resources": [
+        {"name": "pods", "namespaced": true, "kind": "Pod", "verbs": ["get","list"]}
+      ]
     }
   ]
 }`)
@@ -80,7 +74,6 @@ func TestParseAPIResourcesJSON_CoreResources(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Core resources have no group, so groupVersion = "v1"
 	if _, ok := index["v1"]["Pod"]; !ok {
 		t.Fatal("expected Pod under groupVersion v1 (core resource)")
 	}
@@ -88,17 +81,16 @@ func TestParseAPIResourcesJSON_CoreResources(t *testing.T) {
 
 func TestParseAPIResourcesJSON_NonCoreResources(t *testing.T) {
 	dir := t.TempDir()
-	path := filepath.Join(dir, "api-resources.json")
+	path := filepath.Join(dir, "api-surface.json")
 	writeFile(t, path, `{
-  "kind": "APIResourceList",
-  "apiVersion": "v1",
-  "resources": [
+  "apiResourceLists": [
     {
-      "name": "routes",
-      "namespaced": true,
-      "group": "route.openshift.io",
-      "version": "v1",
-      "kind": "Route"
+      "kind": "APIResourceList",
+      "apiVersion": "v1",
+      "groupVersion": "route.openshift.io/v1",
+      "resources": [
+        {"name": "routes", "namespaced": true, "kind": "Route", "verbs": ["get","list"]}
+      ]
     }
   ]
 }`)
@@ -115,17 +107,16 @@ func TestParseAPIResourcesJSON_NonCoreResources(t *testing.T) {
 
 func TestParseAPIResourcesJSON_ResourcePlural(t *testing.T) {
 	dir := t.TempDir()
-	path := filepath.Join(dir, "api-resources.json")
+	path := filepath.Join(dir, "api-surface.json")
 	writeFile(t, path, `{
-  "kind": "APIResourceList",
-  "apiVersion": "v1",
-  "resources": [
+  "apiResourceLists": [
     {
-      "name": "deployments",
-      "namespaced": true,
-      "group": "apps",
-      "version": "v1",
-      "kind": "Deployment"
+      "kind": "APIResourceList",
+      "apiVersion": "v1",
+      "groupVersion": "apps/v1",
+      "resources": [
+        {"name": "deployments", "namespaced": true, "kind": "Deployment", "verbs": ["get","list"]}
+      ]
     }
   ]
 }`)
@@ -146,22 +137,18 @@ func TestParseAPIResourcesJSON_ResourcePlural(t *testing.T) {
 
 func TestParseAPIResourcesJSON_EmptyResources(t *testing.T) {
 	dir := t.TempDir()
-	path := filepath.Join(dir, "api-resources.json")
-	writeFile(t, path, `{
-  "kind": "APIResourceList",
-  "apiVersion": "v1",
-  "resources": []
-}`)
+	path := filepath.Join(dir, "api-surface.json")
+	writeFile(t, path, `{"apiResourceLists": []}`)
 
 	_, err := ParseAPIResourcesJSON(path)
 	if err == nil {
-		t.Fatal("expected error for empty resources, got nil")
+		t.Fatal("expected error for empty api resource lists, got nil")
 	}
 }
 
 func TestParseAPIResourcesJSON_MalformedJSON(t *testing.T) {
 	dir := t.TempDir()
-	path := filepath.Join(dir, "api-resources.json")
+	path := filepath.Join(dir, "api-surface.json")
 	writeFile(t, path, `{not valid json`)
 
 	_, err := ParseAPIResourcesJSON(path)
@@ -179,24 +166,24 @@ func TestParseAPIResourcesJSON_FileNotFound(t *testing.T) {
 
 func TestParseAPIResourcesJSON_DuplicateKindAcrossGroups(t *testing.T) {
 	dir := t.TempDir()
-	path := filepath.Join(dir, "api-resources.json")
-	// Event exists in both v1 and events.k8s.io/v1
+	path := filepath.Join(dir, "api-surface.json")
 	writeFile(t, path, `{
-  "kind": "APIResourceList",
-  "apiVersion": "v1",
-  "resources": [
+  "apiResourceLists": [
     {
-      "name": "events",
-      "namespaced": true,
-      "version": "v1",
-      "kind": "Event"
+      "kind": "APIResourceList",
+      "apiVersion": "v1",
+      "groupVersion": "v1",
+      "resources": [
+        {"name": "events", "namespaced": true, "kind": "Event", "verbs": ["get","list"]}
+      ]
     },
     {
-      "name": "events",
-      "namespaced": true,
-      "group": "events.k8s.io",
-      "version": "v1",
-      "kind": "Event"
+      "kind": "APIResourceList",
+      "apiVersion": "v1",
+      "groupVersion": "events.k8s.io/v1",
+      "resources": [
+        {"name": "events", "namespaced": true, "kind": "Event", "verbs": ["get","list"]}
+      ]
     }
   ]
 }`)
@@ -216,22 +203,17 @@ func TestParseAPIResourcesJSON_DuplicateKindAcrossGroups(t *testing.T) {
 
 func TestParseAPIResourcesJSON_VerifyNamespaced(t *testing.T) {
 	dir := t.TempDir()
-	path := filepath.Join(dir, "api-resources.json")
+	path := filepath.Join(dir, "api-surface.json")
 	writeFile(t, path, `{
-  "kind": "APIResourceList",
-  "apiVersion": "v1",
-  "resources": [
+  "apiResourceLists": [
     {
-      "name": "namespaces",
-      "namespaced": false,
-      "version": "v1",
-      "kind": "Namespace"
-    },
-    {
-      "name": "pods",
-      "namespaced": true,
-      "version": "v1",
-      "kind": "Pod"
+      "kind": "APIResourceList",
+      "apiVersion": "v1",
+      "groupVersion": "v1",
+      "resources": [
+        {"name": "namespaces", "namespaced": false, "kind": "Namespace", "verbs": ["get","list"]},
+        {"name": "pods", "namespaced": true, "kind": "Pod", "verbs": ["get","list"]}
+      ]
     }
   ]
 }`)
@@ -249,3 +231,33 @@ func TestParseAPIResourcesJSON_VerifyNamespaced(t *testing.T) {
 	}
 }
 
+func TestParseAPIResourcesJSON_SubresourcesFiltered(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "api-surface.json")
+	writeFile(t, path, `{
+  "apiResourceLists": [
+    {
+      "kind": "APIResourceList",
+      "apiVersion": "v1",
+      "groupVersion": "apps/v1",
+      "resources": [
+        {"name": "deployments", "namespaced": true, "kind": "Deployment", "verbs": ["get","list"]},
+        {"name": "deployments/status", "namespaced": true, "kind": "Deployment", "verbs": ["get","patch"]},
+        {"name": "deployments/scale", "namespaced": true, "kind": "Scale", "verbs": ["get","patch"]}
+      ]
+    }
+  ]
+}`)
+
+	index, err := ParseAPIResourcesJSON(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := index["apps/v1"]["Deployment"]; !ok {
+		t.Fatal("expected Deployment in apps/v1")
+	}
+	if len(index["apps/v1"]) != 1 {
+		t.Fatalf("expected 1 resource in apps/v1 (subresources filtered), got %d", len(index["apps/v1"]))
+	}
+}

--- a/internal/validate/matcher.go
+++ b/internal/validate/matcher.go
@@ -10,6 +10,10 @@ import (
 	"k8s.io/client-go/discovery"
 )
 
+// DiscoveryIndex is a two-level lookup: groupVersion -> kind -> discoveryEntry.
+// Both live-cluster discovery and offline api-resources parsing produce this type.
+type DiscoveryIndex map[string]map[string]discoveryEntry
+
 // MatchOptions configures the target-cluster discovery used by MatchResults.
 type MatchOptions struct {
 	DiscoveryClient discovery.DiscoveryInterface
@@ -23,7 +27,13 @@ func MatchResults(entries []ManifestEntry, opts MatchOptions, log logrus.FieldLo
 	if err != nil {
 		return nil, err
 	}
+	return MatchResultsFromIndex(entries, index), nil
+}
 
+// MatchResultsFromIndex compares each ManifestEntry against a pre-built
+// DiscoveryIndex and returns a validation report. Use this when the index
+// is built from an offline source (e.g. kubectl api-resources JSON output).
+func MatchResultsFromIndex(entries []ManifestEntry, index DiscoveryIndex) *ValidationReport {
 	kindIndex := buildKindIndex(index)
 
 	results := make([]ValidationResult, 0, len(entries))
@@ -49,7 +59,7 @@ func MatchResults(entries []ManifestEntry, opts MatchOptions, log logrus.FieldLo
 		TotalScanned: len(results),
 		Compatible:   compatible,
 		Incompatible: incompatible,
-	}, nil
+	}
 }
 
 // discoveryEntry stores one APIResource with its group/version context.
@@ -59,7 +69,7 @@ type discoveryEntry struct {
 
 // buildDiscoveryIndex fetches all served group-versions from the target cluster
 // and builds a two-level lookup: groupVersion -> kind -> discoveryEntry.
-func buildDiscoveryIndex(client discovery.DiscoveryInterface, log logrus.FieldLogger) (map[string]map[string]discoveryEntry, error) {
+func buildDiscoveryIndex(client discovery.DiscoveryInterface, log logrus.FieldLogger) (DiscoveryIndex, error) {
 	_, lists, err := client.ServerGroupsAndResources()
 	if err != nil {
 		if discovery.IsGroupDiscoveryFailedError(err) {
@@ -72,7 +82,7 @@ func buildDiscoveryIndex(client discovery.DiscoveryInterface, log logrus.FieldLo
 		}
 	}
 
-	index := map[string]map[string]discoveryEntry{}
+	index := DiscoveryIndex{}
 	for _, list := range lists {
 		gv := list.GroupVersion
 		if _, ok := index[gv]; !ok {
@@ -89,7 +99,7 @@ func buildDiscoveryIndex(client discovery.DiscoveryInterface, log logrus.FieldLo
 }
 
 // matchEntry checks a single ManifestEntry against the discovery index.
-func matchEntry(entry ManifestEntry, index map[string]map[string]discoveryEntry) ValidationResult {
+func matchEntry(entry ManifestEntry, index DiscoveryIndex) ValidationResult {
 	result := ValidationResult{
 		APIVersion: entry.APIVersion,
 		Kind:       entry.Kind,
@@ -118,7 +128,7 @@ func matchEntry(entry ManifestEntry, index map[string]map[string]discoveryEntry)
 
 // buildKindIndex creates a reverse lookup: kind -> list of groupVersion strings
 // that serve it. Used to suggest alternatives for incompatible resources.
-func buildKindIndex(index map[string]map[string]discoveryEntry) map[string][]string {
+func buildKindIndex(index DiscoveryIndex) map[string][]string {
 	kindIdx := map[string][]string{}
 	for gv, kinds := range index {
 		for kind := range kinds {

--- a/internal/validate/matcher_test.go
+++ b/internal/validate/matcher_test.go
@@ -207,6 +207,72 @@ func TestMatchResults_EmptyEntries(t *testing.T) {
 	}
 }
 
+func TestMatchResultsFromIndex_AllOK(t *testing.T) {
+	index := DiscoveryIndex{
+		"apps/v1": {
+			"Deployment": discoveryEntry{Resource: metav1.APIResource{Name: "deployments", Kind: "Deployment"}},
+		},
+		"v1": {
+			"Service": discoveryEntry{Resource: metav1.APIResource{Name: "services", Kind: "Service"}},
+		},
+	}
+
+	entries := []ManifestEntry{
+		{APIVersion: "apps/v1", Kind: "Deployment", Group: "apps", Version: "v1", Namespace: "prod"},
+		{APIVersion: "v1", Kind: "Service", Group: "", Version: "v1", Namespace: "prod"},
+	}
+
+	report := MatchResultsFromIndex(entries, index)
+	if report.Incompatible != 0 {
+		t.Fatalf("Incompatible = %d, want 0", report.Incompatible)
+	}
+	if report.Compatible != 2 {
+		t.Fatalf("Compatible = %d, want 2", report.Compatible)
+	}
+}
+
+func TestMatchResultsFromIndex_Incompatible(t *testing.T) {
+	index := DiscoveryIndex{
+		"v1": {
+			"ConfigMap": discoveryEntry{Resource: metav1.APIResource{Name: "configmaps", Kind: "ConfigMap"}},
+		},
+	}
+
+	entries := []ManifestEntry{
+		{APIVersion: "v1", Kind: "ConfigMap", Group: "", Version: "v1", Namespace: "prod"},
+		{APIVersion: "route.openshift.io/v1", Kind: "Route", Group: "route.openshift.io", Version: "v1", Namespace: "prod"},
+	}
+
+	report := MatchResultsFromIndex(entries, index)
+	if report.Compatible != 1 || report.Incompatible != 1 {
+		t.Fatalf("Compatible=%d Incompatible=%d, want 1/1", report.Compatible, report.Incompatible)
+	}
+}
+
+func TestMatchResultsFromIndex_Suggestion(t *testing.T) {
+	index := DiscoveryIndex{
+		"apps/v1": {
+			"Deployment": discoveryEntry{Resource: metav1.APIResource{Name: "deployments", Kind: "Deployment"}},
+		},
+	}
+
+	entries := []ManifestEntry{
+		{APIVersion: "extensions/v1beta1", Kind: "Deployment", Group: "extensions", Version: "v1beta1", Namespace: "prod"},
+	}
+
+	report := MatchResultsFromIndex(entries, index)
+	if report.Incompatible != 1 {
+		t.Fatalf("Incompatible = %d, want 1", report.Incompatible)
+	}
+	r := report.Results[0]
+	if r.Suggestion == "" {
+		t.Fatal("expected suggestion when alternative GV exists")
+	}
+	if !strings.Contains(r.Suggestion, "apps/v1") {
+		t.Fatalf("Suggestion = %q, expected it to mention apps/v1", r.Suggestion)
+	}
+}
+
 func TestMatchResults_ResourcePluralPopulated(t *testing.T) {
 	disc := fakeDiscovery([]*metav1.APIResourceList{
 		{

--- a/internal/validate/report.go
+++ b/internal/validate/report.go
@@ -28,6 +28,12 @@ func FormatTable(w io.Writer, report *ValidationReport) {
 	table.SetTablePadding("  ")
 	table.SetNoWhiteSpace(true)
 
+	if report.Mode == "offline" {
+		fmt.Fprintf(w, "Mode: offline (api-resources: %s)\n\n", report.APIResourcesSource)
+	} else if report.Mode == "live" {
+		fmt.Fprintf(w, "Mode: live (context: %s)\n\n", report.ClusterContext)
+	}
+
 	for _, r := range report.Results {
 		table.Append([]string{
 			r.APIVersion,

--- a/internal/validate/types.go
+++ b/internal/validate/types.go
@@ -33,10 +33,13 @@ type ValidationResult struct {
 
 // ValidationReport is the complete output.
 type ValidationReport struct {
-	Results      []ValidationResult `json:"results"`
-	TotalScanned int                `json:"totalScanned"`
-	Compatible   int                `json:"compatible"`
-	Incompatible int                `json:"incompatible"`
+	Mode               string             `json:"mode"`                         // "live" or "offline"
+	APIResourcesSource string             `json:"apiResourcesSource,omitempty"` // file path (offline mode)
+	ClusterContext     string             `json:"clusterContext,omitempty"`     // kubeconfig context (live mode)
+	Results            []ValidationResult `json:"results"`
+	TotalScanned       int                `json:"totalScanned"`
+	Compatible         int                `json:"compatible"`
+	Incompatible       int                `json:"incompatible"`
 }
 
 // HasIncompatible returns true if any resources are incompatible with the target.

--- a/scripts/capture-api-surface.sh
+++ b/scripts/capture-api-surface.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# capture-api-surface.sh
+# Run this on a machine with kubectl access to the target cluster.
+# It captures the full API surface (all served versions, not just preferred).
+# Pass the output file to: crane validate --api-resources api-surface.json
+#
+# Usage:
+#   bash capture-api-surface.sh --context <context-name> -o <output-file>
+#   bash capture-api-surface.sh --kubeconfig <path> -o <output-file>
+#   bash capture-api-surface.sh --kubeconfig <path> --context <context-name> -o <output-file>
+#
+# Examples:
+#   bash capture-api-surface.sh --context my-target-cluster -o api-surface.json
+#   bash capture-api-surface.sh --kubeconfig /path/to/kubeconfig -o api-surface.json
+
+set -euo pipefail
+
+CONTEXT=""
+KUBECONFIG_PATH=""
+OUTPUT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --context)    CONTEXT="$2"; shift 2 ;;
+    --kubeconfig) KUBECONFIG_PATH="$2"; shift 2 ;;
+    -o)           OUTPUT="$2"; shift 2 ;;
+    *)            echo "Unknown flag: $1"; exit 1 ;;
+  esac
+done
+
+if [ -z "$OUTPUT" ]; then
+  echo "Usage: bash capture-api-surface.sh [--context <name>] [--kubeconfig <path>] -o <output-file>"
+  exit 1
+fi
+
+# Build kubectl flags
+KUBECTL_FLAGS=""
+[ -n "$CONTEXT" ] && KUBECTL_FLAGS="$KUBECTL_FLAGS --context=$CONTEXT"
+[ -n "$KUBECONFIG_PATH" ] && KUBECTL_FLAGS="$KUBECTL_FLAGS --kubeconfig=$KUBECONFIG_PATH"
+
+echo "Capturing API surface..."
+[ -n "$CONTEXT" ] && echo "  Context: $CONTEXT"
+[ -n "$KUBECONFIG_PATH" ] && echo "  Kubeconfig: $KUBECONFIG_PATH"
+
+# Step 1: Get all API versions served by the cluster
+API_VERSIONS=$(kubectl api-versions $KUBECTL_FLAGS)
+
+# Step 2: For each API version, fetch the list of resources it serves
+echo '{"apiResourceLists":[' > "$OUTPUT"
+FIRST=true
+
+for GV in $API_VERSIONS; do
+  # Core API (v1) lives at /api/v1, everything else at /apis/<group>/<version>
+  if [ "$GV" = "v1" ]; then
+    ENDPOINT="/api/v1"
+  else
+    ENDPOINT="/apis/$GV"
+  fi
+
+  RESOURCES=$(kubectl get --raw "$ENDPOINT" $KUBECTL_FLAGS 2>/dev/null) || continue
+
+  if [ "$FIRST" = true ]; then
+    FIRST=false
+  else
+    echo "," >> "$OUTPUT"
+  fi
+  echo "$RESOURCES" >> "$OUTPUT"
+done
+
+echo ']}' >> "$OUTPUT"
+
+COUNT=$(echo "$API_VERSIONS" | wc -l | tr -d ' ')
+echo "Done. Captured $COUNT API versions to $OUTPUT"


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                
   
  Adds offline GVK validation to `crane validate` via a new `--api-resources` flag. This enables validation against a target cluster's API surface without a live kubeconfig connection — supporting air-gapped             
  environments, CI/CD pipelines, and team handoff scenarios.          
                                                                                                                                                                                                                            
  ## Problem                                                          

  `crane validate` required a live connection to the target cluster. This blocked validation in disconnected environments and pipelines without cluster access.                                                             
   
  ## Solution                                                                                                                                                                                                               
                                                                      
  A capture script (`scripts/capture-api-surface.sh`) that calls `kubectl get --raw /apis/<group>/<version>` for every served group-version — producing the exact same data as `ServerGroupsAndResources()`. This eliminates
   the preferred-vs-all-served gap entirely.
                                                                                                                                                                                                                            
  **On target cluster** (only kubectl needed, no crane):              

      bash scripts/capture-api-surface.sh --context target-cluster -o api-surface.json

  **On migration workstation** (no cluster access needed):
                                                                                                                                                                                                                            
      crane validate -i output/ --api-resources api-surface.json
                                                                                                                                                                                                                            
  The script output is an array of native Kubernetes `APIResourceList` objects — the same type `ServerGroupsAndResources()` returns in Go. The parser uses `metav1.APIResourceList` directly with zero custom types or
  parsing heuristics.                                                                                                                                                                                                       
   
  `--api-resources` is mutually exclusive with `--context`/`--kubeconfig`. When neither is set, existing default kubeconfig behavior is unchanged.                                                                          
                                                                      
  ## Design decisions                                                                                                                                                                                                       
   
  - **Full API surface, not just preferred:** The capture script uses `kubectl api-versions` + `kubectl get --raw` to dump all served group-versions, matching the live path's `ServerGroupsAndResources()`. This was       
  changed after aufi's review identified that `kubectl api-resources -o json` only returns preferred versions.
  - **Subresource filtering parity:** Both live (`buildDiscoveryIndex`) and offline (`ParseAPIResourcesJSON`) skip resources with `/` in the name (e.g., `deployments/status`), ensuring consistent behavior.               
  - **No custom format:** The capture script output uses native Kubernetes `APIResourceList` JSON — no crane-specific types.                                                                                                
  - **Refactor, not rewrite:** `MatchResults` delegates to `MatchResultsFromIndex`. Both paths produce the same `DiscoveryIndex` type, so all matching logic is untouched.                                                  
                                                                                                                                                                                                                            
  ## Test plan                                                                                                                                                                                                              
                                                                                                                                                                                                                            
  - [x] `go build ./...` compiles                                     
  - [x] All unit tests pass (`go test ./internal/validate/... ./cmd/validate/...`)
  - [x] Existing live-mode tests unchanged and passing                                                                                                                                                                      
  - [x] `bash scripts/capture-api-surface.sh --context tgt -o api-surface.json` captures 27 API versions                                                                                                                    
  - [x] `crane validate -i output/ --api-resources api-surface.json` works in offline mode                                                                                                                                  
  - [x] `crane validate --api-resources api-surface.json --context foo` returns mutual exclusion error                                                                                                                      
  - [x] Cross-mode equivalence: 28 GVKs across 13 API groups tested — live and offline produce **identical** results (status, resourcePlural, suggestions all match)
  - [x] Subresource filtering consistent: `apps/v1 Scale` reported as "kind not found" in both modes      