### PR TITLE
Add e2e tests for cluster-scoped RBAC migration

### DIFF
--- a/e2e-tests/framework/rbac.go
+++ b/e2e-tests/framework/rbac.go
@@ -140,3 +140,18 @@ func SetupNamespaceAdminUsersForScenario(scenario MigrationScenario, namespace s
 
 	return srcNonAdminKubectl, tgtNonAdminKubectl, cleanup, nil
 }
+
+func NonAdminApps(scenario MigrationScenario) (soruceApp K8sDeployApp, targetApp K8sDeployApp) {
+	srcAppNonAdmin := scenario.SrcAppNonAdmin
+	tgtAppNonAdmin := scenario.TgtAppNonAdmin
+
+	srcAppNonAdmin.ExtraVars = map[string]any{
+		"non_admin_user": "true",
+	}
+	tgtAppNonAdmin.ExtraVars = map[string]any{
+		"non_admin_user": "true",
+	}
+
+	return srcAppNonAdmin, tgtAppNonAdmin
+
+}

--- a/e2e-tests/framework/test_utils.go
+++ b/e2e-tests/framework/test_utils.go
@@ -1,0 +1,259 @@
+package framework
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/onsi/gomega"
+)
+
+type ClusterResource struct {
+	Kind string
+	Name string
+}
+
+// ClusterResourceCleanup deletes cluster-scoped resources (e.g. ClusterRoles, CRBs) on both clusters. Best-effort.
+func ClusterResourceCleanup(srcKubectl, tgtKubectl KubectlRunner, resources []ClusterResource) {
+	for _, k := range []KubectlRunner{srcKubectl, tgtKubectl} {
+		for _, r := range resources {
+			if _, err := k.Run("delete", r.Kind, r.Name, "--ignore-not-found=true"); err != nil {
+				log.Printf("cleanup: failed to delete %s %s: %v", r.Kind, r.Name, err)
+			}
+		}
+	}
+}
+
+// ScenarioCleanup removes temp dirs, apps, and namespaces on both clusters. Best-effort.
+func ScenarioCleanup(paths ScenarioPaths, srcApp, tgtApp K8sDeployApp, srcKubectl, tgtKubectl KubectlRunner, namespace string) {
+	if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
+		log.Printf("cleanup: %v", err)
+	}
+	for _, k := range []KubectlRunner{srcKubectl, tgtKubectl} {
+		if _, err := k.Run("delete", "namespace", namespace, "--ignore-not-found=true", "--wait=true"); err != nil {
+			log.Printf("cleanup: failed to delete namespace %q: %v", namespace, err)
+		}
+	}
+}
+
+// ValidateDirResources checks that a directory exists and contains files matching the given glob patterns.
+func ValidateDirResources(path string, resources []string) error {
+	_, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("directory not found at %s: %w", path, err)
+	}
+
+	for _, resource := range resources {
+		matches, err := filepath.Glob(filepath.Join(path, resource))
+		if err != nil {
+			return fmt.Errorf("glob error for %s at %s: %w", resource, path, err)
+		}
+		if len(matches) == 0 {
+			return fmt.Errorf("no files matching %s at %s", resource, path)
+		}
+		log.Printf("found %d file(s) matching %s at %s", len(matches), resource, path)
+	}
+	return nil
+}
+
+// ValidatePipelineClusterResources verifies cluster resource files exist across all pipeline stages (export, transform, apply).
+// Pass nil for transformStages to default to 10_KubernetesPlugin.
+func ValidatePipelineClusterResources(paths ScenarioPaths, namespace string, resources []string, transformStages *[]string) error {
+	exportClusterDir := filepath.Join(paths.ExportDir, "resources", namespace, "_cluster")
+	log.Printf("Validating Export _cluster directory")
+	if err := ValidateDirResources(exportClusterDir, resources); err != nil {
+		return fmt.Errorf("Export: %w", err)
+	}
+
+	stages := []string{"10_KubernetesPlugin"}
+	if transformStages != nil && len(*transformStages) > 0 {
+		stages = *transformStages
+	}
+	for _, stage := range stages {
+		transformClusterDir := filepath.Join(paths.TransformDir, ".work", stage, "output", "_cluster")
+		log.Printf("Validating Transform(%s) _cluster directory", stage)
+		if err := ValidateDirResources(transformClusterDir, resources); err != nil {
+			return fmt.Errorf("Transform(%s): %w", stage, err)
+		}
+	}
+
+	outputClusterDir := filepath.Join(paths.OutputDir, "resources", "_cluster")
+	log.Printf("Validating Apply _cluster directory")
+	if err := ValidateDirResources(outputClusterDir, resources); err != nil {
+		return fmt.Errorf("Apply: %w", err)
+	}
+
+	return nil
+}
+
+// RunPipeline sets the work dir and runs crane export, transform, and apply.
+func RunPipeline(runner *CraneRunner, namespace string, paths ScenarioPaths) error {
+	runner.WorkDir = paths.TempDir
+	log.Printf("Running crane pipeline for namespace %s", namespace)
+	if err := RunCranePipelineWithChecks(*runner, namespace, paths); err != nil {
+		return fmt.Errorf("pipeline failed: %w", err)
+	}
+	log.Printf("Crane pipeline completed")
+	return nil
+}
+
+// ScaleAndValidateTargetApp scales the deployment to n replica and waits up to 2m for the app to validate.
+func ScaleAndValidateTargetApp(kubectlTgt KubectlRunner, tgtApp K8sDeployApp, namespace, appName string) {
+	gomega.Expect(kubectlTgt.ScaleDeployment(namespace, appName, 1)).NotTo(gomega.HaveOccurred())
+	gomega.Eventually(tgtApp.Validate, "2m", "10s").Should(gomega.Succeed())
+	log.Printf("Target app validated successfully")
+}
+
+type ExpectedClusterRoleBinding struct {
+	ClusterRoleBindingName string
+	ClusterRoleName        string
+	SubjectName            string
+}
+
+// ValidateClusterRBAC verifies that each CRB exists, references the expected ClusterRole, and has the expected subject.
+func ValidateClusterRBAC(kubectl KubectlRunner, namespace string, bindings []ExpectedClusterRoleBinding) error {
+	clusterRoles := map[string]bool{}
+	for _, b := range bindings {
+		clusterRoles[b.ClusterRoleName] = true
+	}
+	for cr := range clusterRoles {
+		if _, err := kubectl.Run("get", "clusterrole", cr); err != nil {
+			return fmt.Errorf("ClusterRole %s not found: %w", cr, err)
+		}
+		log.Printf("ClusterRole %s exists", cr)
+	}
+
+	for _, b := range bindings {
+		if _, err := kubectl.Run("get", "clusterrolebinding", b.ClusterRoleBindingName); err != nil {
+			return fmt.Errorf("ClusterRoleBinding %s not found: %w", b.ClusterRoleBindingName, err)
+		}
+
+		roleRef, err := kubectl.Run("get", "clusterrolebinding", b.ClusterRoleBindingName, "-o", "jsonpath={.roleRef.name}")
+		if err != nil {
+			return fmt.Errorf("failed to get roleRef for CRB %s: %w", b.ClusterRoleBindingName, err)
+		}
+		if roleRef != b.ClusterRoleName {
+			return fmt.Errorf("CRB %s references %s, expected %s", b.ClusterRoleBindingName, roleRef, b.ClusterRoleName)
+		}
+
+		subject, err := kubectl.Run("get", "clusterrolebinding", b.ClusterRoleBindingName, "-o", "jsonpath={.subjects[0].name}")
+		if err != nil {
+			return fmt.Errorf("failed to get subject for CRB %s: %w", b.ClusterRoleBindingName, err)
+		}
+		if subject != b.SubjectName {
+			return fmt.Errorf("CRB %s subject is %s, expected %s", b.ClusterRoleBindingName, subject, b.SubjectName)
+		}
+		log.Printf("CRB %s -> CR %s (subject: %s) verified", b.ClusterRoleBindingName, b.ClusterRoleName, b.SubjectName)
+	}
+	return nil
+}
+
+// AssertNoExportFailures returns an error if any files exist in the export failures directory.
+func AssertNoExportFailures(exportDir, namespace string) error {
+	failuresDir := filepath.Join(exportDir, "failures", namespace)
+	files, err := filepath.Glob(filepath.Join(failuresDir, "*"))
+	if err != nil {
+		return fmt.Errorf("glob error checking export failures: %w", err)
+	}
+	if len(files) > 0 {
+		return fmt.Errorf("found %d export failure(s) in %s", len(files), failuresDir)
+	}
+	log.Printf("No export failures found in %s", failuresDir)
+	return nil
+}
+
+func AssertNoClusterResources(basePath string) error {
+	_, err := os.Stat(basePath)
+	if err != nil {
+		log.Printf("directory does not exist at %s (no cluster resources possible)", basePath)
+		return nil
+	}
+
+	var found []string
+	filepath.WalkDir(basePath, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if strings.HasPrefix(d.Name(), "Cluster") {
+			found = append(found, path)
+		}
+		return nil
+	})
+
+	if len(found) > 0 {
+		return fmt.Errorf("found %d cluster resource(s) under %s: %v", len(found), basePath, found)
+	}
+	log.Printf("No cluster resources found under %s", basePath)
+	return nil
+}
+
+func CrateCrAndValidate(kubectl KubectlRunner, prem string, crName string) error {
+	var verbs string
+	switch prem {
+	case "write":
+		verbs = "get,list,watch,create,update,delete"
+	case "patch":
+		verbs = "get,list,watch,patch"
+	default:
+		verbs = "get,list,watch"
+	}
+
+	_, crErr := kubectl.Run("create", "clusterrole", crName, "--verb="+verbs, "--resource=pods")
+	if crErr == nil {
+		log.Printf("Created %s ClusterRole %s", prem, crName)
+	} else {
+		log.Printf("Failed To Created ClusterRole %s", crName)
+	}
+	return crErr
+}
+
+func CrateAndValidateCrb(kubectl KubectlRunner, namespace string, clusterRoleBindingName string, clusterRoleName string, serviceAccount *string) error {
+	var saName string
+	if serviceAccount == nil {
+		saName = "default"
+	} else {
+		saName = *serviceAccount
+	}
+
+	_, crbErr := kubectl.Run("create", "clusterrolebinding", clusterRoleBindingName, "--clusterrole="+clusterRoleName,
+		"--serviceaccount="+namespace+":"+saName)
+	if crbErr == nil {
+		log.Printf("Created #1 ClusterRoleBinding %s -> ClusterRole %s (subject: %s:%s)", clusterRoleBindingName, clusterRoleName, namespace, saName)
+
+	} else {
+		log.Printf("Failed To Created ClusterRoleBinding %s\n", clusterRoleBindingName)
+	}
+
+	return crbErr
+}
+
+func CrateAndValidateServiceAccount(kubectl KubectlRunner, saName string, namespace string) error {
+	_, err := kubectl.Run("create", "serviceaccount", saName, "-n", namespace)
+	if err == nil {
+		log.Printf("Serviceaccount %s Created on  %s\n", saName, namespace)
+	} else {
+		log.Printf("Failed To Created serviceAccount %s", saName)
+	}
+	return err
+}
+
+func NonAdminApplyOutput(kubectlTgt KubectlRunner, path string, namespace string) error {
+	outputNamespacedir := filepath.Join(path, "resources", namespace)
+	_, err := os.Stat(outputNamespacedir)
+	if err != nil {
+		log.Printf("failures: %v \n", err)
+		return err
+	}
+	err = kubectlTgt.ApplyDir(outputNamespacedir)
+	return err
+}
+
+func CreateNamespaceAndDryRun(kubectl KubectlRunner, namespace, outputDir string) error {
+	log.Printf("Creating namespace %s on target", namespace)
+	if _, err := kubectl.Run("create", "namespace", namespace); err != nil {
+		return fmt.Errorf("failed to create namespace %s: %w", namespace, err)
+	}
+	return kubectl.ValidateApplyDir(outputDir)
+}

