### PR TITLE
Add autocompletion for transform plugins

### DIFF
--- a/cmd/transform/completion_test.go
+++ b/cmd/transform/completion_test.go
@@ -1,0 +1,203 @@
+package transform
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/konveyor/crane/internal/flags"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPluginCompletions(t *testing.T) {
+	tests := []struct {
+		name              string
+		setupCmd          func(t *testing.T) *cobra.Command
+		args              []string
+		toComplete        string
+		wantDirective     cobra.ShellCompDirective
+		wantPlugins       []string
+		wantErr           bool
+		checkContains     bool // if true, check that wantPlugins are contained in result, not exact match
+	}{
+		{
+			name: "success path - returns plugin names",
+			setupCmd: func(t *testing.T) *cobra.Command {
+				// Create a minimal command with just the flags we need
+				tempDir := t.TempDir()
+				pluginDir := filepath.Join(tempDir, "plugins")
+				if err := os.MkdirAll(pluginDir, 0755); err != nil {
+					t.Fatalf("failed to create plugin dir: %v", err)
+				}
+
+				cmd := &cobra.Command{
+					Use: "test",
+				}
+				cmd.Flags().String("plugin-dir", pluginDir, "")
+				cmd.Flags().StringSlice("skip-plugins", []string{}, "")
+
+				return cmd
+			},
+			args:          []string{},
+			toComplete:    "",
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+			wantPlugins:   []string{"KubernetesPlugin"}, // Default plugin is always present
+			checkContains: true,
+		},
+		{
+			name: "success path - with skip-plugins flag",
+			setupCmd: func(t *testing.T) *cobra.Command {
+				tempDir := t.TempDir()
+				pluginDir := filepath.Join(tempDir, "plugins")
+				if err := os.MkdirAll(pluginDir, 0755); err != nil {
+					t.Fatalf("failed to create plugin dir: %v", err)
+				}
+
+				cmd := &cobra.Command{
+					Use: "test",
+				}
+				cmd.Flags().String("plugin-dir", pluginDir, "")
+				cmd.Flags().StringSlice("skip-plugins", []string{"KubernetesPlugin"}, "")
+
+				return cmd
+			},
+			args:          []string{},
+			toComplete:    "",
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+			wantPlugins:   []string{}, // KubernetesPlugin skipped, so empty
+		},
+		{
+			name: "error path - plugin-dir flag does not exist",
+			setupCmd: func(t *testing.T) *cobra.Command {
+				// Create command without the plugin-dir flag
+				cmd := &cobra.Command{
+					Use: "test",
+				}
+				// Don't add any flags - GetString will fail
+				return cmd
+			},
+			args:          []string{},
+			toComplete:    "",
+			wantDirective: cobra.ShellCompDirectiveError,
+			wantPlugins:   nil,
+		},
+		{
+			name: "error path - skip-plugins flag does not exist",
+			setupCmd: func(t *testing.T) *cobra.Command {
+				// Create command with only plugin-dir flag
+				tempDir := t.TempDir()
+				pluginDir := filepath.Join(tempDir, "plugins")
+				if err := os.MkdirAll(pluginDir, 0755); err != nil {
+					t.Fatalf("failed to create plugin dir: %v", err)
+				}
+
+				cmd := &cobra.Command{
+					Use: "test",
+				}
+				// Add only plugin-dir flag, skip-plugins will fail
+				cmd.Flags().String("plugin-dir", pluginDir, "")
+
+				return cmd
+			},
+			args:          []string{},
+			toComplete:    "",
+			wantDirective: cobra.ShellCompDirectiveError,
+			wantPlugins:   nil,
+		},
+		{
+			name: "error path - plugin loading fails with invalid directory",
+			setupCmd: func(t *testing.T) *cobra.Command {
+				// Use a file as plugin-dir to cause an error
+				tempDir := t.TempDir()
+				invalidPath := filepath.Join(tempDir, "not-a-dir")
+
+				// Create a file instead of directory
+				if err := os.WriteFile(invalidPath, []byte("test"), 0644); err != nil {
+					t.Fatalf("failed to create file: %v", err)
+				}
+
+				cmd := &cobra.Command{
+					Use: "test",
+				}
+				cmd.Flags().String("plugin-dir", invalidPath, "")
+				cmd.Flags().StringSlice("skip-plugins", []string{}, "")
+
+				return cmd
+			},
+			args:          []string{},
+			toComplete:    "",
+			wantDirective: cobra.ShellCompDirectiveError,
+			wantPlugins:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := tt.setupCmd(t)
+
+			// Get the completion function
+			f := &flags.GlobalFlags{}
+			log := logrus.New()
+			log.SetOutput(os.Stderr)
+
+			completionFunc := getPluginCompletions(f)
+
+			// Call the completion function
+			plugins, directive := completionFunc(cmd, tt.args, tt.toComplete)
+
+			// Check directive
+			assert.Equal(t, tt.wantDirective, directive, "unexpected directive")
+
+			// Check plugins
+			if tt.checkContains {
+				// Check that all expected plugins are present
+				pluginSet := make(map[string]bool)
+				for _, p := range plugins {
+					pluginSet[p] = true
+				}
+				for _, expected := range tt.wantPlugins {
+					assert.True(t, pluginSet[expected], "expected plugin %q not found in results", expected)
+				}
+			} else {
+				assert.Equal(t, tt.wantPlugins, plugins, "unexpected plugin list")
+			}
+		})
+	}
+}
+
+func TestGetPluginCompletions_Integration(t *testing.T) {
+	// Integration test with real plugin directory structure
+	tempDir := t.TempDir()
+	pluginDir := filepath.Join(tempDir, "plugins")
+	if err := os.MkdirAll(pluginDir, 0755); err != nil {
+		t.Fatalf("failed to create plugin dir: %v", err)
+	}
+
+	f := &flags.GlobalFlags{}
+
+	t.Run("default plugin is included", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "test"}
+		cmd.Flags().String("plugin-dir", pluginDir, "")
+		cmd.Flags().StringSlice("skip-plugins", []string{}, "")
+
+		completionFunc := getPluginCompletions(f)
+		plugins, directive := completionFunc(cmd, []string{}, "")
+
+		assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+		assert.Contains(t, plugins, "KubernetesPlugin", "default plugin should be included")
+	})
+
+	t.Run("skip-plugins filters results", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "test"}
+		cmd.Flags().String("plugin-dir", pluginDir, "")
+		cmd.Flags().StringSlice("skip-plugins", []string{"KubernetesPlugin"}, "")
+
+		completionFunc := getPluginCompletions(f)
+		plugins, directive := completionFunc(cmd, []string{}, "")
+
+		assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+		assert.NotContains(t, plugins, "KubernetesPlugin", "skipped plugin should not be included")
+	})
+}

