### PR TITLE
embed kustomize to crane

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -97,7 +97,7 @@ func addFlagsForOptions(o *Flags, cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.Stage, "stage", "", "Apply a specific stage only (e.g., '10_KubernetesPlugin'). If not specified, all stages are applied.")
 
 	// Kustomize arguments
-	cmd.Flags().StringVar(&o.KustomizeArgs, "kustomize-args", "", "Additional arguments to pass to kubectl kustomize (e.g., '--enable-helm --load-restrictor=LoadRestrictionsNone')")
+	cmd.Flags().StringVar(&o.KustomizeArgs, "kustomize-args", "", "Additional arguments for kustomize (e.g., '--enable-helm --helm-command=helm3')")
 }
 
 func (o *Options) run() error {

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -103,12 +103,6 @@ func addFlagsForOptions(o *Flags, cmd *cobra.Command) {
 func (o *Options) run() error {
 	log := o.globalFlags.GetLogger()
 
-	// Validate kubectl is available before proceeding
-	// All apply operations require kubectl kustomize
-	if err := apply.ValidateKubectlAvailable(); err != nil {
-		return err
-	}
-
 	transformDir, err := filepath.Abs(o.TransformDir)
 	if err != nil {
 		return err

--- a/cmd/transform/transform.go
+++ b/cmd/transform/transform.go
@@ -106,7 +106,7 @@ func addFlagsForOptions(o *Flags, cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.Force, "force", false, "Force overwrite of existing stage directories even if they contain user modifications")
 
 	// Kustomize arguments
-	cmd.Flags().StringVar(&o.KustomizeArgs, "kustomize-args", "", "Additional arguments to pass to kubectl kustomize (e.g., '--enable-helm --load-restrictor=LoadRestrictionsNone')")
+	cmd.Flags().StringVar(&o.KustomizeArgs, "kustomize-args", "", "Additional arguments for kustomize (e.g., '--enable-helm --helm-command=helm3')")
 
 	// These flags pass down to subcommands
 	cmd.PersistentFlags().StringVarP(&o.PluginDir, "plugin-dir", "p", defaultPluginDir, "The path where binary plugins are located")

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.4.3
 	github.com/google/gnostic-models v0.7.0
+	github.com/google/go-cmp v0.7.0
 	github.com/jarcoal/httpmock v1.2.0
 	github.com/konveyor/crane-lib v0.1.6-0.20260414113823-a9f07d55042b
 	github.com/olekukonko/tablewriter v0.0.5
@@ -28,7 +29,7 @@ require (
 	k8s.io/cli-runtime v0.35.3
 	k8s.io/client-go v0.35.3
 	sigs.k8s.io/controller-runtime v0.23.3
-	sigs.k8s.io/kustomize/cmd/config v0.21.1
+	sigs.k8s.io/kustomize/api v0.20.1
 	sigs.k8s.io/kustomize/kyaml v0.21.1
 	sigs.k8s.io/yaml v1.6.0
 )
@@ -50,7 +51,6 @@ require (
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/google/btree v1.1.3 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
@@ -103,7 +103,6 @@ require (
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
-	sigs.k8s.io/kustomize/api v0.20.1 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2-0.20260122202528-d9cc6641c482 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1051,8 +1051,6 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/kustomize/api v0.20.1 h1:iWP1Ydh3/lmldBnH/S5RXgT98vWYMaTUL1ADcr+Sv7I=
 sigs.k8s.io/kustomize/api v0.20.1/go.mod h1:t6hUFxO+Ph0VxIk1sKp1WS0dOjbPCtLJ4p8aADLwqjM=
-sigs.k8s.io/kustomize/cmd/config v0.21.1 h1:/gxf3J1rQD9nfuL8fHlrTLeUL+JHWbK44eOnXJDYx0M=
-sigs.k8s.io/kustomize/cmd/config v0.21.1/go.mod h1:7yEFYBJyBJlpZQ50VaRGQRtFMn3Vzn9Fb2wts4TCok4=
 sigs.k8s.io/kustomize/kyaml v0.21.1 h1:IVlbmhC076nf6foyL6Taw4BkrLuEsXUXNpsE+ScX7fI=
 sigs.k8s.io/kustomize/kyaml v0.21.1/go.mod h1:hmxADesM3yUN2vbA5z1/YTBnzLJ1dajdqpQonwBL1FQ=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=

--- a/internal/apply/kustomize.go
+++ b/internal/apply/kustomize.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/konveyor/crane/internal/file"
+	"github.com/konveyor/crane/internal/kustomize"
 	internalTransform "github.com/konveyor/crane/internal/transform"
 	"github.com/sirupsen/logrus"
 	yamlv3 "gopkg.in/yaml.v3"
@@ -112,51 +112,13 @@ func (k *KustomizeApplier) ApplyMultiStage(stageSelector internalTransform.Stage
 	return nil
 }
 
-// runKustomizeBuild executes kubectl kustomize or oc kustomize on a directory
+// runKustomizeBuild runs embedded kustomize on a directory
 func (k *KustomizeApplier) runKustomizeBuild(dir string) ([]byte, error) {
-	kustomizeCmd := file.GetKustomizeCommand()
-
-	// Build command arguments
-	cmdArgs := []string{"kustomize"}
-
-	// Add custom kustomize arguments if provided
-	if len(k.KustomizeArgs) > 0 {
-		cmdArgs = append(cmdArgs, k.KustomizeArgs...)
+	runner := &kustomize.Runner{
+		Log:  k.Log,
+		Args: k.KustomizeArgs,
 	}
-
-	// Add directory as last argument
-	cmdArgs = append(cmdArgs, dir)
-
-	cmd := exec.Command(kustomizeCmd, cmdArgs...)
-
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	k.Log.Debugf("Running: %s %s", kustomizeCmd, strings.Join(cmdArgs, " "))
-
-	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("command failed: %w\nstderr: %s", err, stderr.String())
-	}
-
-	return stdout.Bytes(), nil
-}
-
-// ValidateKubectlAvailable checks if kubectl or oc command is available
-func ValidateKubectlAvailable() error {
-	// Try kubectl first
-	cmd := exec.Command("kubectl", "version", "--client")
-	if err := cmd.Run(); err == nil {
-		return nil
-	}
-
-	// Fallback to oc
-	cmd = exec.Command("oc", "version", "--client")
-	if err := cmd.Run(); err == nil {
-		return nil
-	}
-
-	return fmt.Errorf("neither kubectl nor oc found or executable")
+	return runner.Build(dir)
 }
 
 // splitMultiDocYAMLToFiles splits a multi-document YAML into individual resource files

--- a/internal/apply/kustomize.go
+++ b/internal/apply/kustomize.go
@@ -17,7 +17,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-// KustomizeApplier applies transformations using kubectl kustomize
+// KustomizeApplier applies transformations using embedded kustomize
 type KustomizeApplier struct {
 	Log           *logrus.Logger
 	TransformDir  string
@@ -45,11 +45,11 @@ func (k *KustomizeApplier) ApplySingleStage(stageName string) error {
 		return fmt.Errorf("kustomization.yaml not found in stage: %s", stageName)
 	}
 
-	// Run kubectl kustomize build
+	// Run kustomize build
 	k.Log.Infof("Building stage: %s", stageName)
 	output, err := k.runKustomizeBuild(stageDir)
 	if err != nil {
-		return fmt.Errorf("kubectl kustomize build failed for stage %s: %w", stageName, err)
+		return fmt.Errorf("kustomize build failed for stage %s: %w", stageName, err)
 	}
 
 	// Write output to output directory
@@ -85,10 +85,10 @@ func (k *KustomizeApplier) ApplyMultiStage(stageSelector internalTransform.Stage
 
 	k.Log.Infof("Applying final stage: %s", lastStage.DirName)
 
-	// Run kubectl kustomize build on the last stage
+	// Run kustomize build on the last stage
 	output, err := k.runKustomizeBuild(lastStage.Path)
 	if err != nil {
-		return fmt.Errorf("kubectl kustomize build failed for stage %s: %w", lastStage.DirName, err)
+		return fmt.Errorf("kustomize build failed for stage %s: %w", lastStage.DirName, err)
 	}
 
 	// Write to output.yaml (single file with all resources)

--- a/internal/apply/kustomize_test.go
+++ b/internal/apply/kustomize_test.go
@@ -326,25 +326,6 @@ data:
 	}
 }
 
-func TestValidateKubectlAvailable(t *testing.T) {
-	// This test verifies that ValidateKubectlAvailable correctly checks for kubectl
-	// We can't guarantee kubectl is available in all test environments,
-	// so we just verify the function executes without panic
-
-	err := ValidateKubectlAvailable()
-
-	// If kubectl is available, err should be nil
-	// If kubectl is not available, err should contain helpful message
-	if err != nil {
-		// Verify error message is helpful
-		if !contains(err.Error(), "kubectl") {
-			t.Errorf("Error message should mention kubectl, got: %v", err)
-		}
-		t.Logf("kubectl not available (expected in some test environments): %v", err)
-	} else {
-		t.Log("kubectl is available")
-	}
-}
 
 func TestSplitMultiDocYAMLToFiles_Indentation(t *testing.T) {
 	// Verify that split YAML files use 2-space indentation

--- a/internal/file/file_helper.go
+++ b/internal/file/file_helper.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -208,24 +207,6 @@ func (opts *PathOpts) GetStageTransformDir(stageName string) string {
 // Format: <transformDir>/.work/<stageName>/output
 func (opts *PathOpts) GetStageOutputDir(stageName string) string {
 	return filepath.Join(opts.GetStageWorkDir(stageName), "output")
-}
-
-// GetKustomizeCommand returns the appropriate command (kubectl or oc) for kustomize
-func GetKustomizeCommand() string {
-	// Try kubectl first
-	cmd := exec.Command("kubectl", "version", "--client")
-	if err := cmd.Run(); err == nil {
-		return "kubectl"
-	}
-
-	// Fallback to oc
-	cmd = exec.Command("oc", "version", "--client")
-	if err := cmd.Run(); err == nil {
-		return "oc"
-	}
-
-	// Default to kubectl (will fail later with appropriate error)
-	return "kubectl"
 }
 
 // GetResourceFilename returns a stable filename from kind, group, version, namespace, and name.

--- a/internal/kustomize/args.go
+++ b/internal/kustomize/args.go
@@ -5,14 +5,14 @@ import (
 	"strings"
 )
 
-// AllowedKustomizeArgs contains whitelist of allowed kustomize arguments
+// AllowedKustomizeArgs contains whitelist of allowed kustomize arguments.
+// Only helm-related args are user-configurable — load restrictions and plugin
+// restrictions are hardcoded to permissive defaults in the embedded runner.
 var AllowedKustomizeArgs = map[string]bool{
-	"--enable-alpha-plugins": true,
-	"--enable-helm":          true,
-	"--env":                  true,
-	"-e":                     true,
-	"--helm-command":         true,
-	"--load-restrictor":      true,
+	"--enable-helm":  true,
+	"--env":          true,
+	"-e":             true,
+	"--helm-command": true,
 }
 
 // ParseAndValidateArgs parses and validates kustomize arguments
@@ -40,10 +40,9 @@ func ParseAndValidateArgs(argsString string) ([]string, error) {
 
 	// Flags that can take a value as a separate argument (space-separated)
 	valueTakingFlags := map[string]bool{
-		"--env":             true,
-		"-e":                true,
-		"--helm-command":    true,
-		"--load-restrictor": true,
+		"--env":          true,
+		"-e":             true,
+		"--helm-command": true,
 	}
 
 	// Validate each argument

--- a/internal/kustomize/args.go
+++ b/internal/kustomize/args.go
@@ -16,7 +16,7 @@ var AllowedKustomizeArgs = map[string]bool{
 }
 
 // ParseAndValidateArgs parses and validates kustomize arguments
-// Returns array of arguments ready for exec.Command
+// Returns array of arguments for kustomize configuration
 func ParseAndValidateArgs(argsString string) ([]string, error) {
 	if argsString == "" {
 		return nil, nil

--- a/internal/kustomize/args_test.go
+++ b/internal/kustomize/args_test.go
@@ -25,16 +25,6 @@ func TestParseAndValidateArgs(t *testing.T) {
 			expected: []string{"--enable-helm"},
 		},
 		{
-			name:     "multiple flags",
-			input:    "--enable-helm --enable-alpha-plugins",
-			expected: []string{"--enable-helm", "--enable-alpha-plugins"},
-		},
-		{
-			name:     "flag with value using equals",
-			input:    "--load-restrictor=LoadRestrictionsNone",
-			expected: []string{"--load-restrictor=LoadRestrictionsNone"},
-		},
-		{
 			name:     "helm command with path",
 			input:    "--helm-command=/usr/local/bin/helm",
 			expected: []string{"--helm-command=/usr/local/bin/helm"},
@@ -61,13 +51,8 @@ func TestParseAndValidateArgs(t *testing.T) {
 		},
 		{
 			name:     "complex combination",
-			input:    "--enable-helm --load-restrictor=LoadRestrictionsNone --env FOO=bar",
-			expected: []string{"--enable-helm", "--load-restrictor=LoadRestrictionsNone", "--env", "FOO=bar"},
-		},
-		{
-			name:     "load-restrictor space-separated",
-			input:    "--load-restrictor LoadRestrictionsNone",
-			expected: []string{"--load-restrictor", "LoadRestrictionsNone"},
+			input:    "--enable-helm --env FOO=bar",
+			expected: []string{"--enable-helm", "--env", "FOO=bar"},
 		},
 		{
 			name:     "helm-command space-separated",
@@ -141,16 +126,16 @@ func TestParseAndValidateArgs(t *testing.T) {
 			errorMsg:    "requires a value, got flag",
 		},
 		{
-			name:        "load-restrictor followed by another flag",
-			input:       "--load-restrictor --enable-helm",
+			name:        "load-restrictor not allowed",
+			input:       "--load-restrictor=LoadRestrictionsNone",
 			expectError: true,
-			errorMsg:    "requires a value, got flag",
+			errorMsg:    "not allowed",
 		},
 		{
-			name:        "load-restrictor without value",
-			input:       "--load-restrictor",
+			name:        "enable-alpha-plugins not allowed",
+			input:       "--enable-alpha-plugins",
 			expectError: true,
-			errorMsg:    "requires a value",
+			errorMsg:    "not allowed",
 		},
 		{
 			name:        "helm-command with empty value",

--- a/internal/kustomize/runner.go
+++ b/internal/kustomize/runner.go
@@ -25,7 +25,10 @@ func (r *Runner) Build(dir string) ([]byte, error) {
 	}
 
 	// Set environment variables (used by helm) and restore after build
-	restoreEnv := setEnvVars(envVars)
+	restoreEnv, err := setEnvVars(envVars)
+	if err != nil {
+		return nil, err
+	}
 	defer restoreEnv()
 
 	k := krusty.MakeKustomizer(opts)
@@ -125,7 +128,7 @@ type envVar struct {
 	key, value string
 }
 
-func setEnvVars(vars []envVar) func() {
+func setEnvVars(vars []envVar) (func(), error) {
 	originals := make(map[string]string)
 	unsetKeys := make([]string, 0)
 
@@ -135,15 +138,17 @@ func setEnvVars(vars []envVar) func() {
 		} else {
 			unsetKeys = append(unsetKeys, v.key)
 		}
-		os.Setenv(v.key, v.value)
+		if err := os.Setenv(v.key, v.value); err != nil {
+			return nil, fmt.Errorf("failed to set env %q: %w", v.key, err)
+		}
 	}
 
 	return func() {
 		for k, v := range originals {
-			os.Setenv(k, v)
+			_ = os.Setenv(k, v)
 		}
 		for _, k := range unsetKeys {
-			os.Unsetenv(k)
+			_ = os.Unsetenv(k)
 		}
-	}
+	}, nil
 }

--- a/internal/kustomize/runner.go
+++ b/internal/kustomize/runner.go
@@ -49,6 +49,7 @@ func (r *Runner) Build(dir string) ([]byte, error) {
 // buildOptions maps CLI args to krusty.Options.
 func (r *Runner) buildOptions() (*krusty.Options, []envVar, error) {
 	opts := krusty.MakeDefaultOptions()
+	opts.Reorder = krusty.ReorderOptionLegacy
 	var envVars []envVar
 
 	for i := 0; i < len(r.Args); i++ {

--- a/internal/kustomize/runner.go
+++ b/internal/kustomize/runner.go
@@ -50,9 +50,13 @@ func (r *Runner) Build(dir string) ([]byte, error) {
 }
 
 // buildOptions maps CLI args to krusty.Options.
+// LoadRestrictions and PluginRestrictions are hardcoded to permissive defaults
+// since crane controls the kustomization filesystem and doesn't need CLI-era restrictions.
 func (r *Runner) buildOptions() (*krusty.Options, []envVar, error) {
 	opts := krusty.MakeDefaultOptions()
 	opts.Reorder = krusty.ReorderOptionLegacy
+	opts.LoadRestrictions = types.LoadRestrictionsNone
+	opts.PluginConfig.PluginRestrictions = types.PluginRestrictionsNone
 	var envVars []envVar
 
 	for i := 0; i < len(r.Args); i++ {
@@ -60,10 +64,7 @@ func (r *Runner) buildOptions() (*krusty.Options, []envVar, error) {
 
 		switch {
 		case arg == "--enable-helm":
-			opts.PluginConfig = types.EnabledPluginConfig(types.BploUseStaticallyLinked)
-
-		case arg == "--enable-alpha-plugins":
-			opts.PluginConfig.PluginRestrictions = types.PluginRestrictionsNone
+			opts.PluginConfig.HelmConfig.Enabled = true
 
 		case arg == "--helm-command":
 			if i+1 >= len(r.Args) {
@@ -77,21 +78,6 @@ func (r *Runner) buildOptions() (*krusty.Options, []envVar, error) {
 			val := strings.SplitN(arg, "=", 2)[1]
 			opts.PluginConfig.HelmConfig.Enabled = true
 			opts.PluginConfig.HelmConfig.Command = val
-
-		case arg == "--load-restrictor":
-			if i+1 >= len(r.Args) {
-				return nil, nil, fmt.Errorf("--load-restrictor requires a value")
-			}
-			i++
-			if err := setLoadRestrictions(opts, r.Args[i]); err != nil {
-				return nil, nil, err
-			}
-
-		case strings.HasPrefix(arg, "--load-restrictor="):
-			val := strings.SplitN(arg, "=", 2)[1]
-			if err := setLoadRestrictions(opts, val); err != nil {
-				return nil, nil, err
-			}
 
 		case arg == "--env" || arg == "-e":
 			if i+1 >= len(r.Args) {
@@ -110,18 +96,6 @@ func (r *Runner) buildOptions() (*krusty.Options, []envVar, error) {
 	}
 
 	return opts, envVars, nil
-}
-
-func setLoadRestrictions(opts *krusty.Options, value string) error {
-	switch value {
-	case "LoadRestrictionsNone", "none":
-		opts.LoadRestrictions = types.LoadRestrictionsNone
-	case "LoadRestrictionsRootOnly", "rootOnly":
-		opts.LoadRestrictions = types.LoadRestrictionsRootOnly
-	default:
-		return fmt.Errorf("unknown load-restrictor value: %q", value)
-	}
-	return nil
 }
 
 type envVar struct {

--- a/internal/kustomize/runner.go
+++ b/internal/kustomize/runner.go
@@ -1,0 +1,148 @@
+package kustomize
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/kustomize/api/krusty"
+	"sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+)
+
+// Runner wraps the krusty API to build kustomizations without shelling out to kubectl/oc.
+type Runner struct {
+	Log  *logrus.Logger
+	Args []string
+}
+
+// Build runs kustomize build on the given directory and returns the rendered YAML.
+func (r *Runner) Build(dir string) ([]byte, error) {
+	opts, envVars, err := r.buildOptions()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build kustomize options: %w", err)
+	}
+
+	// Set environment variables (used by helm) and restore after build
+	restoreEnv := setEnvVars(envVars)
+	defer restoreEnv()
+
+	k := krusty.MakeKustomizer(opts)
+	resMap, err := k.Run(filesys.MakeFsOnDisk(), dir)
+	if err != nil {
+		return nil, fmt.Errorf("kustomize build failed for %s: %w", dir, err)
+	}
+
+	yamlBytes, err := resMap.AsYaml()
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize kustomize output: %w", err)
+	}
+
+	if r.Log != nil {
+		r.Log.Debugf("Kustomize build completed for %s (%d bytes)", dir, len(yamlBytes))
+	}
+
+	return yamlBytes, nil
+}
+
+// buildOptions maps CLI args to krusty.Options.
+func (r *Runner) buildOptions() (*krusty.Options, []envVar, error) {
+	opts := krusty.MakeDefaultOptions()
+	var envVars []envVar
+
+	for i := 0; i < len(r.Args); i++ {
+		arg := r.Args[i]
+
+		switch {
+		case arg == "--enable-helm":
+			opts.PluginConfig = types.EnabledPluginConfig(types.BploUseStaticallyLinked)
+
+		case arg == "--enable-alpha-plugins":
+			opts.PluginConfig.PluginRestrictions = types.PluginRestrictionsNone
+
+		case arg == "--helm-command":
+			if i+1 >= len(r.Args) {
+				return nil, nil, fmt.Errorf("--helm-command requires a value")
+			}
+			i++
+			opts.PluginConfig.HelmConfig.Enabled = true
+			opts.PluginConfig.HelmConfig.Command = r.Args[i]
+
+		case strings.HasPrefix(arg, "--helm-command="):
+			val := strings.SplitN(arg, "=", 2)[1]
+			opts.PluginConfig.HelmConfig.Enabled = true
+			opts.PluginConfig.HelmConfig.Command = val
+
+		case arg == "--load-restrictor":
+			if i+1 >= len(r.Args) {
+				return nil, nil, fmt.Errorf("--load-restrictor requires a value")
+			}
+			i++
+			if err := setLoadRestrictions(opts, r.Args[i]); err != nil {
+				return nil, nil, err
+			}
+
+		case strings.HasPrefix(arg, "--load-restrictor="):
+			val := strings.SplitN(arg, "=", 2)[1]
+			if err := setLoadRestrictions(opts, val); err != nil {
+				return nil, nil, err
+			}
+
+		case arg == "--env" || arg == "-e":
+			if i+1 >= len(r.Args) {
+				return nil, nil, fmt.Errorf("%s requires a value", arg)
+			}
+			i++
+			parts := strings.SplitN(r.Args[i], "=", 2)
+			if len(parts) != 2 {
+				return nil, nil, fmt.Errorf("invalid env format %q, expected KEY=VALUE", r.Args[i])
+			}
+			envVars = append(envVars, envVar{key: parts[0], value: parts[1]})
+
+		default:
+			return nil, nil, fmt.Errorf("unsupported kustomize argument: %q", arg)
+		}
+	}
+
+	return opts, envVars, nil
+}
+
+func setLoadRestrictions(opts *krusty.Options, value string) error {
+	switch value {
+	case "LoadRestrictionsNone", "none":
+		opts.LoadRestrictions = types.LoadRestrictionsNone
+	case "LoadRestrictionsRootOnly", "rootOnly":
+		opts.LoadRestrictions = types.LoadRestrictionsRootOnly
+	default:
+		return fmt.Errorf("unknown load-restrictor value: %q", value)
+	}
+	return nil
+}
+
+type envVar struct {
+	key, value string
+}
+
+func setEnvVars(vars []envVar) func() {
+	originals := make(map[string]string)
+	unsetKeys := make([]string, 0)
+
+	for _, v := range vars {
+		if orig, exists := os.LookupEnv(v.key); exists {
+			originals[v.key] = orig
+		} else {
+			unsetKeys = append(unsetKeys, v.key)
+		}
+		os.Setenv(v.key, v.value)
+	}
+
+	return func() {
+		for k, v := range originals {
+			os.Setenv(k, v)
+		}
+		for _, k := range unsetKeys {
+			os.Unsetenv(k)
+		}
+	}
+}

--- a/internal/kustomize/runner_test.go
+++ b/internal/kustomize/runner_test.go
@@ -1,0 +1,339 @@
+package kustomize
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestBuild_BasicKustomization(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "kustomize-runner-basic-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	resourceYAML := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+  namespace: default
+data:
+  key: value
+`
+	kustomizationYAML := `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- configmap.yaml
+`
+
+	if err := os.WriteFile(filepath.Join(tmpDir, "configmap.yaml"), []byte(resourceYAML), 0644); err != nil {
+		t.Fatalf("Failed to write resource: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "kustomization.yaml"), []byte(kustomizationYAML), 0644); err != nil {
+		t.Fatalf("Failed to write kustomization: %v", err)
+	}
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+	runner := &Runner{Log: logger}
+
+	output, err := runner.Build(tmpDir)
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	outputStr := string(output)
+	if !strings.Contains(outputStr, "test-config") {
+		t.Error("Output should contain ConfigMap name")
+	}
+	if !strings.Contains(outputStr, "key: value") {
+		t.Error("Output should contain ConfigMap data")
+	}
+}
+
+func TestBuild_WithPatches(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "kustomize-runner-patch-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	resourceYAML := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+      - name: web
+        image: nginx:1.21
+`
+	patchYAML := `- op: replace
+  path: /spec/replicas
+  value: 3
+`
+	kustomizationYAML := `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yaml
+patches:
+- path: patch.yaml
+  target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: web
+    namespace: default
+`
+
+	if err := os.WriteFile(filepath.Join(tmpDir, "deployment.yaml"), []byte(resourceYAML), 0644); err != nil {
+		t.Fatalf("Failed to write resource: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "patch.yaml"), []byte(patchYAML), 0644); err != nil {
+		t.Fatalf("Failed to write patch: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "kustomization.yaml"), []byte(kustomizationYAML), 0644); err != nil {
+		t.Fatalf("Failed to write kustomization: %v", err)
+	}
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+	runner := &Runner{Log: logger}
+
+	output, err := runner.Build(tmpDir)
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if !strings.Contains(string(output), "replicas: 3") {
+		t.Error("Patch should have changed replicas to 3")
+	}
+}
+
+func TestBuild_WithLoadRestrictionsNone(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "kustomize-runner-loadrestrict-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	resourceYAML := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+  namespace: default
+data:
+  key: value
+`
+	kustomizationYAML := `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- configmap.yaml
+`
+
+	if err := os.WriteFile(filepath.Join(tmpDir, "configmap.yaml"), []byte(resourceYAML), 0644); err != nil {
+		t.Fatalf("Failed to write resource: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "kustomization.yaml"), []byte(kustomizationYAML), 0644); err != nil {
+		t.Fatalf("Failed to write kustomization: %v", err)
+	}
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+	runner := &Runner{
+		Log:  logger,
+		Args: []string{"--load-restrictor=LoadRestrictionsNone"},
+	}
+
+	output, err := runner.Build(tmpDir)
+	if err != nil {
+		t.Fatalf("Build with --load-restrictor=LoadRestrictionsNone failed: %v", err)
+	}
+
+	if !strings.Contains(string(output), "test") {
+		t.Error("Output should contain the ConfigMap")
+	}
+}
+
+func TestBuild_InvalidDir(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+	runner := &Runner{Log: logger}
+
+	_, err := runner.Build("/nonexistent/path")
+	if err == nil {
+		t.Error("Build should fail for non-existent directory")
+	}
+}
+
+func TestBuild_MixedNamespacedAndClusterScoped(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "kustomize-runner-mixed-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	deployYAML := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: my-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+      - name: web
+        image: nginx:1.21
+`
+	clusterRoleYAML := `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: web-reader
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+`
+	kustomizationYAML := `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yaml
+- clusterrole.yaml
+`
+
+	if err := os.WriteFile(filepath.Join(tmpDir, "deployment.yaml"), []byte(deployYAML), 0644); err != nil {
+		t.Fatalf("Failed to write deployment: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "clusterrole.yaml"), []byte(clusterRoleYAML), 0644); err != nil {
+		t.Fatalf("Failed to write clusterrole: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "kustomization.yaml"), []byte(kustomizationYAML), 0644); err != nil {
+		t.Fatalf("Failed to write kustomization: %v", err)
+	}
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+	runner := &Runner{Log: logger}
+
+	output, err := runner.Build(tmpDir)
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	outputStr := string(output)
+	if !strings.Contains(outputStr, "Deployment") {
+		t.Error("Output should contain Deployment")
+	}
+	if !strings.Contains(outputStr, "ClusterRole") {
+		t.Error("Output should contain ClusterRole")
+	}
+}
+
+func TestBuildOptions_ArgMapping(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		expectErr bool
+	}{
+		{
+			name: "no args",
+			args: nil,
+		},
+		{
+			name: "enable-helm",
+			args: []string{"--enable-helm"},
+		},
+		{
+			name: "load-restrictor equals syntax",
+			args: []string{"--load-restrictor=LoadRestrictionsNone"},
+		},
+		{
+			name: "load-restrictor space syntax",
+			args: []string{"--load-restrictor", "LoadRestrictionsNone"},
+		},
+		{
+			name: "helm-command equals",
+			args: []string{"--helm-command=helm3"},
+		},
+		{
+			name: "helm-command space",
+			args: []string{"--helm-command", "helm3"},
+		},
+		{
+			name: "env var",
+			args: []string{"--env", "MY_VAR=hello"},
+		},
+		{
+			name: "env short flag",
+			args: []string{"-e", "MY_VAR=hello"},
+		},
+		{
+			name: "enable-alpha-plugins",
+			args: []string{"--enable-alpha-plugins"},
+		},
+		{
+			name:      "unknown arg",
+			args:      []string{"--unknown-flag"},
+			expectErr: true,
+		},
+		{
+			name:      "load-restrictor missing value",
+			args:      []string{"--load-restrictor"},
+			expectErr: true,
+		},
+		{
+			name:      "helm-command missing value",
+			args:      []string{"--helm-command"},
+			expectErr: true,
+		},
+		{
+			name:      "env missing value",
+			args:      []string{"--env"},
+			expectErr: true,
+		},
+		{
+			name:      "env invalid format",
+			args:      []string{"--env", "NOEQUALS"},
+			expectErr: true,
+		},
+		{
+			name:      "invalid load-restrictor value",
+			args:      []string{"--load-restrictor=InvalidValue"},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := &Runner{Args: tt.args}
+			_, _, err := runner.buildOptions()
+
+			if tt.expectErr && err == nil {
+				t.Error("Expected error but got none")
+			}
+			if !tt.expectErr && err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/internal/kustomize/runner_test.go
+++ b/internal/kustomize/runner_test.go
@@ -123,7 +123,7 @@ patches:
 	}
 }
 
-func TestBuild_WithLoadRestrictionsNone(t *testing.T) {
+func TestBuild_DefaultLoadRestrictionsNone(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "kustomize-runner-loadrestrict-*")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
@@ -153,14 +153,12 @@ resources:
 
 	logger := logrus.New()
 	logger.SetLevel(logrus.ErrorLevel)
-	runner := &Runner{
-		Log:  logger,
-		Args: []string{"--load-restrictor=LoadRestrictionsNone"},
-	}
+	// No args — LoadRestrictionsNone is hardcoded as default
+	runner := &Runner{Log: logger}
 
 	output, err := runner.Build(tmpDir)
 	if err != nil {
-		t.Fatalf("Build with --load-restrictor=LoadRestrictionsNone failed: %v", err)
+		t.Fatalf("Build with default LoadRestrictionsNone failed: %v", err)
 	}
 
 	if !strings.Contains(string(output), "test") {
@@ -264,14 +262,6 @@ func TestBuildOptions_ArgMapping(t *testing.T) {
 			args: []string{"--enable-helm"},
 		},
 		{
-			name: "load-restrictor equals syntax",
-			args: []string{"--load-restrictor=LoadRestrictionsNone"},
-		},
-		{
-			name: "load-restrictor space syntax",
-			args: []string{"--load-restrictor", "LoadRestrictionsNone"},
-		},
-		{
 			name: "helm-command equals",
 			args: []string{"--helm-command=helm3"},
 		},
@@ -288,17 +278,18 @@ func TestBuildOptions_ArgMapping(t *testing.T) {
 			args: []string{"-e", "MY_VAR=hello"},
 		},
 		{
-			name: "enable-alpha-plugins",
-			args: []string{"--enable-alpha-plugins"},
+			name:      "enable-alpha-plugins rejected",
+			args:      []string{"--enable-alpha-plugins"},
+			expectErr: true,
+		},
+		{
+			name:      "load-restrictor rejected",
+			args:      []string{"--load-restrictor=LoadRestrictionsNone"},
+			expectErr: true,
 		},
 		{
 			name:      "unknown arg",
 			args:      []string{"--unknown-flag"},
-			expectErr: true,
-		},
-		{
-			name:      "load-restrictor missing value",
-			args:      []string{"--load-restrictor"},
 			expectErr: true,
 		},
 		{
@@ -314,11 +305,6 @@ func TestBuildOptions_ArgMapping(t *testing.T) {
 		{
 			name:      "env invalid format",
 			args:      []string{"--env", "NOEQUALS"},
-			expectErr: true,
-		},
-		{
-			name:      "invalid load-restrictor value",
-			args:      []string{"--load-restrictor=InvalidValue"},
 			expectErr: true,
 		},
 	}

--- a/internal/transform/orchestrator.go
+++ b/internal/transform/orchestrator.go
@@ -32,7 +32,7 @@ type Orchestrator struct {
 	// NewlyCreatedStages tracks stages created in this run that can be overwritten
 	// This prevents double-write errors when creating a stage and then running it
 	NewlyCreatedStages map[string]bool
-	// KustomizeArgs holds additional arguments to pass to kubectl kustomize
+	// KustomizeArgs holds additional arguments for embedded kustomize (e.g. helm options)
 	KustomizeArgs []string
 }
 

--- a/internal/transform/orchestrator.go
+++ b/internal/transform/orchestrator.go
@@ -302,7 +302,7 @@ func (o *Orchestrator) applyStageTransforms(stageDir string) ([]unstructured.Uns
 
 	output, err := runner.Build(stageDir)
 	if err != nil {
-		return nil, fmt.Errorf("kustomize build failed: %w", err)
+		return nil, fmt.Errorf("kustomize build failed for stage directory %s: %w", stageDir, err)
 	}
 
 	// Parse the multi-document YAML output

--- a/internal/transform/orchestrator.go
+++ b/internal/transform/orchestrator.go
@@ -1,18 +1,17 @@
 package transform
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
 	jsonpatch "github.com/evanphx/json-patch"
 	cranelib "github.com/konveyor/crane-lib/transform"
 	"github.com/konveyor/crane/internal/file"
+	"github.com/konveyor/crane/internal/kustomize"
 	"github.com/konveyor/crane/internal/plugin"
 	"github.com/sirupsen/logrus"
 	yamlv3 "gopkg.in/yaml.v3"
@@ -294,39 +293,23 @@ func (o *Orchestrator) getAvailablePluginNames(plugins []cranelib.Plugin) string
 }
 
 // applyStageTransforms applies patches from a stage and returns the transformed resources
-// This materializes the output by running kubectl kustomize or oc kustomize on the stage directory
+// This materializes the output by running embedded kustomize on the stage directory
 func (o *Orchestrator) applyStageTransforms(stageDir string) ([]unstructured.Unstructured, error) {
-	// Run kubectl kustomize or oc kustomize to build the stage with patches applied
-	kustomizeCmd := file.GetKustomizeCommand()
-
-	// Build command arguments
-	cmdArgs := []string{"kustomize"}
-
-	// Add custom kustomize arguments if provided
-	if len(o.KustomizeArgs) > 0 {
-		cmdArgs = append(cmdArgs, o.KustomizeArgs...)
+	runner := &kustomize.Runner{
+		Log:  o.Log,
+		Args: o.KustomizeArgs,
 	}
 
-	// Add stage directory as last argument
-	cmdArgs = append(cmdArgs, stageDir)
-
-	cmd := exec.Command(kustomizeCmd, cmdArgs...)
-
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	o.Log.Debugf("Running: %s %s", kustomizeCmd, strings.Join(cmdArgs, " "))
-
-	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("%s kustomize failed: %w\nstderr: %s", kustomizeCmd, err, stderr.String())
+	output, err := runner.Build(stageDir)
+	if err != nil {
+		return nil, fmt.Errorf("kustomize build failed: %w", err)
 	}
 
 	// Parse the multi-document YAML output
 	var resources []unstructured.Unstructured
 
 	// Use yaml.v3 Decoder to properly handle multi-document YAML streams
-	decoder := yamlv3.NewDecoder(strings.NewReader(stdout.String()))
+	decoder := yamlv3.NewDecoder(strings.NewReader(string(output)))
 
 	for {
 		var doc interface{}

--- a/internal/transform/test_helpers.go
+++ b/internal/transform/test_helpers.go
@@ -1,21 +1,12 @@
 package transform
 
 import (
-	"os/exec"
 	"testing"
-
-	"github.com/konveyor/crane/internal/file"
 )
 
-// hasKustomizeCommand checks if kubectl or oc is available for kustomize
+// hasKustomizeCommand returns true since kustomize is embedded in the crane binary.
 func hasKustomizeCommand(t *testing.T) bool {
 	t.Helper()
-	cmd := file.GetKustomizeCommand()
-	// Try to run "<cmd> version" to verify it's available
-	if err := exec.Command(cmd, "version", "--client").Run(); err != nil {
-		t.Logf("Kustomize command '%s' not available: %v", cmd, err)
-		return false
-	}
 	return true
 }
 

--- a/internal/transform/writer.go
+++ b/internal/transform/writer.go
@@ -112,7 +112,7 @@ func (w *KustomizeWriter) WriteStage(artifacts []cranelib.TransformArtifact, for
 
 		// Write patch if there are operations
 		if len(artifact.Patches) > 0 {
-			// Filter out remove operations for non-existent paths to prevent kubectl kustomize errors
+			// Filter out remove operations for non-existent paths to prevent kustomize errors
 			validPatches, err := filterValidRemoveOps(artifact.Resource, artifact.Patches)
 			if err != nil {
 				return fmt.Errorf("failed to filter patches for %s/%s/%s: %w",
@@ -227,7 +227,7 @@ func getResourceID(resource unstructured.Unstructured) string {
 }
 
 // filterValidRemoveOps filters out JSONPatch remove operations for paths that don't exist in the resource.
-// This prevents kubectl kustomize from failing when trying to remove non-existent fields.
+// This prevents kustomize from failing when trying to remove non-existent fields.
 func filterValidRemoveOps(resource unstructured.Unstructured, patches jsonpatch.Patch) (jsonpatch.Patch, error) {
 	if len(patches) == 0 {
 		return patches, nil


### PR DESCRIPTION
 Replaces all `exec.Command` calls to `kubectl kustomize` / `oc kustomize` with the embedded
  `sigs.k8s.io/kustomize/api/krusty` library. Crane no longer requires `kubectl` or `oc` to be
  installed for `transform` and `apply` commands.

  Addresses [issue #369](https://github.com/migtools/crane/issues/369).

  ## Approach

  Created `internal/kustomize/Runner` that wraps the `krusty.MakeKustomizer(opts).Run(fSys, path)`
  API. The `Runner.Build(dir)` method maps CLI `--kustomize-args` flags to `krusty.Options` fields
  and returns rendered YAML bytes — same interface as the old `exec.Command` calls.
  
  ## Manual Testing on Minikube (kubectl removed from PATH)
  
  All scenarios ran with `kubectl` and `oc` removed from `PATH` to prove crane operates
  independently. Export uses client-go (kubeconfig), not kubectl binary. 

  ### Scenario 1: Basic namespaced resources (no cluster-scoped)
  - **Setup**: Namespace `crane-embed-s1` with Deployment + ConfigMap
  - **Result**: PASS — 2 resources in output (ConfigMap, Deployment), whiteouts excluded

  ### Scenario 2: Mixed namespaced + cluster-scoped (RBAC)
  - **Setup**: Namespace `crane-embed-s2` with Deployment + ServiceAccount + ClusterRole + ClusterRoleBinding
  - **Result**: PASS — 4 resources: namespaced under `resources/crane-embed-s2/`, cluster-scoped under `resources/_cluster/`

  ### Scenario 3: Multi-stage transform
  - **Setup**: Same as Scenario 2, added `20_CustomEdits` second stage
  - **Result**: PASS — Stage 2 loaded from stage 1 output, `_cluster/` separation preserved, apply picked last stage correctly

  ### Scenario 4: CRD + Custom Resource
  - **Setup**: CRD `widgets.cranetest.io` + Widget CR in namespace `crane-embed-s3`
  - **Result**: PASS — CRD in `_cluster/`, Widget in namespace directory, both clean (no server metadata)

  ### Scenario 5: Content correctness
  - **Verified**: CRD output has no `uid`, `resourceVersion`, `creationTimestamp`, `status` — KubernetesPlugin patches applied correctly by embedded kustomize

  ## Unit Tests
  
  ### New: `internal/kustomize/runner_test.go` (7 tests)
  
  | Test | Verifies |
  |------|----------|
  | `TestBuild_BasicKustomization` | Build a kustomization with a single ConfigMap |
  | `TestBuild_WithPatches` | JSONPatch applied correctly (replicas: 1 → 3) |
  | `TestBuild_WithLoadRestrictionsNone` | `--load-restrictor=LoadRestrictionsNone` maps correctly |
  | `TestBuild_InvalidDir` | Error on non-existent directory |
  | `TestBuild_MixedNamespacedAndClusterScoped` | Deployment + ClusterRole both render correctly |
  | `TestBuildOptions_ArgMapping` | 15 subtests covering all arg combinations, error cases |

  ### Existing tests
  All existing tests in `internal/transform/`, `internal/apply/`, `internal/kustomize/` pass unchanged.

  ## Files Changed
  
  | File | Lines |
  |------|-------|
  | `internal/kustomize/runner.go` | +130 (new) |
  | `internal/kustomize/runner_test.go` | +290 (new) |
  | `internal/transform/orchestrator.go` | -20 |
  | `internal/apply/kustomize.go` | -40 |
  | `internal/file/file_helper.go` | -17 |
  | `cmd/apply/apply.go` | -6 |
  | `internal/apply/kustomize_test.go` | -19 |
  | `internal/transform/test_helpers.go` | -8 |
  | `internal/kustomize/args.go` | -1 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kustomize is now embedded in the application, eliminating reliance on external kubectl/oc for builds.

* **Improvements**
  * Faster, more reliable in-process kustomize builds and clearer "kustomize build failed" error messages.
  * CLI help text for passing kustomize args updated.

* **Behavioral Changes**
  * Accepted kustomize flags narrowed (some flags like --enable-alpha-plugins and --load-restrictor are no longer allowed).

* **Tests**
  * Added and strengthened tests for build behavior and YAML handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/migtools/crane/pull/388?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->