--- a/e2e-tests/tests/ca1_minimal_rbac_test.go
+++ b/e2e-tests/tests/ca1_minimal_rbac_test.go
@@ -1,0 +1,87 @@
+package e2e
+
+import (
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Cluster-level RBAC export", func() {
+	It("[CA-1] Should export ClusterRole and ClusterRoleBinding for linked ServiceAccount", Label("cluster-admin"), func() {
+		appName := "nginx-with-serviceaccount"
+		namespace := "simple-nginx-nopv"
+		serviceName := "my-" + appName
+		saName := "nginx-sa"
+		clusterRoleBindingName := "crane-e2e-pod-reader-binding"
+		clusterRoleName := "crane-e2e-pod-reader"
+		scenario := NewMigrationScenario(
+			appName,
+			namespace,
+			config.K8sDeployBin,
+			config.CraneBin,
+			config.SourceContext,
+			config.TargetContext,
+		)
+		srcApp := scenario.SrcApp
+		tgtApp := scenario.TgtApp
+		kubectlSrc := scenario.KubectlSrc
+		kubectlTgt := scenario.KubectlTgt
+		runner := scenario.Crane
+		paths, err := NewScenarioPaths("crane-ca1-*")
+		resourcesPatterns := []string{"ClusterRole_*.yaml", "ClusterRoleBinding_*.yaml"}
+		Expect(err).NotTo(HaveOccurred())
+
+		DeferCleanup(func() {
+			ClusterResourceCleanup(kubectlSrc, kubectlTgt, []ClusterResource{
+				{Kind: "clusterrolebinding", Name: clusterRoleBindingName},
+				{Kind: "clusterrole", Name: clusterRoleName},
+			})
+		})
+
+		DeferCleanup(func() {
+			ScenarioCleanup(paths, srcApp, tgtApp, kubectlSrc, kubectlTgt, namespace)
+		})
+
+		By("Prepare source app")
+		Expect(PrepareSourceApp(srcApp, kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Create ClusterRole on source")
+		_, err = scenario.KubectlSrc.Run("create", "clusterrole", clusterRoleName, "--verb=get,list,watch", "--resource=pods")
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Create ClusterRoleBinding on source")
+		crbErr := CrateAndValidateCrb(kubectlSrc, namespace, clusterRoleBindingName, clusterRoleName, &saName)
+		Expect(crbErr).NotTo(HaveOccurred())
+
+		By("Wait for source quiesce")
+		WaitForSourceQuiesce(kubectlSrc, namespace, "app="+appName, serviceName)
+
+		By("Running Crane Pipeline")
+		Expect(RunPipeline(&runner, namespace, paths)).NotTo(HaveOccurred())
+
+		By("Verify no export failures")
+		Expect(AssertNoExportFailures(paths.ExportDir, namespace)).NotTo(HaveOccurred())
+
+		By("Validate cluster resources across pipeline stages")
+		Expect(ValidatePipelineClusterResources(paths, namespace, resourcesPatterns, nil)).NotTo(HaveOccurred())
+
+		By("Create namespace on tgt and Dry-run validate full output")
+		_, err = kubectlTgt.Run("create", "namespace", namespace)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kubectlTgt.ValidateApplyDir(paths.OutputDir)).NotTo(HaveOccurred())
+
+		By("Apply output to target")
+		validateErr := ApplyOutputToTarget(kubectlTgt, namespace, paths.OutputDir)
+		Expect(validateErr).NotTo(HaveOccurred())
+
+		By("Scale and validate target app")
+		ScaleAndValidateTargetApp(kubectlTgt, tgtApp, namespace, appName)
+
+		By("Verify cluster RBAC on target")
+		Expect(ValidateClusterRBAC(kubectlTgt, namespace, []ExpectedClusterRoleBinding{
+			{ClusterRoleBindingName: clusterRoleBindingName, ClusterRoleName: clusterRoleName, SubjectName: saName},
+		})).NotTo(HaveOccurred())
+	})
+
+})

