### PR TITLE
test: add tier0 e2e migration coverage for transform --instructions-file

### DIFF
--- a/e2e-tests/framework/crane.go
+++ b/e2e-tests/framework/crane.go
@@ -82,6 +82,31 @@ func (c CraneRunner) TransformStage(exportDir, transformDir, stage string) error
 	return nil
 }
 
+// TransformWithInstructionsFile runs crane transform using an instructions file.
+func (c CraneRunner) TransformWithInstructionsFile(exportDir, transformDir, instructionsFile string, force bool) error {
+	if instructionsFile == "" {
+		return fmt.Errorf("crane transform --instructions-file requires a non-empty instructions file path")
+	}
+	args := []string{
+		"transform",
+		"--export-dir", exportDir,
+		"--transform-dir", transformDir,
+		"--instructions-file", instructionsFile,
+	}
+	if force {
+		args = append(args, "--force")
+	}
+	logVerboseCommand(c.Bin, args)
+	cmd := exec.Command(c.Bin, args...)
+	cmd.Dir = c.WorkDir
+	out, err := cmd.CombinedOutput()
+	logVerboseOutput("crane transform --instructions-file", out)
+	if err != nil {
+		return fmt.Errorf("crane transform --instructions-file failed: %w, output: %s", err, string(out))
+	}
+	return nil
+}
+
 // Apply runs crane apply to render manifests into the output directory.
 func (c CraneRunner) Apply(exportDir, transformDir string, outputDir string) error {
 	args := []string{"apply", "--export-dir", exportDir, "--transform-dir", transformDir, "--output-dir", outputDir}

--- a/e2e-tests/testdata/basic-instructions-file.yaml
+++ b/e2e-tests/testdata/basic-instructions-file.yaml
@@ -1,0 +1,4 @@
+---
+stages:
+  - KubernetesPlugin
+  - CustomStage

--- a/e2e-tests/tests/instructions_file_migration_test.go
+++ b/e2e-tests/tests/instructions_file_migration_test.go
@@ -1,0 +1,97 @@
+package e2e
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	"github.com/konveyor/crane/e2e-tests/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Instructions-file migration", func() {
+	It("should migrate a simple nginx app using transform --instructions-file", Label("tier0"), func() {
+		appName := "simple-nginx-nopv"
+		namespace := "simple-nginx-instructionsfile"
+		scenario := NewMigrationScenario(
+			appName,
+			namespace,
+			config.K8sDeployBin,
+			config.CraneBin,
+			config.SourceContext,
+			config.TargetContext,
+		)
+
+		if scenario.KubectlSrcNonAdmin.Context == "" {
+			Skip("source-nonadmin-context is required for non-admin instructions file migration test")
+		}
+		if scenario.KubectlTgtNonAdmin.Context == "" {
+			Skip("target-nonadmin-context is required for non-admin instructions file migration test")
+		}
+
+		srcApp := scenario.SrcAppNonAdmin
+		tgtApp := scenario.TgtAppNonAdmin
+		runner := scenario.CraneNonAdmin
+		srcApp.ExtraVars = map[string]any{
+			"non_admin_user": "true",
+		}
+		tgtApp.ExtraVars = srcApp.ExtraVars
+
+		By("Grant ns admin permissions to nonadmin user on source and target")
+		kubectlSrcNonAdmin, _, cleanup, err := SetupNamespaceAdminUsersForScenario(scenario, namespace)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			By("Delete test namespace on source and target (wait for completion)")
+			for _, k := range []KubectlRunner{scenario.KubectlSrc, scenario.KubectlTgt} {
+				if _, err := k.Run("delete", "namespace", namespace, "--ignore-not-found=true", "--wait=true"); err != nil {
+					log.Printf("cleanup: failed to delete namespace %q on context %q: %v", namespace, k.Context, err)
+				}
+			}
+		})
+		DeferCleanup(cleanup)
+		By("Prepare source app")
+		log.Printf("Preparing source app %s in namespace %s\n", srcApp.Name, srcApp.Namespace)
+		Expect(PrepareSourceApp(srcApp, kubectlSrcNonAdmin)).NotTo(HaveOccurred())
+		log.Printf("Source app %s prepared successfully\n", srcApp.Name)
+
+		paths, err := NewScenarioPaths("crane-pipeline-*")
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			By("Cleanup source and target resources")
+			if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
+				log.Printf("cleanup: %v", err)
+
+			}
+		})
+		runner.WorkDir = paths.TempDir
+		By("Run crane export/transform/apply pipeline with instructions file")
+		log.Printf("Running crane export for namespace %s\n", srcApp.Namespace)
+		Expect(runner.Export(srcApp.Namespace, paths.ExportDir)).NotTo(HaveOccurred())
+		log.Printf("Running crane transform --instructions-file for namespace %s\n", srcApp.Namespace)
+		instructionsFile, err := utils.TestdataFilePath("basic-instructions-file.yaml")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(runner.TransformWithInstructionsFile(paths.ExportDir, paths.TransformDir, instructionsFile, false)).NotTo(HaveOccurred())
+		By("Assert instructions-file stages are present as stage-directories in transform dir")
+		stageDirectories := []string{"10_KubernetesPlugin", "20_CustomStage"}
+		for _, stageDir := range stageDirectories {
+			dirPath := filepath.Join(paths.TransformDir, stageDir)
+			_, err = os.Stat(dirPath)
+			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("expected stage dir %q at %q to be present", stageDir, dirPath))
+		}
+		log.Printf("Running crane apply for namespace %s\n", srcApp.Namespace)
+		Expect(runner.Apply(paths.ExportDir, paths.TransformDir, paths.OutputDir)).NotTo(HaveOccurred())
+		log.Printf("Crane pipeline completed for namespace %s\n", srcApp.Namespace)
+
+		By("Apply rendered manifests to target")
+		Expect(ApplyOutputToTargetNonAdmin(scenario.KubectlTgtNonAdmin, paths.OutputDir)).NotTo(HaveOccurred())
+
+		By("Scale target deployment and validate app on target")
+		Expect(scenario.KubectlTgtNonAdmin.ScaleDeployment(namespace, appName, 1)).NotTo(HaveOccurred())
+
+		Eventually(tgtApp.Validate, "2m", "10s").Should(Succeed())
+	})
+})

--- a/e2e-tests/utils/utils.go
+++ b/e2e-tests/utils/utils.go
@@ -99,6 +99,21 @@ func ReadTestdataFile(filename string) (string, error) {
 	return string(b), nil
 }
 
+// TestdataFilePath returns the path to a file under e2e-tests/testdata,
+// resolved relative to this package so it does not depend on process working directory.
+func TestdataFilePath(filename string) (string, error) {
+	if filename == "" {
+		return "", fmt.Errorf("filename is required")
+	}
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("runtime.Caller failed")
+	}
+	baseDir := filepath.Dir(thisFile)
+	path := filepath.Join(baseDir, "..", "testdata", filename)
+	return path, nil
+}
+
 // GoldenManifestsDir returns the path to the golden fixtures directory for an app and pipeline stage.
 // It resolves e2e-tests/golden-manifests/<appName>/<stage> relative to this file's location, so the
 // result does not depend on the process working directory. Valid stage values are "export", "transform",


### PR DESCRIPTION
Adds a new tier0 end-to-end test that validates export -> transform --instructions-file -> apply migration flow for a simple nginx app. The test asserts instructions-driven stage directory generation, applies rendered manifests to target, and verifies target app health to confirm baseline migration success in instructions-file mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for using instructions files with the `crane transform` command, enabling users to define and execute custom transformation stages via YAML configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->