### PR TITLE
Added transform stage files test for OLM resources

### DIFF
--- a/e2e-tests/tests/olm_whiteout_test.go
+++ b/e2e-tests/tests/olm_whiteout_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"log"
+	"os"
 	"strings"
 
 	"github.com/konveyor/crane/e2e-tests/config"
@@ -99,6 +100,97 @@ var _ = Describe("OLM whiteout", func() {
 				Expect(err).To(HaveOccurred(), "%s %s should not exist on target", res.kind, res.name)
 				Expect(err.Error()).To(ContainSubstring("NotFound"))
 			}
+		})
+	})
+
+	Describe("Transform-stage auditability", func() {
+		It("should preserve whiteout resource files and comments in transform stage", Label("olm", "tier1"), func() {
+			kubectlPreflight := KubectlRunner{Bin: "kubectl", Context: config.SourceContext}
+			olmAvailable, err := kubectlPreflight.OLMAPIAvailable()
+			Expect(err).NotTo(HaveOccurred())
+			if !olmAvailable {
+				Skip("OLM APIs not installed (subscriptions.operators.coreos.com CRD missing)")
+			}
+
+			namespace := "olm-audit"
+			scenario := NewMigrationScenario(
+				"olm-audit",
+				namespace,
+				config.K8sDeployBin,
+				config.CraneBin,
+				config.SourceContext,
+				config.TargetContext,
+			)
+			kubectlSrc := scenario.KubectlSrc
+
+			paths, err := NewScenarioPaths("crane-audit-*")
+			Expect(err).NotTo(HaveOccurred())
+
+			DeferCleanup(func() {
+				By("Cleanup OLM resources on source")
+				for _, res := range []struct {
+					kind string
+					name string
+				}{
+					{"subscription", "olm-whiteout-subscription"},
+					{"catalogsource", "olm-whiteout-catalog"},
+					{"operatorgroup", "olm-whiteout-og"},
+				} {
+					if _, err := kubectlSrc.Run("delete", res.kind, res.name, "-n", namespace, "--ignore-not-found=true"); err != nil {
+						log.Printf("cleanup: failed to delete %s/%s: %v", res.kind, res.name, err)
+					}
+				}
+				By("Cleanup namespace and temp dir")
+				if _, err := kubectlSrc.Run("delete", "namespace", namespace, "--ignore-not-found=true"); err != nil {
+					log.Printf("cleanup: failed to delete namespace: %v", err)
+				}
+				if paths.TempDir != "" {
+					os.RemoveAll(paths.TempDir)
+				}
+			})
+
+			By("Create source namespace")
+			Expect(kubectlSrc.CreateNamespace(namespace)).NotTo(HaveOccurred())
+
+			By("Create OLM resources (OperatorGroup, CatalogSource, Subscription)")
+			olmSpec, err := utils.ReadTestdataFile("olm-resources.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			olmSpec = strings.ReplaceAll(olmSpec, "__NAMESPACE__", namespace)
+			Expect(kubectlSrc.ApplyYAMLSpec(olmSpec, namespace)).NotTo(HaveOccurred())
+
+			By("Create ConfigMap as non-OLM resource")
+			configMapSpec, err := utils.ReadTestdataFile("app-configmap.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(kubectlSrc.ApplyYAMLSpec(configMapSpec, namespace)).NotTo(HaveOccurred())
+
+			runner := scenario.Crane
+			runner.WorkDir = paths.TempDir
+
+			By("Run crane export")
+			Expect(runner.Export(namespace, paths.ExportDir)).NotTo(HaveOccurred())
+
+			By("Run crane transform")
+			Expect(runner.Transform(paths.ExportDir, paths.TransformDir)).NotTo(HaveOccurred())
+
+			olmKindsDeployed := []string{"Subscription", "CatalogSource", "OperatorGroup"}
+
+			By("Verify whiteout resource files exist in transform resources/ directory")
+			Expect(utils.AssertWhiteoutResourceFilesExist(paths.TransformDir, olmKindsDeployed)).NotTo(HaveOccurred())
+
+			By("Verify kustomization.yaml has whiteout comments for OLM kinds")
+			Expect(utils.AssertWhiteoutCommentsInKustomization(paths.TransformDir, olmKindsDeployed)).NotTo(HaveOccurred())
+
+			By("Verify OLM kinds are NOT in active kustomization.yaml resources list")
+			Expect(utils.AssertKindsNotInActiveKustomizeResources(paths.TransformDir, olmWhiteoutKinds)).NotTo(HaveOccurred())
+
+			By("Run crane apply")
+			Expect(runner.Apply(paths.ExportDir, paths.TransformDir, paths.OutputDir)).NotTo(HaveOccurred())
+
+			By("Verify output does not contain OLM whiteout kinds")
+			Expect(utils.AssertNoKindsInOutput(paths.OutputDir, olmWhiteoutKinds)).NotTo(HaveOccurred())
+
+			By("Verify output contains ConfigMap (non-OLM resource)")
+			Expect(utils.AssertKindsInOutput(paths.OutputDir, []string{"ConfigMap"})).NotTo(HaveOccurred())
 		})
 	})
 

--- a/e2e-tests/utils/utils.go
+++ b/e2e-tests/utils/utils.go
@@ -697,3 +697,140 @@ func shouldDropField(path []string, key string) bool {
 	}
 	return false
 }
+
+// AssertWhiteoutResourceFilesExist walks all stage resource directories under
+// transformDir and verifies that at least one resource file exists for each kind
+// in kinds. Resource filenames follow the convention Kind_group_version_namespace_name.yaml.
+func AssertWhiteoutResourceFilesExist(transformDir string, kinds []string) error {
+	found := make(map[string]bool)
+
+	err := filepath.Walk(transformDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, _ := filepath.Rel(transformDir, path)
+		if !strings.Contains(rel, "resources/") {
+			return nil
+		}
+		name := info.Name()
+		for _, kind := range kinds {
+			if strings.HasPrefix(name, kind+"_") || strings.HasPrefix(name, kind+".") {
+				found[kind] = true
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("walking transform dir: %w", err)
+	}
+
+	var missing []string
+	for _, kind := range kinds {
+		if !found[kind] {
+			missing = append(missing, kind)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("whiteout resource files missing from transform resources/ for kinds: %v", missing)
+	}
+	return nil
+}
+
+// AssertWhiteoutCommentsInKustomization finds all kustomization.yaml files under
+// transformDir and verifies that at least one contains a whiteout comment header
+// and commented references for each kind in kinds.
+func AssertWhiteoutCommentsInKustomization(transformDir string, kinds []string) error {
+	found := make(map[string]bool)
+	hasHeader := false
+
+	err := filepath.Walk(transformDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || info.Name() != "kustomization.yaml" {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		content := string(data)
+		lines := strings.Split(content, "\n")
+		for _, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "# Whiteout") {
+				hasHeader = true
+			}
+			if strings.HasPrefix(trimmed, "#") {
+				for _, kind := range kinds {
+					if strings.Contains(trimmed, kind+"_") || strings.Contains(trimmed, kind+".") {
+						found[kind] = true
+					}
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("walking transform dir: %w", err)
+	}
+
+	if !hasHeader {
+		return fmt.Errorf("no kustomization.yaml contains whiteout comment header (expected '# Whiteout ...')")
+	}
+
+	var missing []string
+	for _, kind := range kinds {
+		if !found[kind] {
+			missing = append(missing, kind)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("whiteout comments missing from kustomization.yaml for kinds: %v", missing)
+	}
+	return nil
+}
+
+// AssertKindsNotInActiveKustomizeResources parses all kustomization.yaml files under
+// transformDir and returns an error if any active (non-comment) resource entry
+// references a denied kind.
+func AssertKindsNotInActiveKustomizeResources(transformDir string, deniedKinds []string) error {
+	return filepath.Walk(transformDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || info.Name() != "kustomization.yaml" {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		lines := strings.Split(string(data), "\n")
+		inResources := false
+		for _, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "resources:" {
+				inResources = true
+				continue
+			}
+			if inResources && trimmed != "" && !strings.HasPrefix(trimmed, "-") && !strings.HasPrefix(trimmed, "#") {
+				inResources = false
+				continue
+			}
+			if !inResources || strings.HasPrefix(trimmed, "#") || trimmed == "" {
+				continue
+			}
+			for _, kind := range deniedKinds {
+				if strings.Contains(trimmed, kind+"_") || strings.Contains(trimmed, kind+".") {
+					return fmt.Errorf("kustomization.yaml %s has denied kind %q in active resources: %s", path, kind, trimmed)
+				}
+			}
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
 ## Summary
  - Added E2E test for transform-stage auditability of OLM whiteouts (tier1)
  - Test verifies whiteout resources exist as files in `resources/` for auditing, appear as comments in `kustomization.yaml`, are excluded from active resources list, and are absent from final `crane apply` output
  - Added 3 reusable assertion helpers in `e2e-tests/utils/`: `AssertWhiteoutResourceFilesExist`, `AssertWhiteoutCommentsInKustomization`, `AssertKindsNotInActiveKustomizeResources`

  ## Test plan
  - [x] `go build ./...` passes
  - [x] `go vet ./e2e-tests/...` passes
  - [x] Manually verified on minikube (`src`/`tgt` clusters with OLM CRDs): all 5 assertions pass against real crane pipeline output
  - [x] `ginkgo run -v --label-filter="olm && tier1" e2e-tests/tests -- --crane-bin=./crane --source-context=src --target-context=tgt`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite validating OLM whiteout artifact handling during the transform stage
  * Verifies whiteout resource files, kustomization configurations, and ensures OLM kinds are properly excluded from active resources
  * Enhanced test cleanup logic for namespace and temporary directory management

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/migtools/crane/pull/360)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->