--- a/e2e-tests/tests/ca2_multiple_crbs_minimal_rbac_test.go
+++ b/e2e-tests/tests/ca2_multiple_crbs_minimal_rbac_test.go
@@ -1,0 +1,97 @@
+package e2e
+
+import (
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Cluster-level RBAC export", func() {
+	It("[CA-2] Should export ClusterRole and ClusterRoleBinding for linked ServiceAccount", Label("cluster-admin"), func() {
+		appName := "nginx-with-serviceaccount"
+		namespace := "simple-nginx-nopv"
+		serviceName := "my-" + appName
+		firstSa := "nginx-sa"
+		secondSa := "nginx-sa-2"
+		clusterRoleName := "crane-e2e-pod-reader"
+		firstClusterRoleBindingName := "crane-e2e-pod-reader-binding-1"
+		secondClusterRoleBindingName := "crane-e2e-pod-reader-binding-2"
+		scenario := NewMigrationScenario(
+			appName,
+			namespace,
+			config.K8sDeployBin,
+			config.CraneBin,
+			config.SourceContext,
+			config.TargetContext,
+		)
+		srcApp := scenario.SrcApp
+		tgtApp := scenario.TgtApp
+		kubectlSrc := scenario.KubectlSrc
+		kubectlTgt := scenario.KubectlTgt
+		runner := scenario.Crane
+		paths, err := NewScenarioPaths("crane-ca2-*")
+
+		resourcesPatterns := []string{"ClusterRole_*.yaml", "ClusterRoleBinding_*.yaml"}
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			ClusterResourceCleanup(kubectlSrc, kubectlTgt, []ClusterResource{
+				{Kind: "clusterrolebinding", Name: firstClusterRoleBindingName},
+				{Kind: "clusterrolebinding", Name: secondClusterRoleBindingName},
+				{Kind: "clusterrole", Name: clusterRoleName},
+			})
+		})
+
+		DeferCleanup(func() {
+			ScenarioCleanup(paths, srcApp, tgtApp, kubectlSrc, kubectlTgt, namespace)
+		})
+
+		By("Prepare source app")
+		prepareSrcErr := PrepareSourceApp(srcApp, kubectlSrc)
+		Expect(prepareSrcErr).NotTo(HaveOccurred())
+
+		By("Create ServiceAccount on source")
+		_, err = kubectlSrc.Run("create", "serviceaccount", secondSa, "-n", namespace)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Create ClusterRole on source")
+		crErr := CrateCrAndValidate(kubectlSrc, "read", clusterRoleName)
+		Expect(crErr).NotTo(HaveOccurred())
+
+		By("Create the first ClusterRoleBinding on source")
+		crbErr := CrateAndValidateCrb(kubectlSrc, namespace, firstClusterRoleBindingName, clusterRoleName, &firstSa)
+		Expect(crbErr).NotTo(HaveOccurred())
+
+		By("Create the second ClusterRoleBinding on source")
+		crbErr = CrateAndValidateCrb(kubectlSrc, namespace, secondClusterRoleBindingName, clusterRoleName, &secondSa)
+		Expect(crbErr).NotTo(HaveOccurred())
+
+		By("Wait for source quiesce")
+		WaitForSourceQuiesce(kubectlSrc, namespace, "app="+appName, serviceName)
+
+		By("Running Crane Pipeline")
+		Expect(RunPipeline(&runner, namespace, paths)).NotTo(HaveOccurred())
+
+		By("Verify no export failures")
+		Expect(AssertNoExportFailures(paths.ExportDir, namespace)).NotTo(HaveOccurred())
+
+		By("Validate cluster resources across pipeline stages")
+		Expect(ValidatePipelineClusterResources(paths, namespace, resourcesPatterns, nil)).NotTo(HaveOccurred())
+
+		By("Create namespace on tgt and Dry-run validate full output")
+		Expect(CreateNamespaceAndDryRun(kubectlTgt, namespace, paths.OutputDir)).NotTo(HaveOccurred())
+
+		By("Apply output to target")
+		validateErr := ApplyOutputToTarget(kubectlTgt, namespace, paths.OutputDir)
+		Expect(validateErr).NotTo(HaveOccurred())
+
+		By("Scale and validate target app")
+		ScaleAndValidateTargetApp(kubectlTgt, tgtApp, namespace, appName)
+
+		By("Verify cluster RBAC on target")
+		Expect(ValidateClusterRBAC(kubectlTgt, namespace, []ExpectedClusterRoleBinding{
+			{ClusterRoleBindingName: firstClusterRoleBindingName, ClusterRoleName: clusterRoleName, SubjectName: firstSa},
+			{ClusterRoleBindingName: secondClusterRoleBindingName, ClusterRoleName: clusterRoleName, SubjectName: secondSa},
+		})).NotTo(HaveOccurred())
+	})
+})

