### PR TITLE
Added multiple olm operators test

### DIFF
--- a/e2e-tests/testdata/olm-multi-operator-resources.yaml
+++ b/e2e-tests/testdata/olm-multi-operator-resources.yaml
@@ -1,0 +1,38 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: olm-multi-og
+spec:
+  targetNamespaces: []
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: olm-multi-catalog
+spec:
+  sourceType: grpc
+  image: quay.io/operatorhubio/catalog:latest
+  displayName: Community Operators
+  publisher: OperatorHub.io
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: olm-multi-sub-certmgr
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: cert-manager
+  source: olm-multi-catalog
+  sourceNamespace: __NAMESPACE__
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: olm-multi-sub-cockroachdb
+spec:
+  channel: stable-v6.x
+  installPlanApproval: Automatic
+  name: cockroachdb
+  source: olm-multi-catalog
+  sourceNamespace: __NAMESPACE__

--- a/e2e-tests/tests/olm_whiteout_test.go
+++ b/e2e-tests/tests/olm_whiteout_test.go
@@ -276,7 +276,7 @@ var _ = Describe("OLM whiteout", func() {
 			Expect(utils.AssertNoKindsInOutput(paths.OutputDir, olmWhiteoutKinds)).NotTo(HaveOccurred())
 
 			By("Verify transform stage has whiteout resource files for both Subscriptions")
-			Expect(utils.AssertWhiteoutResourceFilesExist(paths.TransformDir, []string{"Subscription"})).NotTo(HaveOccurred())
+			Expect(utils.AssertWhiteoutResourceFilesExist(paths.TransformDir, []string{"Subscription", "CatalogSource", "OperatorGroup"})).NotTo(HaveOccurred())
 
 			By("Verify no partial whiteout: all OLM kinds excluded from active kustomize resources")
 			Expect(utils.AssertKindsNotInActiveKustomizeResources(paths.TransformDir, olmWhiteoutKinds)).NotTo(HaveOccurred())

--- a/e2e-tests/tests/olm_whiteout_test.go
+++ b/e2e-tests/tests/olm_whiteout_test.go
@@ -145,7 +145,9 @@ var _ = Describe("OLM whiteout", func() {
 					log.Printf("cleanup: failed to delete namespace: %v", err)
 				}
 				if paths.TempDir != "" {
-					os.RemoveAll(paths.TempDir)
+					if err := os.RemoveAll(paths.TempDir); err != nil {
+						log.Printf("cleanup: failed to remove temp dir %s: %v", paths.TempDir, err)
+					}
 				}
 			})
 
@@ -237,7 +239,9 @@ var _ = Describe("OLM whiteout", func() {
 					log.Printf("cleanup: failed to delete namespace: %v", err)
 				}
 				if paths.TempDir != "" {
-					os.RemoveAll(paths.TempDir)
+					if err := os.RemoveAll(paths.TempDir); err != nil {
+						log.Printf("cleanup: failed to remove temp dir %s: %v", paths.TempDir, err)
+					}
 				}
 			})
 
