### PR TITLE
Ensure crane apply updates stages output

### DIFF
--- a/internal/apply/kustomize.go
+++ b/internal/apply/kustomize.go
@@ -66,6 +66,7 @@ func (k *KustomizeApplier) ApplySingleStage(stageName string) error {
 }
 
 // ApplyMultiStage applies a multi-stage transform pipeline
+// For each stage, it regenerates the .work/<stage>/output/ directory by running kustomize
 func (k *KustomizeApplier) ApplyMultiStage(stageSelector internalTransform.StageSelector) error {
 	// Discover stages
 	stages, err := internalTransform.DiscoverStages(k.TransformDir)
@@ -79,12 +80,46 @@ func (k *KustomizeApplier) ApplyMultiStage(stageSelector internalTransform.Stage
 		return fmt.Errorf("no stages found matching selector")
 	}
 
-	// Get the last (final) stage
-	lastStage := selectedStages[len(selectedStages)-1]
+	opts := file.PathOpts{
+		TransformDir: k.TransformDir,
+		OutputDir:    k.OutputDir,
+	}
 
+	// Process each stage sequentially to regenerate .work directories
+	k.Log.Infof("Processing %d stage(s) sequentially to regenerate .work outputs", len(selectedStages))
+
+	for i, stage := range selectedStages {
+		k.Log.Infof("Processing stage %d/%d: %s", i+1, len(selectedStages), stage.DirName)
+
+		// Run kubectl kustomize build on this stage
+		stageDir := opts.GetStageDir(stage.DirName)
+		output, err := k.runKustomizeBuild(stageDir)
+		if err != nil {
+			return fmt.Errorf("kubectl kustomize build failed for stage %s: %w", stage.DirName, err)
+		}
+
+		// Parse output into resources
+		resources, err := file.ParseMultiDocYAML(output)
+		if err != nil {
+			return fmt.Errorf("failed to parse kustomize output for stage %s: %w", stage.DirName, err)
+		}
+
+		k.Log.Debugf("Stage %s: produced %d resource(s)", stage.DirName, len(resources))
+
+		// Write resources to .work/<stage>/output/ directory
+		stageOutputDir := opts.GetStageOutputDir(stage.DirName)
+		if err := k.writeResourcesToDirectory(resources, stageOutputDir); err != nil {
+			return fmt.Errorf("failed to write stage %s output to .work: %w", stage.DirName, err)
+		}
+
+		k.Log.Debugf("Stage %s: wrote output to %s", stage.DirName, stageOutputDir)
+	}
+
+	// Get the last (final) stage output
+	lastStage := selectedStages[len(selectedStages)-1]
 	k.Log.Infof("Applying final stage: %s", lastStage.DirName)
 
-	// Run kubectl kustomize build on the last stage
+	// Run kubectl kustomize build on the last stage (again, to get bytes for output.yaml)
 	output, err := k.runKustomizeBuild(lastStage.Path)
 	if err != nil {
 		return fmt.Errorf("kubectl kustomize build failed for stage %s: %w", lastStage.DirName, err)
@@ -146,6 +181,35 @@ func ValidateKubectlAvailable() error {
 	return fmt.Errorf("neither kubectl nor oc found or executable")
 }
 
+// writeResourcesToDirectory writes resources as individual YAML files to a directory
+func (k *KustomizeApplier) writeResourcesToDirectory(resources []unstructured.Unstructured, outputDir string) error {
+	// Create output directory
+	if err := os.MkdirAll(outputDir, 0700); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", outputDir, err)
+	}
+
+	// Write each resource to its own file
+	for _, resource := range resources {
+		// Generate filename using shared helper
+		filename := file.GetResourceFilename(resource)
+		filePath := filepath.Join(outputDir, filename)
+
+		// Marshal resource to YAML
+		yamlBytes, err := yaml.Marshal(resource.Object)
+		if err != nil {
+			return fmt.Errorf("failed to marshal resource %s: %w", filename, err)
+		}
+
+		// Write to file
+		if err := os.WriteFile(filePath, yamlBytes, 0644); err != nil {
+			return fmt.Errorf("failed to write file %s: %w", filePath, err)
+		}
+	}
+
+	k.Log.Debugf("Wrote %d resource(s) to %s", len(resources), outputDir)
+	return nil
+}
+
 // splitMultiDocYAMLToFiles splits a multi-document YAML into individual resource files
 // This maintains backward compatibility with tests/tools expecting separate files
 func (k *KustomizeApplier) splitMultiDocYAMLToFiles(yamlData []byte) error {
@@ -153,7 +217,7 @@ func (k *KustomizeApplier) splitMultiDocYAMLToFiles(yamlData []byte) error {
 	decoder := yamlv3.NewDecoder(strings.NewReader(string(yamlData)))
 
 	for {
-		var doc interface{}
+		var doc any
 		err := decoder.Decode(&doc)
 		if err == io.EOF {
 			break

--- a/internal/apply/kustomize.go
+++ b/internal/apply/kustomize.go
@@ -183,6 +183,11 @@ func ValidateKubectlAvailable() error {
 
 // writeResourcesToDirectory writes resources as individual YAML files to a directory
 func (k *KustomizeApplier) writeResourcesToDirectory(resources []unstructured.Unstructured, outputDir string) error {
+	// Clear output directory if it exists to remove stale resources from prior runs
+	if err := os.RemoveAll(outputDir); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove existing output directory: %w", err)
+	}
+
 	// Create output directory
 	if err := os.MkdirAll(outputDir, 0700); err != nil {
 		return fmt.Errorf("failed to create directory %s: %w", outputDir, err)

--- a/internal/apply/kustomize_test.go
+++ b/internal/apply/kustomize_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func TestSplitMultiDocYAMLToFiles(t *testing.T) {
@@ -434,4 +435,138 @@ func findInString(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+func TestWriteResourcesToDirectory(t *testing.T) {
+	tests := []struct {
+		name          string
+		resources     []unstructured.Unstructured
+		expectedFiles []string
+		expectError   bool
+	}{
+		{
+			name: "single resource",
+			resources: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "ConfigMap",
+						"metadata": map[string]interface{}{
+							"name":      "test-config",
+							"namespace": "default",
+						},
+						"data": map[string]interface{}{
+							"key": "value",
+						},
+					},
+				},
+			},
+			expectedFiles: []string{
+				"ConfigMap__v1_default_test-config.yaml",
+			},
+			expectError: false,
+		},
+		{
+			name: "multiple resources",
+			resources: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "Service",
+						"metadata": map[string]interface{}{
+							"name":      "web",
+							"namespace": "prod",
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"apiVersion": "apps/v1",
+						"kind":       "Deployment",
+						"metadata": map[string]interface{}{
+							"name":      "app",
+							"namespace": "prod",
+						},
+					},
+				},
+			},
+			expectedFiles: []string{
+				"Service__v1_prod_web.yaml",
+				"Deployment_apps_v1_prod_app.yaml",
+			},
+			expectError: false,
+		},
+		{
+			name: "cluster-scoped resource",
+			resources: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"apiVersion": "rbac.authorization.k8s.io/v1",
+						"kind":       "ClusterRole",
+						"metadata": map[string]interface{}{
+							"name": "admin",
+						},
+					},
+				},
+			},
+			expectedFiles: []string{
+				"ClusterRole_rbac.authorization.k8s.io_v1_clusterscoped_admin.yaml",
+			},
+			expectError: false,
+		},
+		{
+			name:          "empty resources",
+			resources:     []unstructured.Unstructured{},
+			expectedFiles: []string{},
+			expectError:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir, err := os.MkdirTemp("", "crane-write-test-*")
+			if err != nil {
+				t.Fatalf("Failed to create temp dir: %v", err)
+			}
+			defer os.RemoveAll(tmpDir)
+
+			logger := logrus.New()
+			logger.SetLevel(logrus.ErrorLevel)
+			applier := &KustomizeApplier{
+				Log:       logger,
+				OutputDir: tmpDir,
+			}
+
+			err = applier.writeResourcesToDirectory(tt.resources, tmpDir)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			// Verify expected files exist
+			for _, expectedFile := range tt.expectedFiles {
+				filePath := filepath.Join(tmpDir, expectedFile)
+				if _, err := os.Stat(filePath); os.IsNotExist(err) {
+					t.Errorf("Expected file %s does not exist", expectedFile)
+				}
+			}
+
+			// Verify no unexpected files
+			files, err := os.ReadDir(tmpDir)
+			if err != nil {
+				t.Fatalf("Failed to read output dir: %v", err)
+			}
+
+			if len(files) != len(tt.expectedFiles) {
+				t.Errorf("Expected %d files, found %d", len(tt.expectedFiles), len(files))
+			}
+		})
+	}
 }