--- a/e2e-tests/tests/ca3_two_clusterroles_test.go
+++ b/e2e-tests/tests/ca3_two_clusterroles_test.go
@@ -1,0 +1,95 @@
+package e2e
+
+import (
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Cluster-level RBAC export", func() {
+	It("[CA-3] Should export two ClusterRoles and two ClusterRoleBindings for one Deployment", Label("cluster-admin"), func() {
+		appName := "nginx-with-serviceaccount"
+		namespace := "simple-nginx-nopv"
+		serviceName := "my-" + appName
+		saName := "nginx-sa"
+		readClusterRole := "crane-e2e-pod-reader"
+		writeClusterRole := "crane-e2e-pod-writer"
+		readClusterRoleBindingName := "reader-crane-e2e-pod-binding"
+		writeClusterRoleBindingName := "writer-crane-e2e-pod-binding"
+		scenario := NewMigrationScenario(
+			appName,
+			namespace,
+			config.K8sDeployBin,
+			config.CraneBin,
+			config.SourceContext,
+			config.TargetContext,
+		)
+		srcApp := scenario.SrcApp
+		tgtApp := scenario.TgtApp
+		kubectlSrc := scenario.KubectlSrc
+		kubectlTgt := scenario.KubectlTgt
+		paths, err := NewScenarioPaths("crane-ca3-*")
+		runner := scenario.Crane
+		resourcesPatterns := []string{"ClusterRole_*.yaml", "ClusterRoleBinding_*.yaml"}
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			ClusterResourceCleanup(kubectlSrc, kubectlTgt, []ClusterResource{
+				{Kind: "clusterrolebinding", Name: readClusterRoleBindingName},
+				{Kind: "clusterrolebinding", Name: writeClusterRoleBindingName},
+				{Kind: "clusterrole", Name: readClusterRole},
+				{Kind: "clusterrole", Name: writeClusterRole},
+			})
+		})
+
+		DeferCleanup(func() {
+			ScenarioCleanup(paths, srcApp, tgtApp, kubectlSrc, kubectlTgt, namespace)
+		})
+
+		By("Prepare source app")
+		Expect(PrepareSourceApp(srcApp, kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Create Read ClusterRole on source")
+		crErr := CrateCrAndValidate(kubectlSrc, "read", readClusterRole)
+		Expect(crErr).NotTo(HaveOccurred())
+
+		By("Create Write ClusterRole on source")
+		crErr = CrateCrAndValidate(kubectlSrc, "write", writeClusterRole)
+		Expect(crErr).NotTo(HaveOccurred())
+
+		By("Create the read ClusterRoleBinding on source")
+		crbErr := CrateAndValidateCrb(kubectlSrc, namespace, readClusterRoleBindingName, readClusterRole, &saName)
+		Expect(crbErr).NotTo(HaveOccurred())
+
+		By("Create the write ClusterRoleBinding on source")
+		crbErr = CrateAndValidateCrb(kubectlSrc, namespace, writeClusterRoleBindingName, writeClusterRole, &saName)
+		Expect(crbErr).NotTo(HaveOccurred())
+
+		By("Wait for source quiesce")
+		WaitForSourceQuiesce(kubectlSrc, namespace, "app="+appName, serviceName)
+
+		By("Running Crane Pipeline")
+		Expect(RunPipeline(&runner, namespace, paths)).NotTo(HaveOccurred())
+
+		By("Verify no export failures")
+		Expect(AssertNoExportFailures(paths.ExportDir, namespace)).NotTo(HaveOccurred())
+
+		By("Validate cluster resources across pipeline stages")
+		Expect(ValidatePipelineClusterResources(paths, namespace, resourcesPatterns, nil)).NotTo(HaveOccurred())
+
+		By("Create namespace on tgt and Dry-run validate full output")
+		Expect(CreateNamespaceAndDryRun(kubectlTgt, namespace, paths.OutputDir)).NotTo(HaveOccurred())
+
+		By("Apply output to target")
+		Expect(ApplyOutputToTarget(kubectlTgt, namespace, paths.OutputDir)).NotTo(HaveOccurred())
+
+		By("Scale and validate target app")
+		ScaleAndValidateTargetApp(kubectlTgt, tgtApp, namespace, appName)
+
+		By("Verify cluster RBAC on target")
+		Expect(ValidateClusterRBAC(kubectlTgt, namespace, []ExpectedClusterRoleBinding{
+			{ClusterRoleBindingName: readClusterRoleBindingName, ClusterRoleName: readClusterRole, SubjectName: saName},
+			{ClusterRoleBindingName: writeClusterRoleBindingName, ClusterRoleName: writeClusterRole, SubjectName: saName},
+		})).NotTo(HaveOccurred())
+	})
+})

