### PR TITLE
Skip export of operator managed CRDs

### DIFF
--- a/cmd/export/crd.go
+++ b/cmd/export/crd.go
@@ -51,6 +51,36 @@ func crdFailureAPIResourceName(crdName string) string {
 	return "customresourcedefinition-" + strings.ReplaceAll(crdName, "/", "-")
 }
 
+// getOperatorManager checks if a CRD is managed by an operator.
+// Returns the manager name if detected, empty string otherwise.
+func getOperatorManager(obj *unstructured.Unstructured) string {
+	labels := obj.GetLabels()
+	annotations := obj.GetAnnotations()
+
+	if v, ok := labels["olm.managed"]; ok && v == "true" {
+		if name := labels["operators.coreos.com/managed-by"]; name != "" {
+			return "operator " + name + " (OLM)"
+		}
+		return "OLM"
+	}
+
+	if v, ok := labels["app.kubernetes.io/managed-by"]; ok && v != "" {
+		return v
+	}
+
+	for k := range annotations {
+		if strings.HasPrefix(k, "operators.operatorframework.io/") {
+			return "operator-framework"
+		}
+	}
+
+	if refs := obj.GetOwnerReferences(); len(refs) > 0 {
+		return refs[0].Kind + "/" + refs[0].Name
+	}
+
+	return ""
+}
+
 // collectRelatedCRDs returns synthetic groupResource rows for CRDs backing custom
 // API types that appear in resources (deduplicated by plural.group). Built-in API
 // groups are skipped. Failed GETs are returned as groupResourceError entries for
@@ -104,6 +134,12 @@ func collectRelatedCRDs(resources []*groupResource, dynamicClient dynamic.Interf
 			})
 			continue
 		}
