### PR TITLE
Add unit tests for apply command validation and kustomize applier

### DIFF
--- a/cmd/apply/apply_test.go
+++ b/cmd/apply/apply_test.go
@@ -1,11 +1,87 @@
 package apply
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/konveyor/crane/internal/flags"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
+
+// TestNewApplyCommand_PreRunBindsFlags verifies that PreRun correctly binds cobra flags
+// to viper and unmarshals them into the Options.Flags struct. We can't inspect the
+// internal Options directly, so we observe the effect through Validate's behavior:
+// if mutually exclusive flags are properly unmarshaled, Validate returns the expected error.
+func TestNewApplyCommand_PreRunBindsFlags(t *testing.T) {
+	tests := []struct {
+		name            string
+		flagsToSet      map[string]string
+		expectValError  bool
+		valErrorContain string
+	}{
+		{
+			name: "stage and from-stage are mutually exclusive",
+			flagsToSet: map[string]string{
+				"stage":      "10_kubernetes",
+				"from-stage": "20_openshift",
+			},
+			expectValError:  true,
+			valErrorContain: "mutually exclusive",
+		},
+		{
+			name: "stage and stages are mutually exclusive",
+			flagsToSet: map[string]string{
+				"stage":  "10_kubernetes",
+				"stages": "20_openshift",
+			},
+			expectValError:  true,
+			valErrorContain: "mutually exclusive",
+		},
+		{
+			name: "only stage set passes validation",
+			flagsToSet: map[string]string{
+				"stage": "10_kubernetes",
+			},
+			expectValError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			viper.Reset()
+
+			cmd := NewApplyCommand(&flags.GlobalFlags{})
+			for k, v := range tt.flagsToSet {
+				if err := cmd.Flags().Set(k, v); err != nil {
+					t.Fatalf("failed to set flag %q to %q: %v", k, v, err)
+				}
+			}
+
+			// Execute PreRun to bind flags → viper → Options.Flags
+			cmd.PreRun(cmd, []string{})
+
+			// Execute RunE which calls Complete → Validate → Run
+			err := cmd.RunE(cmd, []string{})
+
+			if tt.expectValError {
+				if err == nil {
+					t.Fatal("expected a validation error but RunE returned nil")
+				}
+				if !strings.Contains(err.Error(), tt.valErrorContain) {
+					t.Errorf("expected error containing %q, got: %v", tt.valErrorContain, err)
+				}
+			} else {
+				// When only "stage" is set, validation passes but run() will fail
+				// (e.g. kubectl not found). We just verify the error is NOT the
+				// validation error, which proves the flags were correctly unmarshaled.
+				if err != nil && strings.Contains(err.Error(), "mutually exclusive") {
+					t.Errorf("unexpected validation error: %v", err)
+				}
+			}
+		})
+	}
+}
 
 func TestValidate(t *testing.T) {
 	tests := []struct {
@@ -189,9 +265,9 @@ func TestStageSelectionRouting(t *testing.T) {
 			flags: Flags{
 				Stages: []string{"10_kubernetes", "30_imagestream"},
 			},
-			expectMulti:      true,
-			expectSelector:   true,
-			selectorStages:   []string{"10_kubernetes", "30_imagestream"},
+			expectMulti:    true,
+			expectSelector: true,
+			selectorStages: []string{"10_kubernetes", "30_imagestream"},
 		},
 	}
 

--- a/internal/apply/kustomize_test.go
+++ b/internal/apply/kustomize_test.go
@@ -13,7 +13,7 @@ func TestSplitMultiDocYAMLToFiles(t *testing.T) {
 	tests := []struct {
 		name           string
 		yamlData       string
-		expectedFiles  map[string]bool // path -> should exist
+		expectedFiles  map[string]bool   // path -> should exist
 		expectedInFile map[string]string // file -> substring to check
 		expectError    bool
 	}{
@@ -61,13 +61,13 @@ data:
   key: value
 `,
 			expectedFiles: map[string]bool{
-				"resources/ns1/Deployment_ns1_app1.yaml": true,
-				"resources/ns1/Service_ns1_svc1.yaml":    true,
+				"resources/ns1/Deployment_ns1_app1.yaml":   true,
+				"resources/ns1/Service_ns1_svc1.yaml":      true,
 				"resources/ns2/ConfigMap_ns2_config1.yaml": true,
 			},
 			expectedInFile: map[string]string{
-				"resources/ns1/Deployment_ns1_app1.yaml": "replicas: 1",
-				"resources/ns1/Service_ns1_svc1.yaml":    "type: ClusterIP",
+				"resources/ns1/Deployment_ns1_app1.yaml":   "replicas: 1",
+				"resources/ns1/Service_ns1_svc1.yaml":      "type: ClusterIP",
 				"resources/ns2/ConfigMap_ns2_config1.yaml": "key: value",
 			},
 		},
@@ -109,11 +109,11 @@ rules:
   verbs: ["get", "list"]
 `,
 			expectedFiles: map[string]bool{
-				"resources/prod/Service_prod_web.yaml": true,
+				"resources/prod/Service_prod_web.yaml":       true,
 				"resources/_cluster/ClusterRole_reader.yaml": true,
 			},
 			expectedInFile: map[string]string{
-				"resources/prod/Service_prod_web.yaml": "type: LoadBalancer",
+				"resources/prod/Service_prod_web.yaml":       "type: LoadBalancer",
 				"resources/_cluster/ClusterRole_reader.yaml": "verbs:",
 			},
 		},
@@ -163,11 +163,11 @@ data:
   key: val
 `,
 			expectedFiles: map[string]bool{
-				"resources/default/Service_default_svc.yaml": true,
+				"resources/default/Service_default_svc.yaml":  true,
 				"resources/default/ConfigMap_default_cm.yaml": true,
 			},
 			expectedInFile: map[string]string{
-				"resources/default/Service_default_svc.yaml": "type: ClusterIP",
+				"resources/default/Service_default_svc.yaml":  "type: ClusterIP",
 				"resources/default/ConfigMap_default_cm.yaml": "key: val",
 			},
 		},
@@ -491,6 +491,95 @@ data:
 
 	if !foundIndentedLine {
 		t.Error("Expected to find indented lines in YAML output")
+	}
+}
+
+func newTestApplier(transformDir, outputDir string) *KustomizeApplier {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+	return &KustomizeApplier{
+		Log:          logger,
+		TransformDir: transformDir,
+		OutputDir:    outputDir,
+	}
+}
+
+func TestApplySingleStageValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		stageName   string
+		createStage bool
+		errContains string
+	}{
+		{
+			name:        "returns error when stage directory does not exist",
+			stageName:   "99_NonExistent",
+			createStage: false,
+			errContains: "stage directory does not exist",
+		},
+		{
+			name:        "returns error when kustomization.yaml is missing",
+			stageName:   "10_TestPlugin",
+			createStage: true,
+			errContains: "kustomization.yaml not found in stage: 10_TestPlugin",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir, err := os.MkdirTemp("", "crane-single-validate-*")
+			if err != nil {
+				t.Fatalf("Failed to create temp dir: %v", err)
+			}
+			defer os.RemoveAll(tmpDir)
+
+			transformDir := filepath.Join(tmpDir, "transform")
+			if err := os.MkdirAll(transformDir, 0700); err != nil {
+				t.Fatalf("Failed to create transform dir: %v", err)
+			}
+
+			if tt.createStage {
+				stageDir := filepath.Join(transformDir, tt.stageName)
+				if err := os.MkdirAll(stageDir, 0700); err != nil {
+					t.Fatalf("Failed to create stage dir: %v", err)
+				}
+			}
+
+			applier := newTestApplier(transformDir, filepath.Join(tmpDir, "output"))
+			err = applier.ApplySingleStage(tt.stageName)
+
+			if err == nil {
+				t.Fatal("Expected error but got nil")
+			}
+			if !strings.Contains(err.Error(), tt.errContains) {
+				t.Errorf("Error %q should contain %q", err.Error(), tt.errContains)
+			}
+		})
+	}
+}
+
+func TestApplyFinalStageNoStages(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "crane-final-validate-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	transformDir := filepath.Join(tmpDir, "transform")
+	if err := os.MkdirAll(transformDir, 0700); err != nil {
+		t.Fatalf("Failed to create transform dir: %v", err)
+	}
+
+	applier := newTestApplier(transformDir, filepath.Join(tmpDir, "output"))
+	err = applier.ApplyFinalStage()
+
+	if err == nil {
+		t.Fatal("Expected error but got nil")
+	}
+
+	expected := "no stages found in transform directory"
+	if !strings.Contains(err.Error(), expected) {
+		t.Errorf("Error %q should contain %q", err.Error(), expected)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds unit test coverage for the apply command across the CLI layer and internal kustomize applier. These paths had no dedicated unit tests before — flag binding, mutual exclusivity validation, and applier error handling were only exercised indirectly through integration tests.

## What's covered

**Flag binding and mutual exclusivity validation:**
- PreRun correctly binds flags to viper so values round-trip through Execute
- `--stage` and `--from-stage` rejected as mutually exclusive
- `--stage` and `--stages` rejected as mutually exclusive
- Single `--stage` flag passes validation

**Single stage validation (`ApplySingleStage`):**
- Non-existent stage directory returns error
- Missing kustomization.yaml in stage directory returns error

**Final stage validation (`ApplyFinalStage`):**
- Empty transform directory with no stages returns error

## Test plan

- [x] `go test ./cmd/apply/...`
- [x] `go test ./internal/apply/...`

closes #405



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for flag validation to ensure proper handling of conflicting options.
  * Added tests for stage validation to verify appropriate error responses when required stage files are missing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/migtools/crane/pull/404?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->