### PR TITLE
Fix bug 432: --output flag is case-sensitive

### DIFF
--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/konveyor/crane/internal/flags"
 	internalValidate "github.com/konveyor/crane/internal/validate"
@@ -50,6 +51,7 @@ func (o *ValidateOptions) Validate() error {
 		return fmt.Errorf("input-dir %q is not a directory", o.inputDir)
 	}
 
+	o.outputFormat = strings.ToLower(o.outputFormat)
 	if o.outputFormat != "yaml" && o.outputFormat != "json" {
 		return fmt.Errorf("--output must be \"yaml\" or \"json\", got %q", o.outputFormat)
 	}

--- a/cmd/validate/validate_test.go
+++ b/cmd/validate/validate_test.go
@@ -106,6 +106,36 @@ func TestValidate_Flags(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "uppercase JSON accepted",
+			setup: func(t *testing.T) *ValidateOptions {
+				return &ValidateOptions{
+					inputDir:     t.TempDir(),
+					outputFormat: "JSON",
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "uppercase YAML accepted",
+			setup: func(t *testing.T) *ValidateOptions {
+				return &ValidateOptions{
+					inputDir:     t.TempDir(),
+					outputFormat: "YAML",
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "mixed case Json accepted",
+			setup: func(t *testing.T) *ValidateOptions {
+				return &ValidateOptions{
+					inputDir:     t.TempDir(),
+					outputFormat: "Json",
+				}
+			},
+			wantErr: false,
+		},
+		{
 			name: "api-resources file not found",
 			setup: func(t *testing.T) *ValidateOptions {
 				return &ValidateOptions{


### PR DESCRIPTION
# PR: Fix bug 432: --output flag is case-sensitive in validate command

  Fixes [#432](https://github.com/migtools/crane/issues/432). `crane validate -o JSON` and `-o YAML` were rejected, while kubectl accepts both uppercase and lowercase.

  ## The Fix
  
  Normalize `outputFormat` to lowercase before validation:


 Now JSON, Json, json, Yaml, YAML all work — consistent with kubectl behavior.

  Verified kubectl behavior

  kubectl get pods -o JSON  → exit 0
  kubectl get pods -o YAML  → exit 0
  kubectl get pods -o json  → exit 0
  kubectl get pods -o yaml  → exit 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The `--output` flag now accepts uppercase and mixed-case values (e.g., `JSON`, `YAML`, `Json`) — validation is case-insensitive for improved usability.
* **Tests**
  * Validation tests expanded to cover uppercase and mixed-case `--output` inputs to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->