### PR TITLE
Add --skip-cluster-scoped flag to apply

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -34,6 +34,8 @@ type Flags struct {
 	Stage string `mapstructure:"stage"`
 	// Kustomize arguments
 	KustomizeArgs string `mapstructure:"kustomize-args"`
+	// Skip cluster-scoped resources in output
+	SkipClusterScoped bool `mapstructure:"skip-cluster-scoped"`
 }
 
 func (o *Options) Complete(c *cobra.Command, args []string) error {
@@ -98,6 +100,8 @@ func addFlagsForOptions(o *Flags, cmd *cobra.Command) {
 
 	// Kustomize arguments
 	cmd.Flags().StringVar(&o.KustomizeArgs, "kustomize-args", "", "Additional arguments for kustomize (e.g., '--enable-helm --helm-command=helm3')")
+	// Cluster-scoped filtering
+	cmd.Flags().BoolVar(&o.SkipClusterScoped, "skip-cluster-scoped", false, "Exclude cluster-scoped resources (ClusterRole, ClusterRoleBinding, CRD, etc.) from output. Useful for non-admin migration scenarios.")
 }
 
 func (o *Options) run() error {
@@ -126,10 +130,11 @@ func (o *Options) run() error {
 
 	// Create applier
 	applier := &apply.KustomizeApplier{
-		Log:           log.WithField("command", "apply").Logger,
-		TransformDir:  transformDir,
-		OutputDir:     outputDir,
-		KustomizeArgs: kustomizeArgs,
+		Log:               log.WithField("command", "apply").Logger,
+		TransformDir:      transformDir,
+		OutputDir:         outputDir,
+		KustomizeArgs:     kustomizeArgs,
+		SkipClusterScoped: o.SkipClusterScoped,
 	}
 
 	// Determine which stages to apply

--- a/internal/apply/kustomize.go
+++ b/internal/apply/kustomize.go
@@ -163,7 +163,9 @@ func (k *KustomizeApplier) filterClusterScopedResources(yamlData []byte) ([]byte
 		if err := encoder.Encode(doc); err != nil {
 			return nil, fmt.Errorf("failed to encode YAML document: %w", err)
 		}
-		encoder.Close()
+		if err := encoder.Close(); err != nil {
+			return nil, fmt.Errorf("failed to close YAML encoder: %w", err)
+		}
 		docBytes := buf.Bytes()
 
 		jsonData, err := yaml.YAMLToJSON(docBytes)

--- a/internal/apply/kustomize.go
+++ b/internal/apply/kustomize.go
@@ -219,7 +219,9 @@ func (k *KustomizeApplier) splitMultiDocYAMLToFiles(yamlData []byte) error {
 		if err := encoder.Encode(doc); err != nil {
 			return fmt.Errorf("failed to encode YAML document: %w", err)
 		}
-		encoder.Close() // Flush the encoder
+		if err := encoder.Close(); err != nil {
+			return fmt.Errorf("failed to close YAML encoder: %w", err)
+		}
 		docBytes := buf.Bytes()
 
 		// Convert YAML to JSON to extract metadata

--- a/internal/apply/kustomize.go
+++ b/internal/apply/kustomize.go
@@ -53,6 +53,14 @@ func (k *KustomizeApplier) ApplySingleStage(stageName string) error {
 		return fmt.Errorf("kustomize build failed for stage %s: %w", stageName, err)
 	}
 
+	// Filter cluster-scoped resources if requested
+	if k.SkipClusterScoped {
+		output, err = k.filterClusterScopedResources(output)
+		if err != nil {
+			return fmt.Errorf("failed to filter cluster-scoped resources: %w", err)
+		}
+	}
+
 	// Write output to output directory
 	outputPath := filepath.Join(k.OutputDir, stageName+".yaml")
 	if err := os.MkdirAll(k.OutputDir, 0700); err != nil {

--- a/internal/apply/kustomize.go
+++ b/internal/apply/kustomize.go
@@ -19,10 +19,11 @@ import (
 
 // KustomizeApplier applies transformations using embedded kustomize
 type KustomizeApplier struct {
-	Log           *logrus.Logger
-	TransformDir  string
-	OutputDir     string
-	KustomizeArgs []string
+	Log               *logrus.Logger
+	TransformDir      string
+	OutputDir         string
+	KustomizeArgs     []string
+	SkipClusterScoped bool
 }
 
 // ApplySingleStage applies a single transform stage to produce output
@@ -91,6 +92,14 @@ func (k *KustomizeApplier) ApplyMultiStage(stageSelector internalTransform.Stage
 		return fmt.Errorf("kustomize build failed for stage %s: %w", lastStage.DirName, err)
 	}
 
+	// Filter cluster-scoped resources if requested
+	if k.SkipClusterScoped {
+		output, err = k.filterClusterScopedResources(output)
+		if err != nil {
+			return fmt.Errorf("failed to filter cluster-scoped resources: %w", err)
+		}
+	}
+
 	// Write to output.yaml (single file with all resources)
 	outputPath := filepath.Join(k.OutputDir, "output.yaml")
 	if err := os.MkdirAll(k.OutputDir, 0700); err != nil {
@@ -119,6 +128,59 @@ func (k *KustomizeApplier) runKustomizeBuild(dir string) ([]byte, error) {
 		Args: k.KustomizeArgs,
 	}
 	return runner.Build(dir)
+}
+
+// filterClusterScopedResources removes cluster-scoped resources from a multi-document YAML stream
+func (k *KustomizeApplier) filterClusterScopedResources(yamlData []byte) ([]byte, error) {
+	decoder := yamlv3.NewDecoder(strings.NewReader(string(yamlData)))
+	var result bytes.Buffer
+	first := true
+
+	for {
+		var doc interface{}
+		err := decoder.Decode(&doc)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode YAML document: %w", err)
+		}
+		if doc == nil {
+			continue
+		}
+
+		var buf bytes.Buffer
+		encoder := yamlv3.NewEncoder(&buf)
+		encoder.SetIndent(2)
+		if err := encoder.Encode(doc); err != nil {
+			return nil, fmt.Errorf("failed to encode YAML document: %w", err)
+		}
+		encoder.Close()
+		docBytes := buf.Bytes()
+
+		jsonData, err := yaml.YAMLToJSON(docBytes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert YAML to JSON: %w", err)
+		}
+
+		u := unstructured.Unstructured{}
+		if err := u.UnmarshalJSON(jsonData); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal resource: %w", err)
+		}
+
+		if u.GetNamespace() == "" {
+			k.Log.Infof("Skipping cluster-scoped resource %s/%s (--skip-cluster-scoped)", u.GetKind(), u.GetName())
+			continue
+		}
+
+		if !first {
+			result.WriteString("---\n")
+		}
+		result.Write(docBytes)
+		first = false
+	}
+
+	return result.Bytes(), nil
 }
 
 // splitMultiDocYAMLToFiles splits a multi-document YAML into individual resource files

--- a/internal/apply/kustomize_test.go
+++ b/internal/apply/kustomize_test.go
@@ -404,6 +404,248 @@ data:
 	}
 }
 
+func TestSplitMultiDocYAML_SkipClusterScoped(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "crane-skip-cluster-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	yamlData := `apiVersion: v1
+kind: Service
+metadata:
+  name: web
+  namespace: prod
+spec:
+  type: ClusterIP
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: reader
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: reader-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: reader
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: prod
+`
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+	applier := &KustomizeApplier{
+		Log:               logger,
+		OutputDir:         tmpDir,
+		SkipClusterScoped: true,
+	}
+
+	// Filter first, then split (mirrors ApplyMultiStage flow)
+	filtered, err := applier.filterClusterScopedResources([]byte(yamlData))
+	if err != nil {
+		t.Fatalf("filterClusterScopedResources failed: %v", err)
+	}
+
+	err = applier.splitMultiDocYAMLToFiles(filtered)
+	if err != nil {
+		t.Fatalf("splitMultiDocYAMLToFiles failed: %v", err)
+	}
+
+	// Namespaced resource should exist
+	svcMatches, _ := filepath.Glob(filepath.Join(tmpDir, "resources/prod/Service_*_web.yaml"))
+	if len(svcMatches) == 0 {
+		t.Error("Service should be in output when --skip-cluster-scoped is set")
+	}
+
+	// Cluster-scoped resources should NOT exist
+	clusterDir := filepath.Join(tmpDir, "resources", "_cluster")
+	if _, err := os.Stat(clusterDir); !os.IsNotExist(err) {
+		t.Error("_cluster/ directory should NOT exist when --skip-cluster-scoped is set")
+	}
+
+	// Verify filtered output.yaml does not contain cluster-scoped resources
+	if contains(string(filtered), "ClusterRole") {
+		t.Error("Filtered YAML should not contain ClusterRole")
+	}
+	if !contains(string(filtered), "Service") {
+		t.Error("Filtered YAML should still contain Service")
+	}
+}
+
+func TestSplitMultiDocYAML_ClusterScopedIncluded(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "crane-include-cluster-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	yamlData := `apiVersion: v1
+kind: Service
+metadata:
+  name: web
+  namespace: prod
+spec:
+  type: ClusterIP
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: reader
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get"]
+`
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+	applier := &KustomizeApplier{
+		Log:               logger,
+		OutputDir:         tmpDir,
+		SkipClusterScoped: false,
+	}
+
+	err = applier.splitMultiDocYAMLToFiles([]byte(yamlData))
+	if err != nil {
+		t.Fatalf("splitMultiDocYAMLToFiles failed: %v", err)
+	}
+
+	// Both should exist
+	svcMatches, _ := filepath.Glob(filepath.Join(tmpDir, "resources/prod/Service_*_web.yaml"))
+	if len(svcMatches) == 0 {
+		t.Error("Service should be in output")
+	}
+
+	crMatches, _ := filepath.Glob(filepath.Join(tmpDir, "resources/_cluster/ClusterRole_*_reader.yaml"))
+	if len(crMatches) == 0 {
+		t.Error("ClusterRole should be in output when --skip-cluster-scoped is NOT set")
+	}
+}
+
+func TestSplitMultiDocYAML_OnlyClusterScoped(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "crane-only-cluster-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	yamlData := `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: admin
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: admin-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+- kind: Group
+  name: admins
+  apiGroup: rbac.authorization.k8s.io
+`
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+	applier := &KustomizeApplier{
+		Log:               logger,
+		OutputDir:         tmpDir,
+		SkipClusterScoped: true,
+	}
+
+	filtered, err := applier.filterClusterScopedResources([]byte(yamlData))
+	if err != nil {
+		t.Fatalf("filterClusterScopedResources failed: %v", err)
+	}
+
+	// Filtered output should be empty
+	if len(strings.TrimSpace(string(filtered))) != 0 {
+		t.Errorf("Expected empty output when all resources are cluster-scoped and skip is set, got: %q", string(filtered))
+	}
+
+	// Splitting empty content should not error
+	err = applier.splitMultiDocYAMLToFiles(filtered)
+	if err != nil {
+		t.Fatalf("splitMultiDocYAMLToFiles on empty input should not error: %v", err)
+	}
+
+	// No resources directory should be created
+	resourcesDir := filepath.Join(tmpDir, "resources")
+	if _, err := os.Stat(resourcesDir); !os.IsNotExist(err) {
+		t.Error("resources/ directory should NOT exist when all resources are filtered out")
+	}
+}
+
+func TestFilterClusterScopedResources_PreservesNamespaced(t *testing.T) {
+	yamlData := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: my-app
+spec:
+  replicas: 1
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-sa
+  namespace: my-app
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: web-reader
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get"]
+`
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+	applier := &KustomizeApplier{
+		Log:               logger,
+		SkipClusterScoped: true,
+	}
+
+	filtered, err := applier.filterClusterScopedResources([]byte(yamlData))
+	if err != nil {
+		t.Fatalf("filterClusterScopedResources failed: %v", err)
+	}
+
+	filteredStr := string(filtered)
+
+	// Should keep namespaced resources
+	if !contains(filteredStr, "Deployment") {
+		t.Error("Filtered YAML should contain Deployment")
+	}
+	if !contains(filteredStr, "ServiceAccount") {
+		t.Error("Filtered YAML should contain ServiceAccount")
+	}
+
+	// Should remove cluster-scoped
+	if contains(filteredStr, "ClusterRole") {
+		t.Error("Filtered YAML should NOT contain ClusterRole")
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) > 0 && len(substr) > 0 && findInString(s, substr)
 }


### PR DESCRIPTION
  Phase 2 of [issue #189](https://github.com/migtools/crane/issues/189). Adds a `--skip-cluster-scoped` flag that excludes cluster-scoped resources from apply output, enabling non-admin migration scenarios where the user
   cannot apply cluster-level objects.

  ## Approach

  Post-build filtering — `kubectl kustomize` renders all resources (namespaced + cluster-scoped), then resources with empty `metadata.namespace` are filtered out before writing `output.yaml` and splitting into individual
   files. This is safer than pre-build filtering (modifying kustomization.yaml before kustomize runs) because it avoids any risk of breaking kustomize when patches reference cluster-scoped resources.

  ## Manual Testing on Minikube (all PASS)

  Setup: namespace `crane-apply-test` with nginx Deployment + ServiceAccount + ClusterRole + ClusterRoleBinding on src cluster.

  | Test | Result |
  |------|--------|
  | `crane apply` (default) — output contains `_cluster/` with ClusterRole + ClusterRoleBinding | PASS |
  | `crane apply --skip-cluster-scoped` — no `_cluster/` directory, only namespaced resources | PASS |
  | `output.yaml` with skip flag contains only ServiceAccount + Deployment (no ClusterRole) | PASS |
  | `kubectl apply -R -f output/resources/ --dry-run=client` works for both outputs | PASS |
  | Log messages: "Skipping cluster-scoped resource ClusterRole/..." printed for each filtered resource | PASS |

  ## Unit Tests Added (4 tests in `internal/apply/kustomize_test.go`)

  | Test | Verifies |
  |------|----------|
  | `TestSplitMultiDocYAML_SkipClusterScoped` | Mixed resources + skip flag: `_cluster/` not created, namespaced resources preserved, filtered YAML has no ClusterRole |
  | `TestSplitMultiDocYAML_ClusterScopedIncluded` | Same input without skip flag: both `_cluster/` and namespace directories created |
  | `TestSplitMultiDocYAML_OnlyClusterScoped` | All cluster-scoped + skip flag: empty output, no `resources/` directory |
  | `TestFilterClusterScopedResources_PreservesNamespaced` | Deployment + ServiceAccount kept, ClusterRole removed |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --skip-cluster-scoped option to the apply command to optionally exclude cluster-scoped Kubernetes resources from generated outputs; when enabled, only namespaced resources are emitted and cluster-scoped kinds are filtered out.
* **Bug Fixes**
  * Improved splitting of multi-document YAML to correctly handle empty/filtered outputs and surface encoding/close errors.
* **Tests**
  * Added tests covering mixed, only-cluster-scoped, and only-namespaced scenarios to verify filtering and output layout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/migtools/crane/pull/386?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->