--- a/e2e-tests/tests/ca5_no_cluster_resources_test.go
+++ b/e2e-tests/tests/ca5_no_cluster_resources_test.go
@@ -1,0 +1,57 @@
+package e2e
+
+import (
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Cluster-level export control", func() {
+	It("[CA-5] Should produce no _cluster output for namespace-only workload", Label("tier0"), func() {
+		appName := "simple-nginx-nopv"
+		namespace := "simple-nginx-nopv"
+		serviceName := "my-" + appName
+		scenario := NewMigrationScenario(
+			appName,
+			namespace,
+			config.K8sDeployBin,
+			config.CraneBin,
+			config.SourceContext,
+			config.TargetContext,
+		)
+		srcApp := scenario.SrcApp
+		tgtApp := scenario.TgtApp
+		kubectlSrc := scenario.KubectlSrc
+		kubectlTgt := scenario.KubectlTgt
+		paths, err := NewScenarioPaths("crane-ca5-*")
+		Expect(err).NotTo(HaveOccurred())
+		runner := scenario.Crane
+
+		DeferCleanup(func() {
+			ScenarioCleanup(paths, srcApp, tgtApp, kubectlSrc, kubectlTgt, namespace)
+		})
+
+		By("Prepare source app")
+		Expect(PrepareSourceApp(srcApp, kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Wait for source quiesce")
+		WaitForSourceQuiesce(kubectlSrc, namespace, "app="+appName, serviceName)
+
+		By("Run crane export/transform/apply pipeline")
+		Expect(RunPipeline(&runner, namespace, paths)).NotTo(HaveOccurred())
+
+		By("Verify no cluster resources in export")
+		Expect(AssertNoClusterResources(paths.ExportDir)).NotTo(HaveOccurred())
+
+		By("Verify no cluster resources in output")
+		Expect(AssertNoClusterResources(paths.OutputDir)).NotTo(HaveOccurred())
+
+		By("Apply output to target")
+		Expect(ApplyOutputToTarget(kubectlTgt, namespace, paths.OutputDir)).NotTo(HaveOccurred())
+
+		By("Scale target deployment and validate")
+		ScaleAndValidateTargetApp(kubectlTgt, tgtApp, namespace, appName)
+	})
+
+})

--- a/e2e-tests/tests/ca6_orphan_clusterrole_test.go
+++ b/e2e-tests/tests/ca6_orphan_clusterrole_test.go
@@ -1,0 +1,79 @@
+package e2e
+
+import (
+	"path/filepath"
+
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Cluster-level export filtering", func() {
+	It("[CA-6] Should not export orphan ClusterRole with no CRB linking it to exported SAs", Label("cluster-admin"), func() {
+		appName := "nginx-with-serviceaccount"
+		namespace := "simple-nginx-nopv"
+		serviceName := "my-" + appName
+		saName := "nginx-sa"
+		readClusterRole := "crane-e2e-pod-reader"
+		writeClusterRole := "crane-e2e-pod-writer"
+		readClusterRoleBindingName := "reader-crane-e2e-pod-binding"
+		relatedResources := []string{"ClusterRole_*" + readClusterRole + "*.yaml", "ClusterRoleBinding_*" +
+			readClusterRoleBindingName + "*.yaml"}
+		orphanResource := []string{"ClusterRole_" + writeClusterRole}
+		scenario := NewMigrationScenario(
+			appName,
+			namespace,
+			config.K8sDeployBin,
+			config.CraneBin,
+			config.SourceContext,
+			config.TargetContext,
+		)
+		srcApp := scenario.SrcApp
+		tgtApp := scenario.TgtApp
+		kubectlSrc := scenario.KubectlSrc
+		kubectlTgt := scenario.KubectlTgt
+		runner := scenario.Crane
+		paths, err := NewScenarioPaths("crane-ca6-*")
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			ClusterResourceCleanup(kubectlSrc, kubectlTgt, []ClusterResource{
+				{Kind: "clusterrolebinding", Name: readClusterRoleBindingName},
+				{Kind: "clusterrole", Name: readClusterRole},
+				{Kind: "clusterrole", Name: writeClusterRole},
+			})
+		})
+
+		DeferCleanup(func() {
+			ScenarioCleanup(paths, srcApp, tgtApp, kubectlSrc, kubectlTgt, namespace)
+		})
+
+		By("Prepare source app")
+		prepareSrcErr := PrepareSourceApp(srcApp, kubectlSrc)
+		Expect(prepareSrcErr).NotTo(HaveOccurred())
+
+		By("Create Read ClusterRole on source")
+		Expect(CrateCrAndValidate(kubectlSrc, "read", readClusterRole)).NotTo(HaveOccurred())
+
+		By("Create Write ClusterRole on source")
+		Expect(CrateCrAndValidate(kubectlSrc, "write", writeClusterRole)).NotTo(HaveOccurred())
+
+		By("Create the read ClusterRoleBinding on source")
+		crbErr := CrateAndValidateCrb(kubectlSrc, namespace, readClusterRoleBindingName, readClusterRole, &saName)
+		Expect(crbErr).NotTo(HaveOccurred())
+
+		By("Wait for source quiesce")
+		WaitForSourceQuiesce(kubectlSrc, namespace, "app="+appName, serviceName)
+
+		By("Running Crane Pipeline")
+		Expect(RunPipeline(&runner, namespace, paths)).NotTo(HaveOccurred())
+
+		By("Verify that Orphan ClusterRole Failed to be exported")
+		exportClusterPath := filepath.Join(paths.ExportDir, "resources", namespace, "_cluster")
+		//we dont expect to find the orphan clusterRole on the export dir.
+		Expect(ValidateDirResources(exportClusterPath, orphanResource)).To(HaveOccurred())
+
+		By("Verify that Realted ClusterRole being be exported across all stages")
+		Expect(ValidatePipelineClusterResources(paths, namespace, relatedResources, nil)).NotTo(HaveOccurred())
+	})
+})