--- a/cmd/transform/listplugins/listplugins.go
+++ b/cmd/transform/listplugins/listplugins.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/konveyor/crane/internal/flags"
 	"github.com/konveyor/crane/internal/plugin"
+	cranelib "github.com/konveyor/crane-lib/transform"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -74,15 +76,35 @@ func NewListPluginsCommand(f *flags.GlobalFlags) *cobra.Command {
 	return cmd
 }
 
-func (o *Options) run() error {
-	pluginDir, err := filepath.Abs(o.PluginDir)
+// GetPluginNames returns a list of available plugin names
+func GetPluginNames(pluginDir string, skipPlugins []string, log *logrus.Logger) ([]string, error) {
+	plugins, err := getFilteredPlugins(pluginDir, skipPlugins, log)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
+	pluginNames := make([]string, len(plugins))
+	for i, p := range plugins {
+		pluginNames[i] = p.Metadata().Name
+	}
+
+	return pluginNames, nil
+}
+
+// getFilteredPlugins is a helper function that gets filtered plugins with absolute path handling
+func getFilteredPlugins(pluginDir string, skipPlugins []string, log *logrus.Logger) ([]cranelib.Plugin, error) {
+	absPluginDir, err := filepath.Abs(pluginDir)
+	if err != nil {
+		return nil, err
+	}
+
+	return plugin.GetFilteredPlugins(absPluginDir, skipPlugins, log)
+}
+
+func (o *Options) run() error {
 	log := o.globalFlags.GetLogger()
 
-	plugins, err := plugin.GetFilteredPlugins(pluginDir, o.SkipPlugins, log)
+	plugins, err := getFilteredPlugins(o.PluginDir, o.SkipPlugins, log)
 	if err != nil {
 		return err
 	}

--- a/cmd/transform/listplugins/listplugins_test.go
+++ b/cmd/transform/listplugins/listplugins_test.go
@@ -1,0 +1,174 @@
+package listplugins
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPluginNames(t *testing.T) {
+	log := logrus.New()
+	log.SetOutput(os.Stderr)
+
+	tests := []struct {
+		name         string
+		setupPlugins func(t *testing.T, pluginDir string)
+		skipPlugins  []string
+		wantNames    []string
+		wantErr      bool
+	}{
+		{
+			name: "empty plugin directory returns only default plugin",
+			setupPlugins: func(t *testing.T, pluginDir string) {
+				// Create empty plugin directory
+				if err := os.MkdirAll(pluginDir, 0755); err != nil {
+					t.Fatalf("failed to create plugin dir: %v", err)
+				}
+			},
+			skipPlugins: []string{},
+			wantNames:   []string{"KubernetesPlugin"}, // Default plugin is always included
+			wantErr:     false,
+		},
+		{
+			name: "skip default plugin",
+			setupPlugins: func(t *testing.T, pluginDir string) {
+				if err := os.MkdirAll(pluginDir, 0755); err != nil {
+					t.Fatalf("failed to create plugin dir: %v", err)
+				}
+			},
+			skipPlugins: []string{"KubernetesPlugin"},
+			wantNames:   []string{},
+			wantErr:     false,
+		},
+		{
+			name: "nonexistent plugin directory",
+			setupPlugins: func(t *testing.T, pluginDir string) {
+				// Don't create the directory
+			},
+			skipPlugins: []string{},
+			wantNames:   []string{"KubernetesPlugin"}, // Default plugin is still included
+			wantErr:     false,
+		},
+		{
+			name: "plugin directory with mock plugins",
+			setupPlugins: func(t *testing.T, pluginDir string) {
+				if err := os.MkdirAll(pluginDir, 0755); err != nil {
+					t.Fatalf("failed to create plugin dir: %v", err)
+				}
+				// Note: We can't easily test with real plugin binaries in unit tests
+				// This test verifies the function works with an empty directory
+				// Integration tests would be needed for testing with actual plugin binaries
+			},
+			skipPlugins: []string{},
+			wantNames:   []string{"KubernetesPlugin"},
+			wantErr:     false,
+		},
+		{
+			name: "skip multiple plugins",
+			setupPlugins: func(t *testing.T, pluginDir string) {
+				if err := os.MkdirAll(pluginDir, 0755); err != nil {
+					t.Fatalf("failed to create plugin dir: %v", err)
+				}
+			},
+			skipPlugins: []string{"KubernetesPlugin", "NonExistentPlugin"},
+			wantNames:   []string{},
+			wantErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			pluginDir := filepath.Join(tempDir, "plugins")
+
+			// Setup plugins directory
+			tt.setupPlugins(t, pluginDir)
+
+			// Call GetPluginNames
+			names, err := GetPluginNames(pluginDir, tt.skipPlugins, log)
+
+			// Check error
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+
+			// Check names
+			assert.Equal(t, len(tt.wantNames), len(names), "expected %d plugins, got %d", len(tt.wantNames), len(names))
+
+			// Check that expected names are present (order might differ)
+			nameSet := make(map[string]bool)
+			for _, name := range names {
+				nameSet[name] = true
+			}
+			for _, expectedName := range tt.wantNames {
+				assert.True(t, nameSet[expectedName], "expected plugin %q not found in result", expectedName)
+			}
+		})
+	}
+}
+
+func TestGetPluginNames_RelativeAndAbsolutePaths(t *testing.T) {
+	log := logrus.New()
+	log.SetOutput(os.Stderr)
+
+	tempDir := t.TempDir()
+	pluginDir := filepath.Join(tempDir, "plugins")
+
+	if err := os.MkdirAll(pluginDir, 0755); err != nil {
+		t.Fatalf("failed to create plugin dir: %v", err)
+	}
+
+	// Test with absolute path
+	t.Run("absolute path", func(t *testing.T) {
+		names, err := GetPluginNames(pluginDir, []string{}, log)
+		assert.NoError(t, err)
+		assert.GreaterOrEqual(t, len(names), 1, "should have at least default plugin")
+	})
+
+	// Test with relative path
+	t.Run("relative path", func(t *testing.T) {
+		// Change to temp dir and use relative path
+		originalDir, err := os.Getwd()
+		assert.NoError(t, err)
+		defer os.Chdir(originalDir)
+
+		err = os.Chdir(tempDir)
+		assert.NoError(t, err)
+
+		names, err := GetPluginNames("plugins", []string{}, log)
+		assert.NoError(t, err)
+		assert.GreaterOrEqual(t, len(names), 1, "should have at least default plugin")
+	})
+}
+
+func TestGetPluginNames_Integration(t *testing.T) {
+	// This is an integration test that verifies GetPluginNames works with
+	// the actual plugin system. It requires the default KubernetesPlugin.
+	log := logrus.New()
+	log.SetOutput(os.Stderr)
+
+	// Use a temporary directory to ensure clean state
+	tempDir := t.TempDir()
+	pluginDir := filepath.Join(tempDir, "plugins")
+
+	if err := os.MkdirAll(pluginDir, 0755); err != nil {
+		t.Fatalf("failed to create plugin dir: %v", err)
+	}
+
+	t.Run("default plugin is always included", func(t *testing.T) {
+		names, err := GetPluginNames(pluginDir, []string{}, log)
+		assert.NoError(t, err)
+		assert.Contains(t, names, "KubernetesPlugin", "default KubernetesPlugin should be included")
+	})
+
+	t.Run("default plugin can be skipped", func(t *testing.T) {
+		names, err := GetPluginNames(pluginDir, []string{"KubernetesPlugin"}, log)
+		assert.NoError(t, err)
+		assert.NotContains(t, names, "KubernetesPlugin", "KubernetesPlugin should be skipped")
+	})
+}

--- a/cmd/transform/transform.go
+++ b/cmd/transform/transform.go
@@ -68,6 +68,32 @@ func (o *Options) Run() error {
 	return o.run()
 }
 
+// getPluginCompletions returns a completion function that suggests available plugin names
+func getPluginCompletions(f *flags.GlobalFlags) func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		// Get plugin-dir from flags
+		pluginDir, err := cmd.Flags().GetString("plugin-dir")
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		// Get skip-plugins from flags
+		skipPlugins, err := cmd.Flags().GetStringSlice("skip-plugins")
+		if err != nil {
+			skipPlugins = []string{}
+		}
+
+		// Get plugin names using shared function
+		log := f.GetLogger()
+		pluginNames, err := listplugins.GetPluginNames(pluginDir, skipPlugins, log)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		return pluginNames, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
 func NewTransformCommand(f *flags.GlobalFlags) *cobra.Command {
 	o := &Options{
 		cobraGlobalFlags: f,
@@ -82,7 +108,8 @@ Stages can be specified by:
 - Plugin name (e.g., KubernetesPlugin)
 
 If no stages specified, all discovered stages are run.`,
-		Args: cobra.ArbitraryArgs,
+		Args:              cobra.ArbitraryArgs,
+		ValidArgsFunction: getPluginCompletions(f),
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := o.Complete(c, args); err != nil {
 				return err

--- a/cmd/transform/transform.go
+++ b/cmd/transform/transform.go
@@ -80,7 +80,7 @@ func getPluginCompletions(f *flags.GlobalFlags) func(cmd *cobra.Command, args []
 		// Get skip-plugins from flags
 		skipPlugins, err := cmd.Flags().GetStringSlice("skip-plugins")
 		if err != nil {
-			skipPlugins = []string{}
+			return nil, cobra.ShellCompDirectiveError
 		}
 
 		// Get plugin names using shared function


### PR DESCRIPTION
Add plugin name autocompletion for `crane transform`.

Example:
```
$ crane transform <Tab>
KubernetesPlugin                                                                     NamespaceCleanupPlugin                                                                     
list-plugins      (Return a list of configured plugins)                              optionals         (Return a list of optional fields accepted by configured plugins)  
```

Related to https://github.com/migtools/crane/issues/370

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic shell completion for transform now suggests available plugin names.
  * Added a public helper to retrieve configured plugin names from plugin directories.

* **Refactor**
  * Centralized plugin-directory path resolution to improve discovery consistency.

* **Tests**
  * Added comprehensive unit and integration tests for plugin discovery, default-plugin behavior, skip-plugin handling, path-resolution, and empty/nonexistent directory handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->