### PR TITLE
Fix bug 428: Reports passing when no manifests are found for validation

### DIFF
--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -80,6 +80,10 @@ func (o *ValidateOptions) Run() error {
 
 	log.Infof("Scanned %d distinct GVK+namespace tuples", len(entries))
 
+	if len(entries) == 0 {
+		return fmt.Errorf("no manifests found in %s: nothing to validate", o.inputDir)
+	}
+
 	var report *internalValidate.ValidationReport
 
 	if o.apiResourcesFile != "" {

--- a/cmd/validate/validate_test.go
+++ b/cmd/validate/validate_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/konveyor/crane/internal/flags"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
@@ -197,6 +198,35 @@ func TestValidate_Flags(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 		})
+	}
+}
+
+func TestRun_EmptyInputDirReturnsError(t *testing.T) {
+	emptyDir := t.TempDir()
+	validateDir := filepath.Join(t.TempDir(), "validate")
+
+	// Create a minimal valid API resources file for offline mode
+	apiFile := filepath.Join(t.TempDir(), "api-resources.json")
+	if err := os.WriteFile(apiFile, []byte(`{}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	o := &ValidateOptions{
+		configFlags:      genericclioptions.NewConfigFlags(true),
+		IOStreams:         genericclioptions.NewTestIOStreamsDiscard(),
+		inputDir:         emptyDir,
+		validateDir:      validateDir,
+		outputFormat:     "json",
+		apiResourcesFile: apiFile,
+		globalFlags:      &flags.GlobalFlags{},
+	}
+
+	err := o.Run()
+	if err == nil {
+		t.Fatal("expected error when input dir has no manifests, got nil")
+	}
+	if !strings.Contains(err.Error(), "no manifests found") {
+		t.Fatalf("expected 'no manifests found' error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
# PR: Fix bug 428: Reports passing when no manifests are found for validation

  Fixes [#428](https://github.com/migtools/crane/issues/428). 
 `crane validate` previously exited 0 and reported "PASSED" when the input directory contained no manifests (`totalScanned: 0`). 
 
  ## The Problem

  ```bash
  mkdir /tmp/empty-dir
  crane validate --context tgt -i /tmp/empty-dir --validate-dir /tmp/validate/
  # Exit: 0
  # Result: PASSED — all resources compatible with target cluster
  # totalScanned: 0
  ```

  ## The Fix

  Added an early return with error when ScanManifests finds zero entries, before any matching or report writing occurs:

  if len(entries) == 0 {
      return fmt.Errorf("no manifests found in %s: nothing to validate", o.inputDir)
  }

  **Now**:
  crane validate --context tgt -i /tmp/empty-dir --validate-dir /tmp/validate/
  Exit: 1
  Error: no manifests found in /tmp/empty-dir: nothing to validate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The validate command now exits early with a clear error message when no manifests are found in the specified input directory, preventing unnecessary processing steps.

* **Tests**
  * Added test coverage for empty input directory scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->