### PR TITLE
comment out flaky PVC content validation pending root cause investigation

### DIFF
--- a/e2e-tests/tests/mta_813_cronJob_PVC_test.go
+++ b/e2e-tests/tests/mta_813_cronJob_PVC_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 var _ = Describe("CronJob with attached PVC migration as non-admin user", func() {
-	It("[BUG #330][MTA-813] Should migrate a cronjob and its attached PVC as a namespace-admin user", Label("BUG #330", "tier0"), func() {
+	It("[BUG #330][BUG #408][MTA-813] Should migrate a cronjob and its attached PVC as a namespace-admin user", Label("BUG #330", "BUG #408", "tier0"), func() {
 		appName := "cronjob"
 		namespace := "mta-813-ns"
 		expectedLogSubstring := fmt.Sprintf("Hello! from namespace %s", namespace)
@@ -223,20 +223,18 @@ var _ = Describe("CronJob with attached PVC migration as non-admin user", func()
 		log.Printf("CronJob %s confirmed on target with correct schedule\n", appName)
 
 		By("Skipped - Verify PVC data was transferred intact by running a reader pod on target")
-		// TODO: PVC data integrity assertion is commented out due to flaky behavior on Linux
-		// (locally and on CI). On macOS, migration works correctly as namespace-admin and PVC
-		// content is transferred consistently. On Linux however, even with cluster-admin
-		// contexts, the PVC transfers (Bound on target) but the content is sometimes empty
-		// with no error surfaced.
+		// TODO(https://github.com/migtools/crane/issues/408): PVC data integrity assertion
+		// is commented out due to flaky behavior on Linux (locally and on CI). On macOS,
+		// migration works correctly as namespace-admin and PVC content is transferred
+		// consistently. On Linux however, even with cluster-admin contexts, the PVC transfers
+		// (Bound on target) but the content is sometimes empty with no error surfaced.
 		//
 		// When investigating the crane source, the rsync server health check result was found
 		// to be silently discarded in cmd/transfer-pvc/transfer-pvc.go — if the server never
 		// becomes healthy, the command proceeds anyway with no error, making it harder to
 		// diagnose why the content isn't being transferred on Linux.
 		//
-		// This will be investigated further after the initial release. The assertion will be
-		// re-enabled once the root cause is confirmed and a bug is filed.
-
+		// Re-enable this assertion once crane#408 is resolved.
 		// _, err = scenario.KubectlTgtNonAdmin.Run(
 		// 	"run", "pvc-reader",
 		// 	"-n", namespace,

--- a/e2e-tests/tests/mta_813_cronJob_PVC_test.go
+++ b/e2e-tests/tests/mta_813_cronJob_PVC_test.go
@@ -222,46 +222,60 @@ var _ = Describe("CronJob with attached PVC migration as non-admin user", func()
 		}, "1m", "5s").Should(Equal("*/1 * * * *"))
 		log.Printf("CronJob %s confirmed on target with correct schedule\n", appName)
 
-		By("Verify PVC data was transferred intact by running a reader pod on target")
-		_, err = scenario.KubectlTgtNonAdmin.Run(
-			"run", "pvc-reader",
-			"-n", namespace,
-			"--image=busybox",
-			"--restart=Never",
-			fmt.Sprintf(`--overrides={
-				"spec": {
-					"containers": [{
-						"name": "pvc-reader",
-						"image": "busybox",
-						"command": ["sh", "-c", "cat /data/log.txt || echo FILE_NOT_FOUND"],
-						"volumeMounts": [{"name":"data","mountPath":"/data"}]
-					}],
-					"volumes": [{"name":"data","persistentVolumeClaim":{"claimName":"%s"}}],
-					"restartPolicy": "Never"
-				}
-			}`, pvcName),
-		)
-		Expect(err).NotTo(HaveOccurred())
+		By("Skipped - Verify PVC data was transferred intact by running a reader pod on target")
+		// TODO: PVC data integrity assertion is commented out due to flaky behavior on Linux
+		// (locally and on CI). On macOS, migration works correctly as namespace-admin and PVC
+		// content is transferred consistently. On Linux however, even with cluster-admin
+		// contexts, the PVC transfers (Bound on target) but the content is sometimes empty
+		// with no error surfaced.
+		//
+		// When investigating the crane source, the rsync server health check result was found
+		// to be silently discarded in cmd/transfer-pvc/transfer-pvc.go — if the server never
+		// becomes healthy, the command proceeds anyway with no error, making it harder to
+		// diagnose why the content isn't being transferred on Linux.
+		//
+		// This will be investigated further after the initial release. The assertion will be
+		// re-enabled once the root cause is confirmed and a bug is filed.
 
-		Eventually(func() string {
-			out, err := scenario.KubectlTgtNonAdmin.Run(
-				"get", "pod", "pvc-reader",
-				"-n", namespace,
-				"-o", "jsonpath={.status.phase}",
-			)
-			if err != nil {
-				return ""
-			}
-			return out
-		}, "2m", "5s").Should(Or(Equal("Succeeded"), Equal("Failed")))
+		// _, err = scenario.KubectlTgtNonAdmin.Run(
+		// 	"run", "pvc-reader",
+		// 	"-n", namespace,
+		// 	"--image=busybox",
+		// 	"--restart=Never",
+		// 	fmt.Sprintf(`--overrides={
+		// 		"spec": {
+		// 			"containers": [{
+		// 				"name": "pvc-reader",
+		// 				"image": "busybox",
+		// 				"command": ["sh", "-c", "cat /data/log.txt || echo FILE_NOT_FOUND"],
+		// 				"volumeMounts": [{"name":"data","mountPath":"/data"}]
+		// 			}],
+		// 			"volumes": [{"name":"data","persistentVolumeClaim":{"claimName":"%s"}}],
+		// 			"restartPolicy": "Never"
+		// 		}
+		// 	}`, pvcName),
+		// )
+		// Expect(err).NotTo(HaveOccurred())
 
-		pvcReaderLogs, err := scenario.KubectlTgtNonAdmin.Run("logs", "pvc-reader", "-n", namespace)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(pvcReaderLogs).To(ContainSubstring(expectedLogSubstring),
-			"expected PVC log.txt to contain data written on source cluster")
-		log.Printf("PVC data integrity confirmed, source log entries present on target\n")
+		// Eventually(func() string {
+		// 	out, err := scenario.KubectlTgtNonAdmin.Run(
+		// 		"get", "pod", "pvc-reader",
+		// 		"-n", namespace,
+		// 		"-o", "jsonpath={.status.phase}",
+		// 	)
+		// 	if err != nil {
+		// 		return ""
+		// 	}
+		// 	return out
+		// }, "2m", "5s").Should(Or(Equal("Succeeded"), Equal("Failed")))
 
-		_, _ = scenario.KubectlTgtNonAdmin.Run("delete", "pod", "pvc-reader", "-n", namespace, "--ignore-not-found=true")
+		// pvcReaderLogs, err := scenario.KubectlTgtNonAdmin.Run("logs", "pvc-reader", "-n", namespace)
+		// Expect(err).NotTo(HaveOccurred())
+		// Expect(pvcReaderLogs).To(ContainSubstring(expectedLogSubstring),
+		// 	"expected PVC log.txt to contain data written on source cluster")
+		// log.Printf("PVC data integrity confirmed, source log entries present on target\n")
+
+		// _, _ = scenario.KubectlTgtNonAdmin.Run("delete", "pod", "pvc-reader", "-n", namespace, "--ignore-not-found=true")
 
 		By("Unsuspend CronJob on target and verify it fires")
 		_, err = scenario.KubectlTgtNonAdmin.Run(


### PR DESCRIPTION
Update e2e test for CronJob PVC migration: Comment out PVC data integrity checks due to flaky behavior on Linux. Investigation planned for root cause analysis post-release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end CronJob + PVC migration test: added bug labels, removed the runtime data-integrity pod check in the target namespace (replaced with a commented "Skipped" section and TODO notes citing flaky Linux behavior), while retaining the remainder of the test flow (unsuspending the target CronJob and validating execution/logs).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/migtools/crane/pull/407?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->