### PR TITLE
Added test for app workload coexistence with OLM resources

### DIFF
--- a/e2e-tests/testdata/app-configmap.yaml
+++ b/e2e-tests/testdata/app-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-settings
+data:
+  app.env: production
+  app.log-level: info

--- a/e2e-tests/testdata/olm-resources.yaml
+++ b/e2e-tests/testdata/olm-resources.yaml
@@ -1,0 +1,27 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: olm-whiteout-og
+spec:
+  targetNamespaces: []
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: olm-whiteout-catalog
+spec:
+  sourceType: grpc
+  image: quay.io/operatorhubio/catalog:latest
+  displayName: Community Operators
+  publisher: OperatorHub.io
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: olm-whiteout-subscription
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: cert-manager
+  source: olm-whiteout-catalog
+  sourceNamespace: __NAMESPACE__

--- a/e2e-tests/tests/olm_whiteout_test.go
+++ b/e2e-tests/tests/olm_whiteout_test.go
@@ -1,11 +1,7 @@
 package e2e
 
 import (
-	"fmt"
-	"io"
 	"log"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/konveyor/crane/e2e-tests/config"
@@ -13,7 +9,6 @@ import (
 	"github.com/konveyor/crane/e2e-tests/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"gopkg.in/yaml.v3"
 )
 
 // olmWhiteoutKinds lists Kubernetes object kinds that crane-lib whiteouts for OLM migration.
@@ -24,62 +19,6 @@ var olmWhiteoutKinds = []string{
 	"InstallPlan",
 	"OperatorGroup",
 	"OperatorCondition",
-}
-
-// assertNoOLMWhiteoutKindsInOutput walks root (e.g. crane apply output) and fails if any
-// manifest has a denied kind or if a file path suggests an OLM whiteout resource (same idea as MTC-127).
-func assertNoOLMWhiteoutKindsInOutput(root string) error {
-	denyKind := make(map[string]struct{}, len(olmWhiteoutKinds))
-	for _, k := range olmWhiteoutKinds {
-		denyKind[k] = struct{}{}
-	}
-
-	files, err := utils.ListFilesRecursivelyAsList(root)
-	if err != nil {
-		return err
-	}
-
-	for _, rel := range files {
-		for _, kind := range olmWhiteoutKinds {
-			if strings.Contains(rel, kind) {
-				return fmt.Errorf("output path %q contains forbidden OLM kind substring %q", rel, kind)
-			}
-		}
-
-		absPath := filepath.Join(root, rel)
-		if !utils.LooksLikeYAMLFile(absPath) {
-			continue
-		}
-		data, err := os.ReadFile(absPath)
-		if err != nil {
-			return err
-		}
-		if len(strings.TrimSpace(string(data))) == 0 {
-			continue
-		}
-		dec := yaml.NewDecoder(strings.NewReader(string(data)))
-		for {
-			var doc map[string]interface{}
-			err := dec.Decode(&doc)
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return fmt.Errorf("%s: parse yaml: %w", rel, err)
-			}
-			if doc == nil {
-				continue
-			}
-			kindVal, _ := doc["kind"].(string)
-			if kindVal == "" {
-				continue
-			}
-			if _, bad := denyKind[kindVal]; bad {
-				return fmt.Errorf("%s: document kind %q must not appear in crane output", rel, kindVal)
-			}
-		}
-	}
-	return nil
 }
 
 var _ = Describe("OLM whiteout", func() {
@@ -142,12 +81,122 @@ var _ = Describe("OLM whiteout", func() {
 			log.Printf("Crane pipeline completed for namespace %s", srcApp.Namespace)
 
 			By("Verify output directory does not contain OLM whiteout kinds")
-			Expect(assertNoOLMWhiteoutKindsInOutput(paths.OutputDir)).NotTo(HaveOccurred())
+			Expect(utils.AssertNoKindsInOutput(paths.OutputDir, olmWhiteoutKinds)).NotTo(HaveOccurred())
 
 			By("Apply rendered manifests to target")
 			Expect(ApplyOutputToTarget(kubectlTgt, namespace, paths.OutputDir)).NotTo(HaveOccurred())
 
 			By("Verify OLM objects from baseline setup are not present on target")
+			for _, res := range []struct {
+				kind string
+				name string
+			}{
+				{"subscription", "olm-whiteout-subscription"},
+				{"catalogsource", "olm-whiteout-catalog"},
+				{"operatorgroup", "olm-whiteout-og"},
+			} {
+				_, err := kubectlTgt.Run("get", res.kind, res.name, "-n", namespace)
+				Expect(err).To(HaveOccurred(), "%s %s should not exist on target", res.kind, res.name)
+				Expect(err.Error()).To(ContainSubstring("NotFound"))
+			}
+		})
+	})
+
+	Describe("App workload coexistence", func() {
+		It("should preserve app resources while omitting OLM kinds", Label("olm", "tier1"), func() {
+			kubectlPreflight := KubectlRunner{Bin: "kubectl", Context: config.SourceContext}
+			olmAvailable, err := kubectlPreflight.OLMAPIAvailable()
+			Expect(err).NotTo(HaveOccurred())
+			if !olmAvailable {
+				Skip("OLM APIs not installed (subscriptions.operators.coreos.com CRD missing)")
+			}
+
+			appName := "simple-nginx-nopv"
+			namespace := "olm-app-coexist"
+			scenario := NewMigrationScenario(
+				appName,
+				namespace,
+				config.K8sDeployBin,
+				config.CraneBin,
+				config.SourceContext,
+				config.TargetContext,
+			)
+			srcApp := scenario.SrcApp
+			tgtApp := scenario.TgtApp
+			kubectlSrc := scenario.KubectlSrc
+			kubectlTgt := scenario.KubectlTgt
+
+			By("Deploy application workloads via k8sdeploy (Deployment + Service)")
+			log.Printf("Preparing source app %s in namespace %s\n", srcApp.Name, srcApp.Namespace)
+			Expect(PrepareSourceApp(srcApp, kubectlSrc)).NotTo(HaveOccurred())
+
+			paths, err := NewScenarioPaths("crane-export-*")
+			Expect(err).NotTo(HaveOccurred())
+
+			DeferCleanup(func() {
+				By("Cleanup OLM resources on source")
+				for _, res := range []string{
+					"subscription olm-whiteout-subscription",
+					"catalogsource olm-whiteout-catalog",
+					"operatorgroup olm-whiteout-og",
+				} {
+					_, _ = kubectlSrc.Run("delete", res, "-n", namespace, "--ignore-not-found=true")
+				}
+				By("Cleanup source and target resources")
+				if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
+					log.Printf("cleanup: %v", err)
+				}
+			})
+
+			By("Create ConfigMap as additional app resource")
+			configMapSpec, err := utils.ReadTestdataFile("app-configmap.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(kubectlSrc.ApplyYAMLSpec(configMapSpec, namespace)).NotTo(HaveOccurred())
+
+			By("Create OLM resources (OperatorGroup, CatalogSource, Subscription)")
+			olmSpec, err := utils.ReadTestdataFile("olm-resources.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			olmSpec = strings.ReplaceAll(olmSpec, "__NAMESPACE__", namespace)
+			Expect(kubectlSrc.ApplyYAMLSpec(olmSpec, namespace)).NotTo(HaveOccurred())
+
+			By("Wait for OLM to create InstallPlan and ClusterServiceVersion")
+			Eventually(func(g Gomega) {
+				out, err := kubectlSrc.Run("get", "installplan", "-n", namespace)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(strings.TrimSpace(out)).NotTo(ContainSubstring("No resources found"))
+			}, "12m", "15s").Should(Succeed())
+			Eventually(func(g Gomega) {
+				out, err := kubectlSrc.Run("get", "csv", "-n", namespace)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(strings.TrimSpace(out)).NotTo(ContainSubstring("No resources found"))
+			}, "12m", "15s").Should(Succeed())
+
+			runner := scenario.Crane
+			runner.WorkDir = paths.TempDir
+
+			By("Run crane export/transform/apply pipeline")
+			log.Printf("Running crane pipeline for namespace %s\n", namespace)
+			Expect(RunCranePipelineWithChecks(runner, namespace, paths)).NotTo(HaveOccurred())
+			log.Printf("Crane pipeline completed for namespace %s", namespace)
+
+			By("Verify output does not contain OLM whiteout kinds")
+			Expect(utils.AssertNoKindsInOutput(paths.OutputDir, olmWhiteoutKinds)).NotTo(HaveOccurred())
+
+			By("Verify output contains application resource kinds (Deployment, Service, ConfigMap)")
+			Expect(utils.AssertKindsInOutput(paths.OutputDir, []string{"Deployment", "Service", "ConfigMap"})).NotTo(HaveOccurred())
+
+			By("Apply rendered manifests to target")
+			Expect(ApplyOutputToTarget(kubectlTgt, namespace, paths.OutputDir)).NotTo(HaveOccurred())
+
+			By("Verify app resources exist on target")
+			_, err = kubectlTgt.Run("get", "deployment", appName+"-deployment", "-n", namespace)
+			Expect(err).NotTo(HaveOccurred(), "Deployment should exist on target")
+			_, err = kubectlTgt.Run("get", "service", "my-"+appName, "-n", namespace)
+			Expect(err).NotTo(HaveOccurred(), "Service should exist on target")
+			_, err = kubectlTgt.Run("get", "configmap", "app-settings", "-n", namespace)
+			Expect(err).NotTo(HaveOccurred(), "ConfigMap should exist on target")
+
+			By("Verify OLM resources do NOT exist on target")
 			for _, res := range []struct {
 				kind string
 				name string

--- a/e2e-tests/tests/olm_whiteout_test.go
+++ b/e2e-tests/tests/olm_whiteout_test.go
@@ -135,12 +135,15 @@ var _ = Describe("OLM whiteout", func() {
 
 			DeferCleanup(func() {
 				By("Cleanup OLM resources on source")
-				for _, res := range []string{
-					"subscription olm-whiteout-subscription",
-					"catalogsource olm-whiteout-catalog",
-					"operatorgroup olm-whiteout-og",
+				for _, res := range []struct {
+					kind string
+					name string
+				}{
+					{"subscription", "olm-whiteout-subscription"},
+					{"catalogsource", "olm-whiteout-catalog"},
+					{"operatorgroup", "olm-whiteout-og"},
 				} {
-					_, _ = kubectlSrc.Run("delete", res, "-n", namespace, "--ignore-not-found=true")
+					_, _ = kubectlSrc.Run("delete", res.kind, res.name, "-n", namespace, "--ignore-not-found=true")
 				}
 				By("Cleanup source and target resources")
 				if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {

--- a/e2e-tests/tests/olm_whiteout_test.go
+++ b/e2e-tests/tests/olm_whiteout_test.go
@@ -143,7 +143,9 @@ var _ = Describe("OLM whiteout", func() {
 					{"catalogsource", "olm-whiteout-catalog"},
 					{"operatorgroup", "olm-whiteout-og"},
 				} {
-					_, _ = kubectlSrc.Run("delete", res.kind, res.name, "-n", namespace, "--ignore-not-found=true")
+					if _, err := kubectlSrc.Run("delete", res.kind, res.name, "-n", namespace, "--ignore-not-found=true"); err != nil {
+						log.Printf("cleanup: failed to delete %s/%s: %v", res.kind, res.name, err)
+					}
 				}
 				By("Cleanup source and target resources")
 				if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {

--- a/e2e-tests/utils/utils.go
+++ b/e2e-tests/utils/utils.go
@@ -400,6 +400,115 @@ func compareYAMLFileBytes(relPath string, golden, got []byte) error {
 	return nil
 }
 
+// AssertNoKindsInOutput walks root and returns an error if any YAML manifest
+// has a kind in deniedKinds, or if any file path contains a denied kind as a substring.
+func AssertNoKindsInOutput(root string, deniedKinds []string) error {
+	denySet := make(map[string]struct{}, len(deniedKinds))
+	for _, k := range deniedKinds {
+		denySet[k] = struct{}{}
+	}
+
+	files, err := ListFilesRecursivelyAsList(root)
+	if err != nil {
+		return err
+	}
+
+	for _, rel := range files {
+		for _, kind := range deniedKinds {
+			if strings.Contains(rel, kind) {
+				return fmt.Errorf("output path %q contains forbidden kind substring %q", rel, kind)
+			}
+		}
+
+		absPath := filepath.Join(root, rel)
+		if !LooksLikeYAMLFile(absPath) {
+			continue
+		}
+		data, err := os.ReadFile(absPath)
+		if err != nil {
+			return err
+		}
+		if len(strings.TrimSpace(string(data))) == 0 {
+			continue
+		}
+		dec := yaml.NewDecoder(strings.NewReader(string(data)))
+		for {
+			var doc map[string]interface{}
+			err := dec.Decode(&doc)
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return fmt.Errorf("%s: parse yaml: %w", rel, err)
+			}
+			if doc == nil {
+				continue
+			}
+			kindVal, _ := doc["kind"].(string)
+			if kindVal == "" {
+				continue
+			}
+			if _, bad := denySet[kindVal]; bad {
+				return fmt.Errorf("%s: document kind %q must not appear in output", rel, kindVal)
+			}
+		}
+	}
+	return nil
+}
+
+// AssertKindsInOutput walks root and returns an error if any of requiredKinds
+// is not found as the kind field in at least one YAML manifest.
+func AssertKindsInOutput(root string, requiredKinds []string) error {
+	found := make(map[string]bool)
+
+	files, err := ListFilesRecursivelyAsList(root)
+	if err != nil {
+		return err
+	}
+
+	for _, rel := range files {
+		absPath := filepath.Join(root, rel)
+		if !LooksLikeYAMLFile(absPath) {
+			continue
+		}
+		data, err := os.ReadFile(absPath)
+		if err != nil {
+			return err
+		}
+		if len(strings.TrimSpace(string(data))) == 0 {
+			continue
+		}
+		dec := yaml.NewDecoder(strings.NewReader(string(data)))
+		for {
+			var doc map[string]interface{}
+			err := dec.Decode(&doc)
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return fmt.Errorf("%s: parse yaml: %w", rel, err)
+			}
+			if doc == nil {
+				continue
+			}
+			if kindVal, _ := doc["kind"].(string); kindVal != "" {
+				found[kindVal] = true
+			}
+		}
+	}
+
+	var missing []string
+	for _, k := range requiredKinds {
+		if !found[k] {
+			missing = append(missing, k)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("required kinds missing from output: %v", missing)
+	}
+	return nil
+}
+
 // LooksLikeYAMLFile returns true for paths that look like YAML (by extension or no extension, e.g. output fragments).
 func LooksLikeYAMLFile(path string) bool {
 	ext := strings.ToLower(filepath.Ext(path))


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                
   
  - Added **OLM whiteout + app coexistence E2E test** (`olm_whiteout_test.go`) that deploys a `simple-nginx-nopv` app (Deployment + Service) alongside OLM resources (OperatorGroup, CatalogSource, Subscription) in the    
  same namespace, runs the full crane pipeline, and verifies:
    - All 6 OLM resource kinds are absent from `crane apply` output                                                                                                                                                         
    - Application resources (Deployment, Service, ConfigMap) are preserved in output                                                                                                                                        
    - App resources exist on the target cluster while OLM resources do not                                                                                                                                                  
  - Extracted **`AssertNoKindsInOutput`** and **`AssertKindsInOutput`** as generic, reusable utilities in `e2e-tests/utils/utils.go` (previously inline in the test file)                                                   
  - Added testdata files: `olm-resources.yaml` (OperatorGroup, CatalogSource, Subscription) and `app-configmap.yaml`                                                                                                        
                                                                                                                                                                                                                            
  ## Test plan                                                                                                                                                                                                              
                                                                                                                                                                                                                            
  - [x] `go build ./e2e-tests/...` — compiles cleanly                                                                                                                                                                       
  - [x] `go vet ./e2e-tests/...` — no issues
  - [x] New test passes on minikube (src/tgt clusters with OLM enabled):                                                                                                                                                    
    ginkgo run -v --focus="should preserve app resources while omitting OLM kinds" e2e-tests/tests --                                                                                                                       
      --crane-bin=/crane --source-context=src --target-context=tgt                                                                                                                                                          
  - [x] Existing baseline OLM test unaffected by utils refactor           

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced end-to-end testing for OLM resource handling throughout the manifest export, transformation, and application lifecycle.
  * Introduced reusable validation utilities to verify resource inclusion and exclusion in exported manifests.
  * Added comprehensive test coverage for application workload coexistence with OLM resources, validating proper resource separation and filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->