### PR TITLE
Fixed bug 427: Manifests scanned before kubeconfig/context

### DIFF
--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -29,15 +29,15 @@ type ValidateOptions struct {
 	genericclioptions.IOStreams
 }
 
-// Complete loads the kubeconfig to ensure the target cluster is reachable.
+// Complete loads the kubeconfig and validates the discovery client is reachable.
 // Skipped in offline mode (--api-resources).
 func (o *ValidateOptions) Complete(c *cobra.Command, args []string) error {
 	if o.apiResourcesFile != "" {
 		return nil
 	}
-	_, err := o.configFlags.ToRawKubeConfigLoader().RawConfig()
+	_, err := o.configFlags.ToDiscoveryClient()
 	if err != nil {
-		return fmt.Errorf("loading kubeconfig for target cluster: %w", err)
+		return fmt.Errorf("creating discovery client: %w", err)
 	}
 	return nil
 }

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -29,7 +29,10 @@ type ValidateOptions struct {
 	genericclioptions.IOStreams
 }
 
-// Complete loads the kubeconfig and validates the discovery client is reachable.
+// Complete resolves the kubeconfig/context and constructs a discovery client,
+// failing fast on an invalid or nonexistent context before any manifest scan.
+// Note: this does not contact the API server; cluster unreachability is
+// detected later in Run() when discovery is queried.
 // Skipped in offline mode (--api-resources).
 func (o *ValidateOptions) Complete(c *cobra.Command, args []string) error {
 	if o.apiResourcesFile != "" {

--- a/cmd/validate/validate_test.go
+++ b/cmd/validate/validate_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/konveyor/crane/internal/flags"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
@@ -606,5 +607,69 @@ func TestValidate_HelpGroupsFlags(t *testing.T) {
 
 	if !strings.Contains(kubeSection, "--as-uid") {
 		t.Fatalf("expected --as-uid in inherited kube/client section, got:\n%s", kubeSection)
+	}
+}
+
+func TestComplete_InvalidContextFailsBeforeRun(t *testing.T) {
+	ctx := "nonexistent-context-that-does-not-exist"
+	cf := genericclioptions.NewConfigFlags(true)
+	cf.Context = &ctx
+
+	// Use a temp kubeconfig so the test is environment-independent
+	kc := filepath.Join(t.TempDir(), "kubeconfig")
+	kubeconfig := `apiVersion: v1
+kind: Config
+clusters:
+- name: local
+  cluster:
+    server: https://127.0.0.1:6443
+users:
+- name: local-user
+  user:
+    token: fake
+contexts:
+- name: existing-context
+  context:
+    cluster: local
+    user: local-user
+current-context: existing-context
+`
+	if err := os.WriteFile(kc, []byte(kubeconfig), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cf.KubeConfig = &kc
+
+	o := &ValidateOptions{
+		configFlags:  cf,
+		globalFlags:  &flags.GlobalFlags{},
+		inputDir:     t.TempDir(),
+		outputFormat: "json",
+	}
+
+	cmd := &cobra.Command{}
+	err := o.Complete(cmd, nil)
+
+	if err == nil {
+		t.Fatal("Complete() should fail for nonexistent context, but got nil")
+	}
+	if !strings.Contains(err.Error(), "nonexistent-context-that-does-not-exist") {
+		t.Fatalf("error should mention the invalid context name, got: %v", err)
+	}
+}
+
+func TestComplete_SkippedInOfflineMode(t *testing.T) {
+	o := &ValidateOptions{
+		configFlags:      genericclioptions.NewConfigFlags(true),
+		globalFlags:      &flags.GlobalFlags{},
+		inputDir:         t.TempDir(),
+		outputFormat:     "json",
+		apiResourcesFile: "/some/file.json",
+	}
+
+	cmd := &cobra.Command{}
+	err := o.Complete(cmd, nil)
+
+	if err != nil {
+		t.Fatalf("Complete() should skip in offline mode, got: %v", err)
 	}
 }


### PR DESCRIPTION
## The Problem

  ```bash
  $ crane validate --context does-not-exist -i output/
  INFO[0000] Scanned 3 distinct GVK+namespace tuples      ← misleading progress
  Error: creating discovery client: context "does-not-exist" does not exist
```

##  The Fix

  Replaced ToRawKubeConfigLoader().RawConfig() with ToDiscoveryClient() in Complete(). The old call only parsed the kubeconfig file without checking whether the specified context exists. The new call creates a discovery client
  for the specific context, which validates the context name before Run() starts scanning.

  $ crane validate --context does-not-exist -i output/
  Error: creating discovery client: context "does-not-exist" does not exist

No scan output before the error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Live validation now performs an earlier discovery client check and fails faster with clearer discovery/connection errors.
  * Offline validation (API-resources mode) behavior is unchanged.

* **Tests**
  * Added tests ensuring invalid cluster/context configurations fail early during validation and that offline/API-resources mode continues to skip live checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->