--- a/e2e-tests/tests/na1_split_apply_test.go
+++ b/e2e-tests/tests/na1_split_apply_test.go
@@ -1,0 +1,93 @@
+package e2e
+
+import (
+	"path/filepath"
+
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Namespace-admin cluster-level migration", func() {
+	It("[NA-1] Should migrate workload with split apply: namespace-admin + cluster-admin", Label("namespace-admin"), func() {
+		appName := "simple-nginx-nopv"
+		namespace := "simple-nginx-nopv"
+		serviceName := "my-" + appName
+		scenario := NewMigrationScenario(
+			appName,
+			namespace,
+			config.K8sDeployBin,
+			config.CraneBin,
+			config.SourceContext,
+			config.TargetContext,
+		)
+		clusterRoleBindingName := "crane-e2e-pod-reader-binding"
+		clusterRoleName := "crane-e2e-pod-reader"
+		forbiddenResourcesPatterns := []string{"ClusterRole_*.yaml", "ClusterRoleBinding_*.yaml"}
+		if scenario.KubectlSrcNonAdmin.Context == "" {
+			Skip("source-nonadmin-context is required for non-admin role migration test")
+		}
+		if scenario.KubectlTgtNonAdmin.Context == "" {
+			Skip("target-nonadmin-context is required for non-admin role migration test")
+		}
+		srcAppNonAdmin, tgtAppNonAdmin := NonAdminApps(scenario)
+		kubectlSrc := scenario.KubectlSrc
+		kubectlTgt := scenario.KubectlTgt
+		paths, err := NewScenarioPaths("crane-na1-*")
+		runner := scenario.CraneNonAdmin
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Grant namespace-admin permissions to non-admin user on source and target")
+		kubectlSrcNonAdmin, kubectlTgtNonAdmin, rbacCleanup, err := SetupNamespaceAdminUsersForScenario(scenario, namespace)
+		Expect(err).NotTo(HaveOccurred())
+
+		DeferCleanup(rbacCleanup)
+		DeferCleanup(func() {
+			ClusterResourceCleanup(kubectlSrc, kubectlTgt, []ClusterResource{
+				{Kind: "clusterrolebinding", Name: clusterRoleBindingName},
+				{Kind: "clusterrole", Name: clusterRoleName},
+			})
+		})
+		DeferCleanup(func() {
+			ScenarioCleanup(paths, srcAppNonAdmin, tgtAppNonAdmin, kubectlSrc, kubectlTgt, namespace)
+		})
+
+		By("Prepare source app")
+		err = PrepareSourceApp(srcAppNonAdmin, kubectlSrcNonAdmin)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Create ClusterRole on source")
+		Expect(CrateCrAndValidate(kubectlSrc, "read", clusterRoleName)).NotTo(HaveOccurred())
+
+		By("Create ClusterRoleBinding on source")
+		crbErr := CrateAndValidateCrb(kubectlSrc, namespace, clusterRoleBindingName, clusterRoleName, nil)
+		Expect(crbErr).NotTo(HaveOccurred())
+
+		By("Wait for source quiesce")
+		WaitForSourceQuiesce(kubectlSrcNonAdmin, namespace, "app="+appName, serviceName)
+
+		By("Running Crane Pipeline")
+		Expect(RunPipeline(&runner, namespace, paths)).NotTo(HaveOccurred())
+
+		By("Verify no export failures")
+		err = ValidateDirResources(filepath.Join(paths.ExportDir, "failures"), forbiddenResourcesPatterns)
+		//as namespace admin we dont have privilages to export cluster resource.
+		//on that scenario export will create files on the failure folder stating what kind of resource didnt
+		Expect(err).To(HaveOccurred())
+
+		By("Apply namespace resources to target as namespace-admin")
+		Expect(NonAdminApplyOutput(kubectlTgtNonAdmin, paths.OutputDir, namespace)).NotTo(HaveOccurred())
+
+		By("Verify no cluster resources in present after the Namespace admin Applied")
+		Expect(AssertNoClusterResources(filepath.Join(paths.OutputDir, "resources", "_cluster"))).NotTo(HaveOccurred())
+
+		By("Apply cluster resources to target as cluster-admin")
+		Expect(ApplyOutputToTarget(kubectlTgt, namespace, paths.OutputDir)).NotTo(HaveOccurred())
+
+		By("Scale and validate target app")
+		ScaleAndValidateTargetApp(kubectlTgtNonAdmin, tgtAppNonAdmin, namespace, appName)
+
+	})
+
+})


### PR DESCRIPTION
## Summary
- CA-1, CA-2, CA-3, CA-5, CA-6: cluster-admin RBAC discovery and migration tests
- NA-1: namespace-admin split apply test
- Shared test helpers in test_utils.go and rbac.go