+		
+		if manager := getOperatorManager(obj); manager != "" {
+			log.Warnf("Skipping CRD %q — managed by %s; install the operator on the target cluster instead", crdName, manager)
+			continue
+		}
+
 		log.Infof("exported CustomResourceDefinition %q for referenced custom resources", crdName)
 		out = append(out, &groupResource{
 			APIGroup:        crdGVR.Group,

--- a/cmd/export/crd_test.go
+++ b/cmd/export/crd_test.go
@@ -46,6 +46,26 @@ func crdUnstructured(name string) *unstructured.Unstructured {
 	return u
 }
 
+func crdWithLabels(name string, labels map[string]string) *unstructured.Unstructured {
+	u := crdUnstructured(name)
+	u.SetLabels(labels)
+	return u
+}
+
+func crdWithAnnotations(name string, annotations map[string]string) *unstructured.Unstructured {
+	u := crdUnstructured(name)
+	u.SetAnnotations(annotations)
+	return u
+}
+
+func crdWithOwnerRef(name, ownerKind, ownerName string) *unstructured.Unstructured {
+	u := crdUnstructured(name)
+	u.SetOwnerReferences([]metav1.OwnerReference{
+		{Kind: ownerKind, Name: ownerName, APIVersion: "v1"},
+	})
+	return u
+}
+
 func widgetGroupResource() *groupResource {
 	return &groupResource{
 		APIGroup:        "example.com",
@@ -231,5 +251,110 @@ func TestCollectRelatedCRDs_IncludeOverridesBuiltinGroup(t *testing.T) {
 	}
 	if got[0].objects.Items[0].GetName() != "routes.route.openshift.io" {
 		t.Fatalf("unexpected CRD object: %s", got[0].objects.Items[0].GetName())
+	}
+}
+
+func TestCollectRelatedCRDs_skipsOLMManagedCRD(t *testing.T) {
+	scheme := runtime.NewScheme()
+	crd := crdWithLabels("widgets.example.com", map[string]string{"olm.managed": "true"})
+	client := fake.NewSimpleDynamicClient(scheme, crd)
+	log := testLogger()
+
+	got, errs := collectRelatedCRDs([]*groupResource{widgetGroupResource()}, client, log, nil, nil)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected OLM-managed CRD to be skipped, got %d", len(got))
+	}
+}
+
+func TestCollectRelatedCRDs_skipsManagedByLabel(t *testing.T) {
+	scheme := runtime.NewScheme()
+	crd := crdWithLabels("widgets.example.com", map[string]string{"app.kubernetes.io/managed-by": "Helm"})
+	client := fake.NewSimpleDynamicClient(scheme, crd)
+	log := testLogger()
+
+	got, errs := collectRelatedCRDs([]*groupResource{widgetGroupResource()}, client, log, nil, nil)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected managed-by CRD to be skipped, got %d", len(got))
+	}
+}
+
+func TestCollectRelatedCRDs_skipsOperatorFrameworkAnnotation(t *testing.T) {
+	scheme := runtime.NewScheme()
+	crd := crdWithAnnotations("widgets.example.com", map[string]string{
+		"operators.operatorframework.io/builder": "operator-sdk-v1.28.0",
+	})
+	client := fake.NewSimpleDynamicClient(scheme, crd)
+	log := testLogger()
+
+	got, errs := collectRelatedCRDs([]*groupResource{widgetGroupResource()}, client, log, nil, nil)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected operator-framework CRD to be skipped, got %d", len(got))
+	}
+}
+
+func TestCollectRelatedCRDs_skipsOwnerReferenceCRD(t *testing.T) {
+	scheme := runtime.NewScheme()
+	crd := crdWithOwnerRef("widgets.example.com", "ClusterServiceVersion", "widget-operator.v1.0.0")
+	client := fake.NewSimpleDynamicClient(scheme, crd)
+	log := testLogger()
+
+	got, errs := collectRelatedCRDs([]*groupResource{widgetGroupResource()}, client, log, nil, nil)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected owner-referenced CRD to be skipped, got %d", len(got))
+	}
+}
+
+func TestCollectRelatedCRDs_exportsUnmanagedCRD(t *testing.T) {
+	scheme := runtime.NewScheme()
+	crd := crdUnstructured("widgets.example.com")
+	client := fake.NewSimpleDynamicClient(scheme, crd)
+	log := testLogger()
+
+	got, errs := collectRelatedCRDs([]*groupResource{widgetGroupResource()}, client, log, nil, nil)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected unmanaged CRD to be exported, got %d", len(got))
+	}
+}
+
+func TestGetOperatorManager(t *testing.T) {
+	tests := []struct {
+		name     string
+		obj      *unstructured.Unstructured
+		wantEmpty bool
+	}{
+		{"no labels or annotations", crdUnstructured("test"), true},
+		{"olm.managed label", crdWithLabels("test", map[string]string{"olm.managed": "true"}), false},
+		{"managed-by label", crdWithLabels("test", map[string]string{"app.kubernetes.io/managed-by": "Helm"}), false},
+		{"operator-framework annotation", crdWithAnnotations("test", map[string]string{"operators.operatorframework.io/builder": "sdk"}), false},
+		{"owner reference", crdWithOwnerRef("test", "CSV", "my-operator"), false},
+		{"olm.managed=false", crdWithLabels("test", map[string]string{"olm.managed": "false"}), true},
+		{"unrelated labels", crdWithLabels("test", map[string]string{"app": "myapp"}), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getOperatorManager(tt.obj)
+			if tt.wantEmpty && got != "" {
+				t.Fatalf("expected empty manager, got %q", got)
+			}
+			if !tt.wantEmpty && got == "" {
+				t.Fatal("expected non-empty manager, got empty")
+			}
+		})
 	}
 }


### PR DESCRIPTION
 ## Summary

  Skip export of CRDs that are managed by an operator. Operator-managed CRDs should be installed on the target cluster via their operator, not exported and applied directly — doing so creates orphaned CRDs that conflict
  when the operator is later installed.

  ## What changed
  
  Added `getOperatorManager()` in `cmd/export/crd.go` that checks four well-known operator markers on each CRD before exporting:
  
  - `olm.managed=true` label (OLM on OpenShift and K8s)
  - `app.kubernetes.io/managed-by` label (Helm, operator-sdk, ArgoCD, etc.)
  - `operators.operatorframework.io/*` annotations (operator-framework)
  - `ownerReferences` (CRD owned by a ClusterServiceVersion or operator Deployment)
  
  If any marker is detected, the CRD is skipped with a warning:
  
      Skipping CRD widgets.example.com — managed by operator cert-manager (OLM); install the operator on the target cluster instead

  CR instances are still exported normally — only the CRD definition is skipped. Unmanaged (standalone) CRDs continue to be exported as before.

  ## Test plan
  
  - [x] `go build ./...`
  - [x] All existing CRD export tests pass (7 tests)
  - [x] 5 new tests: skip OLM-managed, skip managed-by label, skip operator-framework annotation, skip owner-referenced, export unmanaged CRD
  - [x] 7 new `TestGetOperatorManager` sub-tests covering all marker combinations including negative cases (`olm.managed=false`, unrelated labels)
  - [x] Full unit test suite passes (`go test ./...` excluding e2e)