### PR TITLE
Remove stateful commands from mta-ops CLI.

### DIFF
--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -60,6 +60,7 @@ func NewVersionCommand(f *flags.GlobalFlags) *cobra.Command {
 func (o *Options) run() error {
 	fmt.Println("crane:")
 	fmt.Printf("\tVersion: %s\n", buildinfo.Version)
+	fmt.Printf("\tSHA: %s\n", buildinfo.BuildCommit)
 	fmt.Println("crane-lib:")
 	fmt.Printf("\tVersion: %s\n", buildinfo.CranelibVersion)
 	return nil

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -5,6 +5,8 @@ import (
 )
 
 var (
+	// Version and BuildCommit can be overridden at build time with:
+	// go build -ldflags="-X github.com/konveyor/crane/internal/buildinfo.Version=<version> -X github.com/konveyor/crane/internal/buildinfo.BuildCommit=$(git rev-parse HEAD)"
 	Version string = "v0.0.6"
 
 	CranelibVersion string = cranelibversion.Version

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -8,4 +8,5 @@ var (
 	Version string = "v0.0.6"
 
 	CranelibVersion string = cranelibversion.Version
+	BuildCommit     string = ""
 )

--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -21,7 +21,7 @@ RUN set -e && \
         fi && \
         echo "Building standalone binary $output (version=${MTA_OPS_VERSION}, commit=${MTA_OPS_GIT_COMMIT})..." && \
         CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" go build -trimpath -mod=readonly \
-            -ldflags="-X github.com/konveyor/crane/internal/buildinfo.Version=${MTA_OPS_VERSION}" \
+            -ldflags="-X github.com/konveyor/crane/internal/buildinfo.Version=${MTA_OPS_VERSION} -X github.com/konveyor/crane/internal/buildinfo.BuildCommit=${MTA_OPS_GIT_COMMIT}" \
             -o "/tmp/archives/$output" ./main.go && \
         (cd /tmp/archives && sha256sum "$output" > "$output.sha256"); \
     done && \

--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -1,0 +1,54 @@
+FROM registry.redhat.io/ubi9/go-toolset:1.25 AS builder
+
+COPY . /workspace
+WORKDIR /workspace
+
+ARG BUILD_VERSION=v0.0.0
+ARG SOURCE_GIT_COMMIT=unknown
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+
+RUN set -e && \
+    MTA_OPS_VERSION="${BUILD_VERSION:-dev}" && \
+    mkdir -p /tmp/archives /tmp/bin && \
+    for platform in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64; do \
+        os=$(echo "$platform" | cut -d'/' -f1) && \
+        arch=$(echo "$platform" | cut -d'/' -f2) && \
+        if [ "$os" = "windows" ]; then \
+            output="mta-ops_${os}_${arch}.exe"; \
+        else \
+            output="mta-ops_${os}_${arch}"; \
+        fi && \
+        echo "Building standalone binary $output (version=${MTA_OPS_VERSION})..." && \
+        CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" go build -trimpath -mod=readonly \
+            -ldflags="-X github.com/konveyor/crane/internal/buildinfo.Version=${CRANE_VERSION}" \
+            -o "/tmp/archives/$output" ./main.go && \
+        (cd /tmp/archives && sha256sum "$output" > "$output.sha256"); \
+    done && \
+    cp LICENSE /tmp/archives/LICENSE && \
+    go clean -cache -modcache -testcache && \
+    rm -rf /opt/app-root/src/.cache /opt/app-root/src/go/pkg /tmp/go /tmp/.cache
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath -mod=readonly \
+    -ldflags="-X github.com/konveyor/crane/internal/buildinfo.Version=${BUILD_VERSION}" \
+    -o /tmp/bin/mta-ops ./main.go
+
+FROM registry.access.redhat.com/ubi9:latest
+
+RUN dnf -y install openssl && dnf -y reinstall tzdata && dnf clean all
+
+COPY --from=builder /tmp/archives /archives
+COPY --from=builder /tmp/bin/mta-ops /usr/local/bin/mta-ops
+COPY LICENSE /licenses/
+
+USER 1001
+
+ENTRYPOINT ["/usr/local/bin/mta-ops"]
+
+LABEL \
+    description="MTA-OPS CLI for Kubernetes migration workflows" \
+    io.k8s.description="MTA-Ops CLI for Kubernetes migration workflows" \
+    io.k8s.display-name="MTA-Ops CLI" \
+    io.openshift.maintainer.project="MTA-Ops" \
+    io.openshift.tags="migration,modernization,konveyor,mta-ops" \
+    summary="MTA-Ops CLI"

--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -35,7 +35,7 @@ RUN set -e && \
     go clean -cache -modcache -testcache && \
     rm -rf /opt/app-root/src/.cache /opt/app-root/src/go/pkg /tmp/go /tmp/.cache
 
-FROM registry.access.redhat.com/ubi9:latest
+FROM registry.redhat.io/ubi9/ubi:latest
 
 RUN dnf -y install openssl && dnf -y reinstall tzdata && dnf clean all
 

--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -25,14 +25,15 @@ RUN set -e && \
             -o "/tmp/archives/$output" ./main.go && \
         (cd /tmp/archives && sha256sum "$output" > "$output.sha256"); \
     done && \
+    if [ "${TARGETOS}" = "windows" ]; then \
+        runtime_output="mta-ops_${TARGETOS}_${TARGETARCH}.exe"; \
+    else \
+        runtime_output="mta-ops_${TARGETOS}_${TARGETARCH}"; \
+    fi && \
+    cp "/tmp/archives/${runtime_output}" /tmp/bin/mta-ops && \
     cp LICENSE /tmp/archives/LICENSE && \
     go clean -cache -modcache -testcache && \
     rm -rf /opt/app-root/src/.cache /opt/app-root/src/go/pkg /tmp/go /tmp/.cache
-
-RUN MTA_OPS_VERSION="${BUILD_VERSION:-dev}" && \
-    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath -mod=readonly \
-    -ldflags="-X github.com/konveyor/crane/internal/buildinfo.Version=${MTA_OPS_VERSION}" \
-    -o /tmp/bin/mta-ops ./main.go
 
 FROM registry.access.redhat.com/ubi9:latest
 

--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -51,6 +51,6 @@ LABEL \
     description="MTA-Ops CLI for Kubernetes migration workflows" \
     io.k8s.description="MTA-Ops CLI for Kubernetes migration workflows" \
     io.k8s.display-name="MTA-Ops CLI" \
-    io.openshift.maintainer.project="MTA-Ops" \
+    io.openshift.maintainer.project="MTA" \
     io.openshift.tags="migration,modernization,konveyor,mta-ops" \
     summary="MTA-Ops CLI"

--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -47,7 +47,7 @@ USER 1001
 ENTRYPOINT ["/usr/local/bin/mta-ops"]
 
 LABEL \
-    description="MTA-OPS CLI for Kubernetes migration workflows" \
+    description="MTA-Ops CLI for Kubernetes migration workflows" \
     io.k8s.description="MTA-Ops CLI for Kubernetes migration workflows" \
     io.k8s.display-name="MTA-Ops CLI" \
     io.openshift.maintainer.project="MTA-Ops" \

--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -3,13 +3,13 @@ FROM registry.redhat.io/ubi9/go-toolset:1.25 AS builder
 COPY . /workspace
 WORKDIR /workspace
 
-ARG BUILD_VERSION=v0.0.0
-ARG SOURCE_GIT_COMMIT=unknown
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
 
 RUN set -e && \
+    # Prefer ART/Konflux injected env vars; fall back for local builds.
     MTA_OPS_VERSION="${BUILD_VERSION:-dev}" && \
+    MTA_OPS_GIT_COMMIT="${SOURCE_GIT_COMMIT:-unknown}" && \
     mkdir -p /tmp/archives /tmp/bin && \
     for platform in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64; do \
         os=$(echo "$platform" | cut -d'/' -f1) && \
@@ -19,9 +19,9 @@ RUN set -e && \
         else \
             output="mta-ops_${os}_${arch}"; \
         fi && \
-        echo "Building standalone binary $output (version=${MTA_OPS_VERSION})..." && \
+        echo "Building standalone binary $output (version=${MTA_OPS_VERSION}, commit=${MTA_OPS_GIT_COMMIT})..." && \
         CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" go build -trimpath -mod=readonly \
-            -ldflags="-X github.com/konveyor/crane/internal/buildinfo.Version=${CRANE_VERSION}" \
+            -ldflags="-X github.com/konveyor/crane/internal/buildinfo.Version=${MTA_OPS_VERSION}" \
             -o "/tmp/archives/$output" ./main.go && \
         (cd /tmp/archives && sha256sum "$output" > "$output.sha256"); \
     done && \
@@ -29,8 +29,9 @@ RUN set -e && \
     go clean -cache -modcache -testcache && \
     rm -rf /opt/app-root/src/.cache /opt/app-root/src/go/pkg /tmp/go /tmp/.cache
 
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath -mod=readonly \
-    -ldflags="-X github.com/konveyor/crane/internal/buildinfo.Version=${BUILD_VERSION}" \
+RUN MTA_OPS_VERSION="${BUILD_VERSION:-dev}" && \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath -mod=readonly \
+    -ldflags="-X github.com/konveyor/crane/internal/buildinfo.Version=${MTA_OPS_VERSION}" \
     -o /tmp/bin/mta-ops ./main.go
 
 FROM registry.access.redhat.com/ubi9:latest

--- a/main.go
+++ b/main.go
@@ -4,13 +4,8 @@ import (
 	"os"
 
 	"github.com/konveyor/crane/cmd/apply"
-	"github.com/konveyor/crane/cmd/convert"
 	export "github.com/konveyor/crane/cmd/export"
-	plugin_manager "github.com/konveyor/crane/cmd/plugin-manager"
-	skopeo_sync_gen "github.com/konveyor/crane/cmd/skopeo-sync-gen"
-	transfer_pvc "github.com/konveyor/crane/cmd/transfer-pvc"
 	"github.com/konveyor/crane/cmd/transform"
-	tunnel_api "github.com/konveyor/crane/cmd/tunnel-api"
 	"github.com/konveyor/crane/cmd/validate"
 	"github.com/konveyor/crane/cmd/version"
 	"github.com/konveyor/crane/internal/flags"
@@ -21,19 +16,22 @@ import (
 func main() {
 	f := &flags.GlobalFlags{}
 	root := cobra.Command{
-		Use: "crane",
+		Use: "mta-ops",
 	}
 	f.ApplyFlags(&root)
 	root.AddCommand(export.NewExportCommand(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}, f))
-	root.AddCommand(transfer_pvc.NewTransferPVCCommand(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}))
-	root.AddCommand(tunnel_api.NewTunnelAPIOptions(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}))
-	root.AddCommand(convert.NewConvertOptions(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}))
 	root.AddCommand(transform.NewTransformCommand(f))
-	root.AddCommand(skopeo_sync_gen.NewSkopeoSyncGenCommand(f))
 	root.AddCommand(apply.NewApplyCommand(f))
-	root.AddCommand(plugin_manager.NewPluginManagerCommand(f))
-	root.AddCommand(version.NewVersionCommand(f))
 	root.AddCommand(validate.NewValidateCommand(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}, f))
+
+	// Disabled commands for this branch/release:
+	// root.AddCommand(transfer_pvc.NewTransferPVCCommand(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}))
+	// root.AddCommand(tunnel_api.NewTunnelAPIOptions(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}))
+	// root.AddCommand(convert.NewConvertOptions(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}))
+	// root.AddCommand(skopeo_sync_gen.NewSkopeoSyncGenCommand(f))
+	// root.AddCommand(plugin_manager.NewPluginManagerCommand(f))
+	root.AddCommand(version.NewVersionCommand(f))
+
 	if err := root.Execute(); err != nil {
 		os.Exit(1)
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Version output now displays the build commit alongside the version.

* **Changes**
  * CLI renamed from "crane" to "mta-ops".
  * Command set streamlined: active commands are export, transform, apply, validate, and version; removed/unregistered: convert, transfer-pvc, tunnel-api, skopeo-sync-gen, plugin-manager.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/migtools/crane/pull/397?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->