### PR TITLE
Add required tests for cluster-scoped resources in transform

### DIFF
--- a/internal/transform/orchestrator_test.go
+++ b/internal/transform/orchestrator_test.go
@@ -1597,3 +1597,234 @@ resources:
 	t.Log("✓ Error messages include contextual information")
 	t.Log("✓ Single stage executes successfully")
 }
+
+// TestMultiStage_ClusterScopedResources verifies that cluster-scoped resources
+// flow correctly through a multi-stage pipeline: each stage's input/output
+// preserves _cluster/ separation, and kustomization.yaml handles them correctly.
+func TestMultiStage_ClusterScopedResources(t *testing.T) {
+	if !hasKustomizeCommand(t) {
+		t.Skip("kubectl/oc not available, skipping multi-stage cluster-scoped test")
+	}
+
+	tmpDir, err := os.MkdirTemp("", "multistage-cluster-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	exportDir := filepath.Join(tmpDir, "export")
+	transformDir := filepath.Join(tmpDir, "transform")
+
+	// Create export directory with mixed resources:
+	// - namespaced Deployment in my-app/
+	// - cluster-scoped ClusterRole in _cluster/
+	nsDir := filepath.Join(exportDir, "my-app")
+	clusterDir := filepath.Join(exportDir, "_cluster")
+	if err := os.MkdirAll(nsDir, 0700); err != nil {
+		t.Fatalf("Failed to create ns dir: %v", err)
+	}
+	if err := os.MkdirAll(clusterDir, 0700); err != nil {
+		t.Fatalf("Failed to create cluster dir: %v", err)
+	}
+
+	deploymentYAML := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: my-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+      - name: web
+        image: nginx:1.21
+`
+	clusterRoleYAML := `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: web-reader
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+`
+	clusterRoleBindingYAML := `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: web-reader-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: web-reader
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: my-app
+`
+
+	if err := os.WriteFile(filepath.Join(nsDir, "deployment.yaml"), []byte(deploymentYAML), 0644); err != nil {
+		t.Fatalf("Failed to write deployment: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(clusterDir, "clusterrole.yaml"), []byte(clusterRoleYAML), 0644); err != nil {
+		t.Fatalf("Failed to write clusterrole: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(clusterDir, "clusterrolebinding.yaml"), []byte(clusterRoleBindingYAML), 0644); err != nil {
+		t.Fatalf("Failed to write clusterrolebinding: %v", err)
+	}
+
+	// Create two pass-through stages (no plugins)
+	for _, stageName := range []string{"10_stage1", "20_stage2"} {
+		stageDir := filepath.Join(transformDir, stageName)
+		stageResourcesDir := filepath.Join(stageDir, "resources")
+		if err := os.MkdirAll(stageResourcesDir, 0700); err != nil {
+			t.Fatalf("Failed to create %s resources dir: %v", stageName, err)
+		}
+		// Placeholder kustomization that will be overwritten by the orchestrator
+		kustomization := `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []
+`
+		if err := os.WriteFile(filepath.Join(stageDir, "kustomization.yaml"), []byte(kustomization), 0644); err != nil {
+			t.Fatalf("Failed to write %s kustomization: %v", stageName, err)
+		}
+	}
+
+	// Also write the actual resources into stage 1 so kustomize can build them on first pass
+	stage1Dir := filepath.Join(transformDir, "10_stage1")
+	stage1Resources := filepath.Join(stage1Dir, "resources")
+	if err := os.WriteFile(filepath.Join(stage1Resources, "Deployment_apps_v1_my-app_web.yaml"), []byte(deploymentYAML), 0644); err != nil {
+		t.Fatalf("Failed to write stage1 deployment: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stage1Resources, "ClusterRole_rbac.authorization.k8s.io_v1_clusterscoped_web-reader.yaml"), []byte(clusterRoleYAML), 0644); err != nil {
+		t.Fatalf("Failed to write stage1 clusterrole: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stage1Resources, "ClusterRoleBinding_rbac.authorization.k8s.io_v1_clusterscoped_web-reader-binding.yaml"), []byte(clusterRoleBindingYAML), 0644); err != nil {
+		t.Fatalf("Failed to write stage1 clusterrolebinding: %v", err)
+	}
+
+	// Overwrite stage 1 kustomization with actual resource references
+	stage1Kustomization := `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- resources/Deployment_apps_v1_my-app_web.yaml
+- resources/ClusterRole_rbac.authorization.k8s.io_v1_clusterscoped_web-reader.yaml
+- resources/ClusterRoleBinding_rbac.authorization.k8s.io_v1_clusterscoped_web-reader-binding.yaml
+`
+	if err := os.WriteFile(filepath.Join(stage1Dir, "kustomization.yaml"), []byte(stage1Kustomization), 0644); err != nil {
+		t.Fatalf("Failed to write stage1 kustomization: %v", err)
+	}
+
+	// Run multi-stage pipeline
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	o := &Orchestrator{
+		Log:          logger,
+		ExportDir:    exportDir,
+		TransformDir: transformDir,
+		PluginDir:    "/nonexistent",
+		Force:        true,
+	}
+
+	selector := StageSelector{} // Run all stages
+	if err := o.RunMultiStage(selector); err != nil {
+		t.Fatalf("RunMultiStage failed: %v", err)
+	}
+
+	opts := file.PathOpts{
+		TransformDir: transformDir,
+		ExportDir:    exportDir,
+	}
+
+	// === Stage 1 output verification ===
+	stage1OutputDir := opts.GetStageOutputDir("10_stage1")
+
+	// Namespaced resource should be under my-app/
+	stage1NsFiles, _ := filepath.Glob(filepath.Join(stage1OutputDir, "my-app", "Deployment_*_web.yaml"))
+	if len(stage1NsFiles) == 0 {
+		t.Errorf("Stage 1 output: Deployment should be under my-app/ in %s", stage1OutputDir)
+	}
+
+	// Cluster-scoped resources should be under _cluster/
+	stage1ClusterRoles, _ := filepath.Glob(filepath.Join(stage1OutputDir, "_cluster", "ClusterRole_*_web-reader.yaml"))
+	if len(stage1ClusterRoles) == 0 {
+		t.Errorf("Stage 1 output: ClusterRole should be under _cluster/ in %s", stage1OutputDir)
+	}
+	stage1ClusterBindings, _ := filepath.Glob(filepath.Join(stage1OutputDir, "_cluster", "ClusterRoleBinding_*_web-reader-binding.yaml"))
+	if len(stage1ClusterBindings) == 0 {
+		t.Errorf("Stage 1 output: ClusterRoleBinding should be under _cluster/ in %s", stage1OutputDir)
+	}
+
+	// === Stage 2 input verification (should match stage 1 output) ===
+	stage2InputDir := opts.GetStageInputDir("20_stage2")
+
+	stage2InputNs, _ := filepath.Glob(filepath.Join(stage2InputDir, "my-app", "Deployment_*_web.yaml"))
+	if len(stage2InputNs) == 0 {
+		t.Errorf("Stage 2 input: should contain Deployment from stage 1 output under my-app/")
+	}
+	stage2InputCluster, _ := filepath.Glob(filepath.Join(stage2InputDir, "_cluster", "ClusterRole_*_web-reader.yaml"))
+	if len(stage2InputCluster) == 0 {
+		t.Errorf("Stage 2 input: should contain ClusterRole from stage 1 output under _cluster/")
+	}
+
+	// === Stage 2 transform artifacts verification ===
+	stage2Dir := filepath.Join(transformDir, "20_stage2")
+
+	// Read kustomization.yaml and verify cluster-scoped resources are listed
+	stage2KustData, err := os.ReadFile(filepath.Join(stage2Dir, "kustomization.yaml"))
+	if err != nil {
+		t.Fatalf("Failed to read stage 2 kustomization.yaml: %v", err)
+	}
+	stage2KustStr := string(stage2KustData)
+
+	if !strings.Contains(stage2KustStr, "ClusterRole") {
+		t.Errorf("Stage 2 kustomization.yaml should reference ClusterRole resources")
+	}
+	if !strings.Contains(stage2KustStr, "Deployment") {
+		t.Errorf("Stage 2 kustomization.yaml should reference Deployment resources")
+	}
+
+	// === Stage 2 output verification ===
+	stage2OutputDir := opts.GetStageOutputDir("20_stage2")
+
+	stage2OutNs, _ := filepath.Glob(filepath.Join(stage2OutputDir, "my-app", "Deployment_*_web.yaml"))
+	if len(stage2OutNs) == 0 {
+		t.Errorf("Stage 2 output: Deployment should be under my-app/")
+	}
+	stage2OutCluster, _ := filepath.Glob(filepath.Join(stage2OutputDir, "_cluster", "ClusterRole_*_web-reader.yaml"))
+	if len(stage2OutCluster) == 0 {
+		t.Errorf("Stage 2 output: ClusterRole should be under _cluster/")
+	}
+	stage2OutBinding, _ := filepath.Glob(filepath.Join(stage2OutputDir, "_cluster", "ClusterRoleBinding_*_web-reader-binding.yaml"))
+	if len(stage2OutBinding) == 0 {
+		t.Errorf("Stage 2 output: ClusterRoleBinding should be under _cluster/")
+	}
+
+	// === Verify resource content survived both stages ===
+	if len(stage2OutCluster) > 0 {
+		data, err := os.ReadFile(stage2OutCluster[0])
+		if err != nil {
+			t.Fatalf("Failed to read stage 2 ClusterRole output: %v", err)
+		}
+		content := string(data)
+		if !strings.Contains(content, "web-reader") {
+			t.Errorf("ClusterRole content should contain 'web-reader' after two stages")
+		}
+		if !strings.Contains(content, "pods") {
+			t.Errorf("ClusterRole rules should still reference 'pods' after two stages")
+		}
+	}
+
+	t.Log("✓ Stage 1 output: namespaced resources under my-app/, cluster-scoped under _cluster/")
+	t.Log("✓ Stage 2 input: correctly loaded from stage 1 output with _cluster/ separation")
+	t.Log("✓ Stage 2 kustomization.yaml: includes both namespaced and cluster-scoped resources")
+	t.Log("✓ Stage 2 output: all resources preserved with correct directory structure")
+	t.Log("✓ Resource content: ClusterRole rules survived two pipeline stages")
+}

--- a/internal/transform/writer_integration_test.go
+++ b/internal/transform/writer_integration_test.go
@@ -3,6 +3,7 @@ package transform
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	jsonpatch "github.com/evanphx/json-patch"
@@ -115,5 +116,547 @@ func TestWriteStageWithNonExistentRemovePath(t *testing.T) {
 	kustomizationPath := filepath.Join(transformDir, stageName, "kustomization.yaml")
 	if _, err := os.Stat(kustomizationPath); os.IsNotExist(err) {
 		t.Errorf("kustomization.yaml not created")
+	}
+}
+
+func TestWriteStage_ClusterScopedResources(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "crane-writer-cluster-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	transformDir := filepath.Join(tmpDir, "transform")
+	stageName := "10_test"
+
+	clusterRole := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "rbac.authorization.k8s.io/v1",
+			"kind":       "ClusterRole",
+			"metadata": map[string]interface{}{
+				"name": "test-reader",
+			},
+			"rules": []interface{}{
+				map[string]interface{}{
+					"apiGroups": []interface{}{""},
+					"resources": []interface{}{"pods"},
+					"verbs":     []interface{}{"get", "list"},
+				},
+			},
+		},
+	}
+
+	clusterRoleBinding := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "rbac.authorization.k8s.io/v1",
+			"kind":       "ClusterRoleBinding",
+			"metadata": map[string]interface{}{
+				"name": "test-reader-binding",
+			},
+			"roleRef": map[string]interface{}{
+				"apiGroup": "rbac.authorization.k8s.io",
+				"kind":     "ClusterRole",
+				"name":     "test-reader",
+			},
+			"subjects": []interface{}{
+				map[string]interface{}{
+					"kind":      "ServiceAccount",
+					"name":      "test-sa",
+					"namespace": "my-app",
+				},
+			},
+		},
+	}
+
+	artifacts := []cranelib.TransformArtifact{
+		{
+			Resource:     clusterRole,
+			HaveWhiteOut: false,
+			Target:       cranelib.DeriveTargetFromResource(clusterRole),
+			PluginName:   "test-plugin",
+		},
+		{
+			Resource:     clusterRoleBinding,
+			HaveWhiteOut: false,
+			Target:       cranelib.DeriveTargetFromResource(clusterRoleBinding),
+			PluginName:   "test-plugin",
+		},
+	}
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	opts := file.PathOpts{TransformDir: transformDir}
+	writer := NewKustomizeWriter(opts, stageName, logger)
+
+	if err := writer.WriteStage(artifacts, false); err != nil {
+		t.Fatalf("WriteStage failed: %v", err)
+	}
+
+	// Verify resource files use "clusterscoped" in filename
+	resourcesDir := filepath.Join(transformDir, stageName, "resources")
+	entries, err := os.ReadDir(resourcesDir)
+	if err != nil {
+		t.Fatalf("Failed to read resources dir: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("Expected 2 resource files, got %d", len(entries))
+	}
+	for _, entry := range entries {
+		if !strings.Contains(entry.Name(), "clusterscoped") {
+			t.Errorf("Expected 'clusterscoped' in filename, got: %s", entry.Name())
+		}
+	}
+
+	// Verify kustomization.yaml lists resources and patch targets omit namespace
+	kustomizationPath := filepath.Join(transformDir, stageName, "kustomization.yaml")
+	kData, err := os.ReadFile(kustomizationPath)
+	if err != nil {
+		t.Fatalf("Failed to read kustomization.yaml: %v", err)
+	}
+	kStr := string(kData)
+
+	if !strings.Contains(kStr, "ClusterRole_rbac.authorization.k8s.io_v1_clusterscoped_test-reader.yaml") {
+		t.Error("kustomization.yaml missing ClusterRole resource reference")
+	}
+	if !strings.Contains(kStr, "ClusterRoleBinding_rbac.authorization.k8s.io_v1_clusterscoped_test-reader-binding.yaml") {
+		t.Error("kustomization.yaml missing ClusterRoleBinding resource reference")
+	}
+	// Cluster-scoped patch targets must not have namespace
+	if strings.Contains(kStr, "namespace:") {
+		t.Error("kustomization.yaml should not contain 'namespace:' for cluster-scoped resources")
+	}
+}
+
+func TestWriteStage_MixedNamespacedAndClusterScoped(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "crane-writer-mixed-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	transformDir := filepath.Join(tmpDir, "transform")
+	stageName := "10_test"
+
+	deployment := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":      "web",
+				"namespace": "my-app",
+			},
+			"spec": map[string]interface{}{
+				"replicas": int64(1),
+			},
+		},
+	}
+
+	clusterRole := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "rbac.authorization.k8s.io/v1",
+			"kind":       "ClusterRole",
+			"metadata": map[string]interface{}{
+				"name": "web-admin",
+			},
+			"rules": []interface{}{
+				map[string]interface{}{
+					"apiGroups": []interface{}{""},
+					"resources": []interface{}{"pods"},
+					"verbs":     []interface{}{"get"},
+				},
+			},
+		},
+	}
+
+	patchJSON := `[{"op": "remove", "path": "/spec/replicas"}]`
+	deployPatches, _ := jsonpatch.DecodePatch([]byte(patchJSON))
+
+	clusterPatchJSON := `[{"op": "add", "path": "/metadata/labels", "value": {"migrated": "true"}}]`
+	clusterPatches, _ := jsonpatch.DecodePatch([]byte(clusterPatchJSON))
+
+	artifacts := []cranelib.TransformArtifact{
+		{
+			Resource:     deployment,
+			HaveWhiteOut: false,
+			Patches:      deployPatches,
+			Target:       cranelib.DeriveTargetFromResource(deployment),
+			PluginName:   "test-plugin",
+		},
+		{
+			Resource:     clusterRole,
+			HaveWhiteOut: false,
+			Patches:      clusterPatches,
+			Target:       cranelib.DeriveTargetFromResource(clusterRole),
+			PluginName:   "test-plugin",
+		},
+	}
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	opts := file.PathOpts{TransformDir: transformDir}
+	writer := NewKustomizeWriter(opts, stageName, logger)
+
+	if err := writer.WriteStage(artifacts, false); err != nil {
+		t.Fatalf("WriteStage failed: %v", err)
+	}
+
+	// Verify both resource files exist
+	resourcesDir := filepath.Join(transformDir, stageName, "resources")
+	entries, err := os.ReadDir(resourcesDir)
+	if err != nil {
+		t.Fatalf("Failed to read resources dir: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("Expected 2 resource files, got %d", len(entries))
+	}
+
+	// Verify patch files: namespaced has namespace prefix, cluster-scoped does not
+	patchesDir := filepath.Join(transformDir, stageName, "patches")
+	patchEntries, err := os.ReadDir(patchesDir)
+	if err != nil {
+		t.Fatalf("Failed to read patches dir: %v", err)
+	}
+	if len(patchEntries) != 2 {
+		t.Fatalf("Expected 2 patch files, got %d", len(patchEntries))
+	}
+
+	foundNamespacedPatch := false
+	foundClusterPatch := false
+	for _, entry := range patchEntries {
+		if strings.HasPrefix(entry.Name(), "my-app--") {
+			foundNamespacedPatch = true
+		}
+		if strings.HasPrefix(entry.Name(), "rbac.authorization.k8s.io-v1--ClusterRole") {
+			foundClusterPatch = true
+		}
+	}
+	if !foundNamespacedPatch {
+		t.Error("Missing namespaced patch file with namespace prefix")
+	}
+	if !foundClusterPatch {
+		t.Error("Missing cluster-scoped patch file without namespace prefix")
+	}
+
+	// Verify kustomization.yaml has both namespaced and cluster-scoped targets
+	kData, err := os.ReadFile(filepath.Join(transformDir, stageName, "kustomization.yaml"))
+	if err != nil {
+		t.Fatalf("Failed to read kustomization.yaml: %v", err)
+	}
+	kStr := string(kData)
+
+	if !strings.Contains(kStr, "namespace: my-app") {
+		t.Error("kustomization.yaml missing 'namespace: my-app' for namespaced Deployment")
+	}
+
+	// Check that ClusterRole target does not have namespace
+	// The ClusterRole section should have kind+name but no namespace
+	lines := strings.Split(kStr, "\n")
+	inClusterRoleTarget := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "kind: ClusterRole" {
+			inClusterRoleTarget = true
+		}
+		if inClusterRoleTarget && strings.HasPrefix(trimmed, "namespace:") {
+			t.Error("ClusterRole patch target should not have 'namespace:' field")
+			break
+		}
+		if inClusterRoleTarget && trimmed == "" {
+			break
+		}
+	}
+}
+
+func TestWriteStage_ClusterScopedWhiteout(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "crane-writer-whiteout-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	transformDir := filepath.Join(tmpDir, "transform")
+	stageName := "10_test"
+
+	clusterRole := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "rbac.authorization.k8s.io/v1",
+			"kind":       "ClusterRole",
+			"metadata": map[string]interface{}{
+				"name": "whiteout-role",
+			},
+			"rules": []interface{}{},
+		},
+	}
+
+	artifacts := []cranelib.TransformArtifact{
+		{
+			Resource:     clusterRole,
+			HaveWhiteOut: true,
+			Target:       cranelib.DeriveTargetFromResource(clusterRole),
+			PluginName:   "test-plugin",
+		},
+	}
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	opts := file.PathOpts{TransformDir: transformDir}
+	writer := NewKustomizeWriter(opts, stageName, logger)
+
+	if err := writer.WriteStage(artifacts, false); err != nil {
+		t.Fatalf("WriteStage failed: %v", err)
+	}
+
+	// Verify resource file is written to disk
+	resourceFile := filepath.Join(transformDir, stageName, "resources",
+		"ClusterRole_rbac.authorization.k8s.io_v1_clusterscoped_whiteout-role.yaml")
+	if _, err := os.Stat(resourceFile); os.IsNotExist(err) {
+		t.Error("Whiteout cluster-scoped resource should still be written to disk")
+	}
+
+	// Verify it's commented out in kustomization.yaml
+	kData, err := os.ReadFile(filepath.Join(transformDir, stageName, "kustomization.yaml"))
+	if err != nil {
+		t.Fatalf("Failed to read kustomization.yaml: %v", err)
+	}
+	kStr := string(kData)
+
+	// Check the resource is NOT active (uncommented) but IS commented out
+	// We need to be precise: "# - resources/..." (commented) also contains "- resources/..." as substring
+	resourceRef := "resources/ClusterRole_rbac.authorization.k8s.io_v1_clusterscoped_whiteout-role.yaml"
+	lines := strings.Split(kStr, "\n")
+	foundActive := false
+	foundCommented := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "- "+resourceRef {
+			foundActive = true
+		}
+		if trimmed == "# - "+resourceRef {
+			foundCommented = true
+		}
+	}
+	if foundActive {
+		t.Error("Whiteout resource should NOT be in active resources list")
+	}
+	if !foundCommented {
+		t.Error("Whiteout resource should be in commented-out section")
+	}
+}
+
+func TestWriteStage_ClusterScopedWithPatch(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "crane-writer-cluster-patch-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	transformDir := filepath.Join(tmpDir, "transform")
+	stageName := "10_test"
+
+	clusterRole := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "rbac.authorization.k8s.io/v1",
+			"kind":       "ClusterRole",
+			"metadata": map[string]interface{}{
+				"name":            "patched-role",
+				"uid":             "should-be-removed",
+				"resourceVersion": "12345",
+			},
+			"rules": []interface{}{
+				map[string]interface{}{
+					"apiGroups": []interface{}{""},
+					"resources": []interface{}{"pods"},
+					"verbs":     []interface{}{"get"},
+				},
+			},
+		},
+	}
+
+	patchJSON := `[
+		{"op": "remove", "path": "/metadata/uid"},
+		{"op": "remove", "path": "/metadata/resourceVersion"}
+	]`
+	patches, _ := jsonpatch.DecodePatch([]byte(patchJSON))
+
+	artifacts := []cranelib.TransformArtifact{
+		{
+			Resource:     clusterRole,
+			HaveWhiteOut: false,
+			Patches:      patches,
+			Target:       cranelib.DeriveTargetFromResource(clusterRole),
+			PluginName:   "test-plugin",
+		},
+	}
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	opts := file.PathOpts{TransformDir: transformDir}
+	writer := NewKustomizeWriter(opts, stageName, logger)
+
+	if err := writer.WriteStage(artifacts, false); err != nil {
+		t.Fatalf("WriteStage failed: %v", err)
+	}
+
+	// Verify patch file created with correct name (no namespace prefix)
+	expectedPatchFile := "rbac.authorization.k8s.io-v1--ClusterRole--patched-role.patch.yaml"
+	patchPath := filepath.Join(transformDir, stageName, "patches", expectedPatchFile)
+	if _, err := os.Stat(patchPath); os.IsNotExist(err) {
+		t.Errorf("Expected patch file %s not found", expectedPatchFile)
+	}
+
+	// Verify patch content
+	patchData, err := os.ReadFile(patchPath)
+	if err != nil {
+		t.Fatalf("Failed to read patch file: %v", err)
+	}
+	if !strings.Contains(string(patchData), "/metadata/uid") {
+		t.Error("Patch file should contain remove for /metadata/uid")
+	}
+
+	// Verify kustomization.yaml patch target omits namespace
+	kData, err := os.ReadFile(filepath.Join(transformDir, stageName, "kustomization.yaml"))
+	if err != nil {
+		t.Fatalf("Failed to read kustomization.yaml: %v", err)
+	}
+	kStr := string(kData)
+
+	if !strings.Contains(kStr, "kind: ClusterRole") {
+		t.Error("kustomization.yaml missing ClusterRole in patch target")
+	}
+	if !strings.Contains(kStr, "name: patched-role") {
+		t.Error("kustomization.yaml missing name in patch target")
+	}
+	if strings.Contains(kStr, "namespace:") {
+		t.Error("kustomization.yaml should not contain namespace for cluster-scoped patch target")
+	}
+}
+
+func TestWriteStage_KustomizeBuildWithMixedResources(t *testing.T) {
+	if !hasKustomizeCommand(t) {
+		t.Skip("kubectl/oc not available, skipping kustomize build test")
+	}
+
+	tmpDir, err := os.MkdirTemp("", "crane-writer-kustomize-mixed-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	transformDir := filepath.Join(tmpDir, "transform")
+	stageName := "10_test"
+
+	deployment := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":      "web",
+				"namespace": "my-app",
+			},
+			"spec": map[string]interface{}{
+				"replicas": int64(1),
+				"selector": map[string]interface{}{
+					"matchLabels": map[string]interface{}{"app": "web"},
+				},
+				"template": map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{"app": "web"},
+					},
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "web",
+								"image": "nginx:1.21",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	clusterRole := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "rbac.authorization.k8s.io/v1",
+			"kind":       "ClusterRole",
+			"metadata": map[string]interface{}{
+				"name": "web-reader",
+			},
+			"rules": []interface{}{
+				map[string]interface{}{
+					"apiGroups": []interface{}{""},
+					"resources": []interface{}{"pods"},
+					"verbs":     []interface{}{"get", "list"},
+				},
+			},
+		},
+	}
+
+	artifacts := []cranelib.TransformArtifact{
+		{
+			Resource:     deployment,
+			HaveWhiteOut: false,
+			Target:       cranelib.DeriveTargetFromResource(deployment),
+			PluginName:   "test-plugin",
+		},
+		{
+			Resource:     clusterRole,
+			HaveWhiteOut: false,
+			Target:       cranelib.DeriveTargetFromResource(clusterRole),
+			PluginName:   "test-plugin",
+		},
+	}
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	opts := file.PathOpts{TransformDir: transformDir}
+	writer := NewKustomizeWriter(opts, stageName, logger)
+
+	if err := writer.WriteStage(artifacts, false); err != nil {
+		t.Fatalf("WriteStage failed: %v", err)
+	}
+
+	// Run kubectl kustomize to verify the output is valid
+	stageDir := filepath.Join(transformDir, stageName)
+	o := &Orchestrator{
+		Log:       logger,
+		ExportDir: tmpDir,
+	}
+	resources, err := o.applyStageTransforms(stageDir)
+	if err != nil {
+		t.Fatalf("kubectl kustomize failed on mixed resources: %v", err)
+	}
+
+	if len(resources) != 2 {
+		t.Fatalf("Expected 2 resources from kustomize build, got %d", len(resources))
+	}
+
+	foundDeployment := false
+	foundClusterRole := false
+	for _, r := range resources {
+		switch r.GetKind() {
+		case "Deployment":
+			foundDeployment = true
+			if r.GetNamespace() != "my-app" {
+				t.Errorf("Deployment should have namespace 'my-app', got '%s'", r.GetNamespace())
+			}
+		case "ClusterRole":
+			foundClusterRole = true
+			if r.GetNamespace() != "" {
+				t.Errorf("ClusterRole should have empty namespace, got '%s'", r.GetNamespace())
+			}
+		}
+	}
+
+	if !foundDeployment {
+		t.Error("Deployment not found in kustomize output")
+	}
+	if !foundClusterRole {
+		t.Error("ClusterRole not found in kustomize output")
 	}
 }

--- a/internal/transform/writer_integration_test.go
+++ b/internal/transform/writer_integration_test.go
@@ -8,9 +8,11 @@ import (
 
 	jsonpatch "github.com/evanphx/json-patch"
 	cranelib "github.com/konveyor/crane-lib/transform"
+	"github.com/konveyor/crane-lib/transform/kustomize"
 	"github.com/konveyor/crane/internal/file"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
 )
 
 func TestWriteStageWithNonExistentRemovePath(t *testing.T) {
@@ -350,27 +352,22 @@ func TestWriteStage_MixedNamespacedAndClusterScoped(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to read kustomization.yaml: %v", err)
 	}
-	kStr := string(kData)
 
-	if !strings.Contains(kStr, "namespace: my-app") {
-		t.Error("kustomization.yaml missing 'namespace: my-app' for namespaced Deployment")
+	var kustFile kustomize.KustomizationFile
+	if err := yaml.Unmarshal(kData, &kustFile); err != nil {
+		t.Fatalf("Failed to parse kustomization.yaml: %v", err)
 	}
 
-	// Check that ClusterRole target does not have namespace
-	// The ClusterRole section should have kind+name but no namespace
-	lines := strings.Split(kStr, "\n")
-	inClusterRoleTarget := false
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "kind: ClusterRole" {
-			inClusterRoleTarget = true
+	for _, patch := range kustFile.Patches {
+		if patch.Target.Kind == "Deployment" && patch.Target.Name == "web" {
+			if patch.Target.Namespace != "my-app" {
+				t.Errorf("Deployment patch target should have namespace 'my-app', got %q", patch.Target.Namespace)
+			}
 		}
-		if inClusterRoleTarget && strings.HasPrefix(trimmed, "namespace:") {
-			t.Error("ClusterRole patch target should not have 'namespace:' field")
-			break
-		}
-		if inClusterRoleTarget && trimmed == "" {
-			break
+		if patch.Target.Kind == "ClusterRole" && patch.Target.Name == "web-admin" {
+			if patch.Target.Namespace != "" {
+				t.Errorf("ClusterRole patch target should have empty namespace, got %q", patch.Target.Namespace)
+			}
 		}
 	}
 }

--- a/internal/transform/writer_integration_test.go
+++ b/internal/transform/writer_integration_test.go
@@ -270,10 +270,16 @@ func TestWriteStage_MixedNamespacedAndClusterScoped(t *testing.T) {
 	}
 
 	patchJSON := `[{"op": "remove", "path": "/spec/replicas"}]`
-	deployPatches, _ := jsonpatch.DecodePatch([]byte(patchJSON))
+	deployPatches, err := jsonpatch.DecodePatch([]byte(patchJSON))
+	if err != nil {
+		t.Fatalf("Failed to decode deployment patch JSON: %v", err)
+	}
 
 	clusterPatchJSON := `[{"op": "add", "path": "/metadata/labels", "value": {"migrated": "true"}}]`
-	clusterPatches, _ := jsonpatch.DecodePatch([]byte(clusterPatchJSON))
+	clusterPatches, err := jsonpatch.DecodePatch([]byte(clusterPatchJSON))
+	if err != nil {
+		t.Fatalf("Failed to decode ClusterRole patch JSON: %v", err)
+	}
 
 	artifacts := []cranelib.TransformArtifact{
 		{
@@ -479,7 +485,10 @@ func TestWriteStage_ClusterScopedWithPatch(t *testing.T) {
 		{"op": "remove", "path": "/metadata/uid"},
 		{"op": "remove", "path": "/metadata/resourceVersion"}
 	]`
-	patches, _ := jsonpatch.DecodePatch([]byte(patchJSON))
+	patches, err := jsonpatch.DecodePatch([]byte(patchJSON))
+	if err != nil {
+		t.Fatalf("Failed to decode ClusterRole patch JSON: %v", err)
+	}
 
 	artifacts := []cranelib.TransformArtifact{
 		{

--- a/internal/transform/writer_test.go
+++ b/internal/transform/writer_test.go
@@ -186,6 +186,74 @@ func TestFilterValidRemoveOps(t *testing.T) {
 	}
 }
 
+func TestGetResourceID_ClusterScoped(t *testing.T) {
+	tests := []struct {
+		name       string
+		resource   unstructured.Unstructured
+		expectedID string
+	}{
+		{
+			name: "namespaced resource",
+			resource: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "Deployment",
+					"metadata": map[string]interface{}{
+						"name":      "web",
+						"namespace": "my-app",
+					},
+				},
+			},
+			expectedID: "Deployment/my-app/web",
+		},
+		{
+			name: "cluster-scoped resource",
+			resource: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "ClusterRole",
+					"metadata": map[string]interface{}{
+						"name": "admin",
+					},
+				},
+			},
+			expectedID: "ClusterRole/admin",
+		},
+		{
+			name: "cluster-scoped CRD",
+			resource: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "CustomResourceDefinition",
+					"metadata": map[string]interface{}{
+						"name": "widgets.example.com",
+					},
+				},
+			},
+			expectedID: "CustomResourceDefinition/widgets.example.com",
+		},
+		{
+			name: "cluster-scoped with explicit empty namespace",
+			resource: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "ClusterRoleBinding",
+					"metadata": map[string]interface{}{
+						"name":      "binding",
+						"namespace": "",
+					},
+				},
+			},
+			expectedID: "ClusterRoleBinding/binding",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getResourceID(tt.resource)
+			if result != tt.expectedID {
+				t.Errorf("getResourceID() = %q, want %q", result, tt.expectedID)
+			}
+		})
+	}
+}
+
 func TestPathExists(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Phase 1 of [issue #189](https://github.com/migtools/crane/issues/189). The existing transform already handles cluster-scoped resources correctly. This PR adds tests to prove and lock down that behavior.

## Manual Testing on Minikube (all PASS)

| Scenario | What was tested |
|----------|----------------|
| **RBAC** | nginx + ServiceAccount + ClusterRole + ClusterRoleBinding through full export → transform → apply. Verified `_cluster/` layout, patch targets omit namespace, `kubectl kustomize` succeeds, recursive apply works. |
| **CRD** | Custom CRD (`widgets.example.com`) + Widget CR instance. Verified CRD flows to `_cluster/`, CR stays under namespace directory. |
| **Multi-stage** | Two stages (`10_KubernetesPlugin` → `20_CustomStage`). Verified `_cluster/` separation preserved across stage boundaries — stage 2 input correctly loads from stage 1 output, content survives both stages. |

## Unit Tests Added (7 tests)

| File | Test | Verifies |
|------|------|----------|
| `writer_test.go` | `TestGetResourceID_ClusterScoped` | Returns `Kind/name` (no namespace) for cluster-scoped resources |
| `writer_integration_test.go` | `TestWriteStage_ClusterScopedResources` | Only cluster-scoped resources: filenames use `clusterscoped`, kustomization omits `namespace:` |
| | `TestWriteStage_MixedNamespacedAndClusterScoped` | Mixed resources: patch filenames and targets differ correctly |
| | `TestWriteStage_ClusterScopedWhiteout` | Whiteout: file on disk, commented out in kustomization.yaml |
| | `TestWriteStage_ClusterScopedWithPatch` | Patch file named without namespace prefix, target omits namespace |
| | `TestWriteStage_KustomizeBuildWithMixedResources` | `kubectl kustomize` succeeds on mixed namespaced + cluster-scoped stage |
| `orchestrator_test.go` | `TestMultiStage_ClusterScopedResources` | 2-stage pipeline: `_cluster/` separation preserved at every stage boundary, content intact |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded integration coverage for cluster-scoped resource handling in kustomization workflows
  * Added tests for mixed namespaced and cluster-scoped artifacts, including patch naming and namespace behavior
  * Added tests covering whiteout behavior for cluster-scoped resources and patch content validation
  * Added unit tests for resource identifier formatting for cluster-scoped vs namespaced resources
  * Added multi-stage integration test ensuring cluster-scoped resources persist across stages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/migtools/crane/pull/383?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->