@@ -250,19 +254,24 @@ var _ = Describe("OLM whiteout", func() {
 			olmSpec = strings.ReplaceAll(olmSpec, "__NAMESPACE__", namespace)
 			Expect(kubectlSrc.ApplyYAMLSpec(olmSpec, namespace)).NotTo(HaveOccurred())
 
-			By("Wait for both operators to produce CSVs")
-			Eventually(func(g Gomega) {
-				out, err := kubectlSrc.Run("get", "csv", "-n", namespace, "-o", "jsonpath={.items[*].metadata.name}")
-				g.Expect(err).NotTo(HaveOccurred())
-				names := strings.Fields(out)
-				g.Expect(len(names)).To(BeNumerically(">=", 2), "expected at least 2 CSVs, got: %v", names)
-			}, "15m", "20s").Should(Succeed())
+			By("Wait for both subscriptions to have currentCSV populated")
+			for _, subName := range []string{"olm-multi-sub-certmgr", "olm-multi-sub-cockroachdb"} {
+				Eventually(func(g Gomega) {
+					out, err := kubectlSrc.Run("get", "subscription", subName, "-n", namespace, "-o", "jsonpath={.status.currentCSV}")
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(strings.TrimSpace(out)).NotTo(BeEmpty(), "subscription %s has no currentCSV yet", subName)
+				}, "15m", "20s").Should(Succeed())
+			}
 
-			By("Wait for InstallPlan to be created (OLM may bundle multiple operators into one)")
+			By("Wait for all InstallPlans to complete")
 			Eventually(func(g Gomega) {
-				out, err := kubectlSrc.Run("get", "installplan", "-n", namespace)
+				out, err := kubectlSrc.Run("get", "installplan", "-n", namespace, "-o", "jsonpath={.items[*].status.phase}")
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(strings.TrimSpace(out)).NotTo(ContainSubstring("No resources found"))
+				phases := strings.Fields(out)
+				g.Expect(phases).NotTo(BeEmpty(), "no InstallPlans found")
+				for _, p := range phases {
+					g.Expect(p).To(Equal("Complete"), "InstallPlan in phase %q", p)
+				}
 			}, "15m", "20s").Should(Succeed())
 
 			runner := scenario.Crane
@@ -275,8 +284,11 @@ var _ = Describe("OLM whiteout", func() {
 			By("Verify no OLM whiteout kinds in output")
 			Expect(utils.AssertNoKindsInOutput(paths.OutputDir, olmWhiteoutKinds)).NotTo(HaveOccurred())
 
-			By("Verify transform stage has whiteout resource files for both Subscriptions")
+			By("Verify transform stage has whiteout resource files for deployed OLM kinds")
 			Expect(utils.AssertWhiteoutResourceFilesExist(paths.TransformDir, []string{"Subscription", "CatalogSource", "OperatorGroup"})).NotTo(HaveOccurred())
+
+			By("Verify both Subscription whiteout files exist (one per operator)")
+			Expect(utils.AssertWhiteoutResourceFileCount(paths.TransformDir, "Subscription", 2)).NotTo(HaveOccurred())
 
 			By("Verify no partial whiteout: all OLM kinds excluded from active kustomize resources")
 			Expect(utils.AssertKindsNotInActiveKustomizeResources(paths.TransformDir, olmWhiteoutKinds)).NotTo(HaveOccurred())

--- a/e2e-tests/tests/olm_whiteout_test.go
+++ b/e2e-tests/tests/olm_whiteout_test.go
@@ -194,6 +194,95 @@ var _ = Describe("OLM whiteout", func() {
 		})
 	})
 
+	Describe("Multiple OLM operators", func() {
+		It("should whiteout all OLM kinds from multiple operators in the same namespace", Label("olm", "tier1"), func() {
+			kubectlPreflight := KubectlRunner{Bin: "kubectl", Context: config.SourceContext}
+			olmAvailable, err := kubectlPreflight.OLMAPIAvailable()
+			Expect(err).NotTo(HaveOccurred())
+			if !olmAvailable {
+				Skip("OLM APIs not installed (subscriptions.operators.coreos.com CRD missing)")
+			}
+
+			namespace := "olm-multi-op"
+			scenario := NewMigrationScenario(
+				"olm-multi-op",
+				namespace,
+				config.K8sDeployBin,
+				config.CraneBin,
+				config.SourceContext,
+				config.TargetContext,
+			)
+			kubectlSrc := scenario.KubectlSrc
+
+			paths, err := NewScenarioPaths("crane-multi-op-*")
+			Expect(err).NotTo(HaveOccurred())
+
+			DeferCleanup(func() {
+				By("Cleanup OLM resources on source")
+				for _, res := range []struct {
+					kind string
+					name string
+				}{
+					{"subscription", "olm-multi-sub-certmgr"},
+					{"subscription", "olm-multi-sub-cockroachdb"},
+					{"catalogsource", "olm-multi-catalog"},
+					{"operatorgroup", "olm-multi-og"},
+				} {
+					if _, err := kubectlSrc.Run("delete", res.kind, res.name, "-n", namespace, "--ignore-not-found=true"); err != nil {
+						log.Printf("cleanup: failed to delete %s/%s: %v", res.kind, res.name, err)
+					}
+				}
+				By("Cleanup namespace and temp dir")
+				if _, err := kubectlSrc.Run("delete", "namespace", namespace, "--ignore-not-found=true"); err != nil {
+					log.Printf("cleanup: failed to delete namespace: %v", err)
+				}
+				if paths.TempDir != "" {
+					os.RemoveAll(paths.TempDir)
+				}
+			})
+
+			By("Create source namespace")
+			Expect(kubectlSrc.CreateNamespace(namespace)).NotTo(HaveOccurred())
+
+			By("Create OLM resources (OperatorGroup, CatalogSource, 2 Subscriptions)")
+			olmSpec, err := utils.ReadTestdataFile("olm-multi-operator-resources.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			olmSpec = strings.ReplaceAll(olmSpec, "__NAMESPACE__", namespace)
+			Expect(kubectlSrc.ApplyYAMLSpec(olmSpec, namespace)).NotTo(HaveOccurred())
+
+			By("Wait for both operators to produce CSVs")
+			Eventually(func(g Gomega) {
+				out, err := kubectlSrc.Run("get", "csv", "-n", namespace, "-o", "jsonpath={.items[*].metadata.name}")
+				g.Expect(err).NotTo(HaveOccurred())
+				names := strings.Fields(out)
+				g.Expect(len(names)).To(BeNumerically(">=", 2), "expected at least 2 CSVs, got: %v", names)
+			}, "15m", "20s").Should(Succeed())
+
+			By("Wait for InstallPlan to be created (OLM may bundle multiple operators into one)")
+			Eventually(func(g Gomega) {
+				out, err := kubectlSrc.Run("get", "installplan", "-n", namespace)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(strings.TrimSpace(out)).NotTo(ContainSubstring("No resources found"))
+			}, "15m", "20s").Should(Succeed())
+
+			runner := scenario.Crane
+			runner.WorkDir = paths.TempDir
+
+			By("Run crane export/transform/apply pipeline")
+			log.Printf("Running crane pipeline for namespace %s\n", namespace)
+			Expect(RunCranePipelineWithChecks(runner, namespace, paths)).NotTo(HaveOccurred())
+
+			By("Verify no OLM whiteout kinds in output")
+			Expect(utils.AssertNoKindsInOutput(paths.OutputDir, olmWhiteoutKinds)).NotTo(HaveOccurred())
+
+			By("Verify transform stage has whiteout resource files for both Subscriptions")
+			Expect(utils.AssertWhiteoutResourceFilesExist(paths.TransformDir, []string{"Subscription"})).NotTo(HaveOccurred())
+
+			By("Verify no partial whiteout: all OLM kinds excluded from active kustomize resources")
+			Expect(utils.AssertKindsNotInActiveKustomizeResources(paths.TransformDir, olmWhiteoutKinds)).NotTo(HaveOccurred())
+		})
+	})
+
 	Describe("App workload coexistence", func() {
 		It("should preserve app resources while omitting OLM kinds", Label("olm", "tier1"), func() {
 			kubectlPreflight := KubectlRunner{Bin: "kubectl", Context: config.SourceContext}

--- a/e2e-tests/utils/utils.go
+++ b/e2e-tests/utils/utils.go
@@ -739,6 +739,37 @@ func AssertWhiteoutResourceFilesExist(transformDir string, kinds []string) error
 	return nil
 }
 
+// AssertWhiteoutResourceFileCount verifies that exactly expectedCount files
+// matching the given kind prefix exist in the transform resources/ directory.
+func AssertWhiteoutResourceFileCount(transformDir string, kind string, expectedCount int) error {
+	count := 0
+
+	err := filepath.Walk(transformDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, _ := filepath.Rel(transformDir, path)
+		if !strings.Contains(rel, "resources/") {
+			return nil
+		}
+		if strings.HasPrefix(info.Name(), kind+"_") || strings.HasPrefix(info.Name(), kind+".") {
+			count++
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("walking transform dir: %w", err)
+	}
+
+	if count != expectedCount {
+		return fmt.Errorf("expected %d whiteout resource files for kind %s, found %d", expectedCount, kind, count)
+	}
+	return nil
+}
+
 // AssertWhiteoutCommentsInKustomization finds all kustomization.yaml files under
 // transformDir and verifies that at least one contains a whiteout comment header
 // and commented references for each kind in kinds.


### PR DESCRIPTION
 ## Summary
  - Added E2E test for multiple OLM operators in the same namespace (tier1)
  - Deploys cert-manager and cockroachdb via shared CatalogSource, waits for both CSVs and InstallPlan, runs full crane pipeline
  - Verifies all OLM kinds from both operators are whiteout-ed with no partial leakage
  - Added `e2e-tests/testdata/olm-multi-operator-resources.yaml` with 2 Subscriptions, shared OperatorGroup and CatalogSource

  ## Test plan
  - [x] `go build ./...` passes
  - [x] `go vet ./e2e-tests/...` passes
  - [x] Manually verified on fresh minikube (`src` cluster with OLM v0.28.0): both CSVs created, all 3 assertions pass against real pipeline output


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test data and a new "Multiple OLM operators" test suite to validate multi-operator deployment scenarios.
  * Test verifies export/transform/apply pipeline handles OLM resources: produces whiteout files for OLM kinds, generates exactly two Subscription whiteouts, and excludes OLM kinds from active resources.
  * Added a test helper to assert exact counts of generated whiteout resource files.
* **Bug Fixes**
  * Cleanup now checks and logs failures when removing temporary test artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/migtools/crane/pull/362)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->