--- a/internal/apply/kustomize_test.go
+++ b/internal/apply/kustomize_test.go
@@ -570,3 +570,117 @@ func TestWriteResourcesToDirectory(t *testing.T) {
 		})
 	}
 }
+
+func TestWriteResourcesToDirectory_CleansStaleFiles(t *testing.T) {
+	// Test that writeResourcesToDirectory removes stale files from previous runs
+	tmpDir, err := os.MkdirTemp("", "crane-stale-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+	applier := &KustomizeApplier{
+		Log:       logger,
+		OutputDir: tmpDir,
+	}
+
+	// First run: write 3 resources
+	firstRun := []unstructured.Unstructured{
+		{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name":      "config1",
+					"namespace": "default",
+				},
+			},
+		},
+		{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name":      "config2",
+					"namespace": "default",
+				},
+			},
+		},
+		{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Service",
+				"metadata": map[string]interface{}{
+					"name":      "svc1",
+					"namespace": "default",
+				},
+			},
+		},
+	}
+
+	err = applier.writeResourcesToDirectory(firstRun, tmpDir)
+	if err != nil {
+		t.Fatalf("First run failed: %v", err)
+	}
+
+	// Verify 3 files exist
+	files, _ := os.ReadDir(tmpDir)
+	if len(files) != 3 {
+		t.Fatalf("Expected 3 files after first run, got %d", len(files))
+	}
+
+	// Second run: write only 1 resource (different from first run)
+	secondRun := []unstructured.Unstructured{
+		{
+			Object: map[string]interface{}{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata": map[string]interface{}{
+					"name":      "app",
+					"namespace": "default",
+				},
+			},
+		},
+	}
+
+	err = applier.writeResourcesToDirectory(secondRun, tmpDir)
+	if err != nil {
+		t.Fatalf("Second run failed: %v", err)
+	}
+
+	// Verify only 1 file exists (old files should be removed)
+	files, _ = os.ReadDir(tmpDir)
+	if len(files) != 1 {
+		t.Errorf("Expected 1 file after second run (stale files should be removed), got %d", len(files))
+	}
+
+	// Verify the correct file exists
+	expectedFile := "Deployment_apps_v1_default_app.yaml"
+	foundExpected := false
+	for _, f := range files {
+		if f.Name() == expectedFile {
+			foundExpected = true
+			break
+		}
+	}
+
+	if !foundExpected {
+		t.Errorf("Expected file %s not found after second run", expectedFile)
+	}
+
+	// Verify old files don't exist
+	staleFiles := []string{
+		"ConfigMap__v1_default_config1.yaml",
+		"ConfigMap__v1_default_config2.yaml",
+		"Service__v1_default_svc1.yaml",
+	}
+
+	for _, staleFile := range staleFiles {
+		filePath := filepath.Join(tmpDir, staleFile)
+		if _, err := os.Stat(filePath); !os.IsNotExist(err) {
+			t.Errorf("Stale file %s should not exist after second run", staleFile)
+		}
+	}
+}

