### PR TITLE
Added kustomize version

### DIFF
--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -37,7 +37,7 @@ func NewVersionCommand(f *flags.GlobalFlags) *cobra.Command {
 	}
 	cmd := &cobra.Command{
 		Use:   "version",
-		Short: "Return the current crane (and crane-lib) version",
+		Short: "Return the current crane, crane-lib, and kustomize versions",
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := o.Complete(c, args); err != nil {
 				return err

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -62,5 +62,7 @@ func (o *Options) run() error {
 	fmt.Printf("\tVersion: %s\n", buildinfo.Version)
 	fmt.Println("crane-lib:")
 	fmt.Printf("\tVersion: %s\n", buildinfo.CranelibVersion)
+	fmt.Println("kustomize:")
+	fmt.Printf("\tVersion: %s\n", buildinfo.KustomizeVersion)
 	return nil
 }

--- a/cmd/version/version_test.go
+++ b/cmd/version/version_test.go
@@ -1,0 +1,48 @@
+package version
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/konveyor/crane/internal/buildinfo"
+)
+
+func TestVersionOutput(t *testing.T) {
+	// Capture stdout
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	o := &Options{}
+	err := o.run()
+
+	w.Close()
+	os.Stdout = old
+
+	if err != nil {
+		t.Fatalf("run() returned error: %v", err)
+	}
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	output := buf.String()
+
+	if !strings.Contains(output, "crane:") {
+		t.Error("output should contain 'crane:' header")
+	}
+	if !strings.Contains(output, "crane-lib:") {
+		t.Error("output should contain 'crane-lib:' header")
+	}
+	if !strings.Contains(output, "kustomize:") {
+		t.Error("output should contain 'kustomize:' header")
+	}
+	if !strings.Contains(output, buildinfo.Version) {
+		t.Errorf("output should contain crane version %q", buildinfo.Version)
+	}
+	if !strings.Contains(output, buildinfo.KustomizeVersion) {
+		t.Errorf("output should contain kustomize version %q", buildinfo.KustomizeVersion)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,8 @@ require (
 	k8s.io/cli-runtime v0.35.3
 	k8s.io/client-go v0.35.3
 	sigs.k8s.io/controller-runtime v0.23.3
-	sigs.k8s.io/kustomize/api v0.20.1
+	sigs.k8s.io/kustomize/api v0.21.1
+	sigs.k8s.io/kustomize/kustomize/v5 v5.8.1
 	sigs.k8s.io/kustomize/kyaml v0.21.1
 	sigs.k8s.io/yaml v1.6.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1049,8 +1049,10 @@ sigs.k8s.io/controller-runtime v0.23.3 h1:VjB/vhoPoA9l1kEKZHBMnQF33tdCLQKJtydy4i
 sigs.k8s.io/controller-runtime v0.23.3/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
-sigs.k8s.io/kustomize/api v0.20.1 h1:iWP1Ydh3/lmldBnH/S5RXgT98vWYMaTUL1ADcr+Sv7I=
-sigs.k8s.io/kustomize/api v0.20.1/go.mod h1:t6hUFxO+Ph0VxIk1sKp1WS0dOjbPCtLJ4p8aADLwqjM=
+sigs.k8s.io/kustomize/api v0.21.1 h1:lzqbzvz2CSvsjIUZUBNFKtIMsEw7hVLJp0JeSIVmuJs=
+sigs.k8s.io/kustomize/api v0.21.1/go.mod h1:f3wkKByTrgpgltLgySCntrYoq5d3q7aaxveSagwTlwI=
+sigs.k8s.io/kustomize/kustomize/v5 v5.8.1 h1:Pgsg5psubpVEy7Nf6S89PARg5VmmWUC1l9dC6Dl4PG0=
+sigs.k8s.io/kustomize/kustomize/v5 v5.8.1/go.mod h1:0vFa5pQ/elNEQMyiAJuGku9rhAMzz7u9+61hRqFKiwY=
 sigs.k8s.io/kustomize/kyaml v0.21.1 h1:IVlbmhC076nf6foyL6Taw4BkrLuEsXUXNpsE+ScX7fI=
 sigs.k8s.io/kustomize/kyaml v0.21.1/go.mod h1:hmxADesM3yUN2vbA5z1/YTBnzLJ1dajdqpQonwBL1FQ=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -4,6 +4,9 @@ import (
 	"runtime/debug"
 
 	cranelibversion "github.com/konveyor/crane-lib/version"
+	// Blank import to keep the kustomize CLI module in the dependency graph
+	// so debug.ReadBuildInfo() can report its version.
+	_ "sigs.k8s.io/kustomize/kustomize/v5/commands/version"
 )
 
 var (
@@ -22,7 +25,7 @@ func readKustomizeVersion() string {
 		return "unknown"
 	}
 	for _, dep := range info.Deps {
-		if dep.Path == "sigs.k8s.io/kustomize/api" {
+		if dep.Path == "sigs.k8s.io/kustomize/kustomize/v5" {
 			return dep.Version
 		}
 	}

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -1,6 +1,8 @@
 package buildinfo
 
 import (
+	"runtime/debug"
+
 	cranelibversion "github.com/konveyor/crane-lib/version"
 )
 
@@ -8,4 +10,19 @@ var (
 	Version string = "v0.0.6"
 
 	CranelibVersion string = cranelibversion.Version
+
+	KustomizeVersion string = readKustomizeVersion()
 )
+
+func readKustomizeVersion() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "unknown"
+	}
+	for _, dep := range info.Deps {
+		if dep.Path == "sigs.k8s.io/kustomize/api" {
+			return dep.Version
+		}
+	}
+	return "unknown"
+}

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -14,8 +14,10 @@ var (
 	KustomizeVersion string = readKustomizeVersion()
 )
 
+var readBuildInfo = debug.ReadBuildInfo
+
 func readKustomizeVersion() string {
-	info, ok := debug.ReadBuildInfo()
+	info, ok := readBuildInfo()
 	if !ok {
 		return "unknown"
 	}

--- a/internal/buildinfo/buildinfo_test.go
+++ b/internal/buildinfo/buildinfo_test.go
@@ -45,13 +45,13 @@ func TestReadKustomizeVersion_DepFound(t *testing.T) {
 		return &debug.BuildInfo{
 			Deps: []*debug.Module{
 				{Path: "github.com/some/other-dep", Version: "v1.0.0"},
-				{Path: "sigs.k8s.io/kustomize/api", Version: "v0.20.1"},
+				{Path: "sigs.k8s.io/kustomize/kustomize/v5", Version: "v5.8.1"},
 			},
 		}, true
 	}
 
 	result := readKustomizeVersion()
-	if result != "v0.20.1" {
-		t.Errorf("expected \"v0.20.1\", got %q", result)
+	if result != "v5.8.1" {
+		t.Errorf("expected \"v5.8.1\", got %q", result)
 	}
 }

--- a/internal/buildinfo/buildinfo_test.go
+++ b/internal/buildinfo/buildinfo_test.go
@@ -1,0 +1,57 @@
+package buildinfo
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func TestReadKustomizeVersion_BuildInfoUnavailable(t *testing.T) {
+	original := readBuildInfo
+	defer func() { readBuildInfo = original }()
+
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return nil, false
+	}
+
+	result := readKustomizeVersion()
+	if result != "unknown" {
+		t.Errorf("expected \"unknown\" when build info unavailable, got %q", result)
+	}
+}
+
+func TestReadKustomizeVersion_DepNotFound(t *testing.T) {
+	original := readBuildInfo
+	defer func() { readBuildInfo = original }()
+
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Deps: []*debug.Module{
+				{Path: "github.com/some/other-dep", Version: "v1.0.0"},
+			},
+		}, true
+	}
+
+	result := readKustomizeVersion()
+	if result != "unknown" {
+		t.Errorf("expected \"unknown\" when dep not found, got %q", result)
+	}
+}
+
+func TestReadKustomizeVersion_DepFound(t *testing.T) {
+	original := readBuildInfo
+	defer func() { readBuildInfo = original }()
+
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Deps: []*debug.Module{
+				{Path: "github.com/some/other-dep", Version: "v1.0.0"},
+				{Path: "sigs.k8s.io/kustomize/api", Version: "v0.20.1"},
+			},
+		}, true
+	}
+
+	result := readKustomizeVersion()
+	if result != "v0.20.1" {
+		t.Errorf("expected \"v0.20.1\", got %q", result)
+	}
+}


### PR DESCRIPTION
 # PR: Add kustomize version to `crane version` output

  Task 2 of [issue #369](https://github.com/migtools/crane/issues/369). Now that kustomize is embedded, users need visibility into which kustomize version is baked into the crane binary.

  ## Output

  $ crane version
  crane:
      Version: v0.0.6
  crane-lib:
      Version: v0.0.10
  kustomize:
      Version: v5.8.1

  ## Binary Size Impact

  - Before: 81,710,386 bytes (78M)
  - After: 81,728,770 bytes (78M)
  - Increase: ~18KB (0.02%)

  ## Files Changed

  | File | Lines | Change |
  |------|-------|--------|
  | `internal/buildinfo/buildinfo.go` | +16 | `KustomizeVersion` via CLI module + `debug.ReadBuildInfo()` |
  | `internal/buildinfo/buildinfo_test.go` | +57 | 3 unit tests |
  | `cmd/version/version.go` | +3 | Print kustomize version, update Short description |
  | `cmd/version/version_test.go` | +46 | 1 test for version output |
  | `go.mod` / `go.sum` | +2 | Added kustomize CLI module dependency |