--- a/internal/file/yaml.go
+++ b/internal/file/yaml.go
@@ -1,0 +1,57 @@
+package file
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	yamlv3 "gopkg.in/yaml.v3"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+)
+
+// ParseMultiDocYAML parses multi-document YAML into unstructured Kubernetes resources
+func ParseMultiDocYAML(yamlBytes []byte) ([]unstructured.Unstructured, error) {
+	var resources []unstructured.Unstructured
+
+	// Use yaml.v3 Decoder to properly handle multi-document YAML streams
+	decoder := yamlv3.NewDecoder(strings.NewReader(string(yamlBytes)))
+
+	for {
+		var doc any
+		err := decoder.Decode(&doc)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode YAML document: %w", err)
+		}
+
+		// Skip empty documents
+		if doc == nil {
+			continue
+		}
+
+		// Convert the decoded document back to YAML bytes, then to JSON
+		docBytes, err := yamlv3.Marshal(doc)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal YAML document: %w", err)
+		}
+
+		// Convert YAML to JSON
+		jsonData, err := yaml.YAMLToJSON(docBytes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert YAML to JSON: %w", err)
+		}
+
+		// Unmarshal into unstructured
+		u := unstructured.Unstructured{}
+		if err := u.UnmarshalJSON(jsonData); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal resource: %w", err)
+		}
+
+		resources = append(resources, u)
+	}
+
+	return resources, nil
+}

--- a/internal/transform/orchestrator.go
+++ b/internal/transform/orchestrator.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -15,7 +14,6 @@ import (
 	"github.com/konveyor/crane/internal/file"
 	"github.com/konveyor/crane/internal/plugin"
 	"github.com/sirupsen/logrus"
-	yamlv3 "gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
 )
@@ -309,45 +307,9 @@ func (o *Orchestrator) applyStageTransforms(stageDir string) ([]unstructured.Uns
 	}
 
 	// Parse the multi-document YAML output
-	var resources []unstructured.Unstructured
-
-	// Use yaml.v3 Decoder to properly handle multi-document YAML streams
-	decoder := yamlv3.NewDecoder(strings.NewReader(stdout.String()))
-
-	for {
-		var doc interface{}
-		err := decoder.Decode(&doc)
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode YAML document: %w", err)
-		}
-
-		// Skip empty documents
-		if doc == nil {
-			continue
-		}
-
-		// Convert the decoded document back to YAML bytes, then to JSON
-		docBytes, err := yamlv3.Marshal(doc)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal YAML document: %w", err)
-		}
-
-		// Convert YAML to JSON
-		jsonData, err := yaml.YAMLToJSON(docBytes)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert YAML to JSON: %w", err)
-		}
-
-		// Unmarshal into unstructured
-		u := unstructured.Unstructured{}
-		if err := u.UnmarshalJSON(jsonData); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal resource: %w", err)
-		}
-
-		resources = append(resources, u)
+	resources, err := file.ParseMultiDocYAML(stdout.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse kustomize output: %w", err)
 	}
 
 	return resources, nil


### PR DESCRIPTION
Update apply for force creating `.work/` directory entries for all stages (output could be not up-to-date from transform after custom modifications).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced multi-stage deployment processing to improve reliability and consistency when applying complex Kubernetes configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->