### PR TITLE
Add test for crane validate alternate GV in offline mode

### DIFF
--- a/e2e-tests/tests/mta_832_validate_alternative_gv_suggestion_offline_test.go
+++ b/e2e-tests/tests/mta_832_validate_alternative_gv_suggestion_offline_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 var _ = Describe("Validate alternative GV suggestion [Offline Mode]", func() {
-	It("[MTA-831] should suggest apps/v1 for extensions/v1beta1 Deployment in offline mode using captured API surface as namespace-admin", Label("tier1"), func() {
+	It("[MTA-832] should suggest apps/v1 for extensions/v1beta1 Deployment in offline mode using captured API surface as namespace-admin", Label("tier1"), func() {
 		appName := "simple-nginx-nopv"
 		namespace := "simple-nginx-validate-alt-gv-offline-mode"
 

--- a/e2e-tests/tests/validate_alternative_gv_suggestion_offline_test.go
+++ b/e2e-tests/tests/validate_alternative_gv_suggestion_offline_test.go
@@ -1,0 +1,139 @@
+package e2e
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	"github.com/konveyor/crane/e2e-tests/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Validate alternative GV suggestion [Offline Mode]", func() {
+	It("[MTA-831] should suggest apps/v1 for extensions/v1beta1 Deployment in offline mode using captured API surface as namespace-admin", Label("tier1"), func() {
+		appName := "simple-nginx-nopv"
+		namespace := "simple-nginx-validate-alt-gv-offline-mode"
+
+		scenario := NewMigrationScenario(
+			appName,
+			namespace,
+			config.K8sDeployBin,
+			config.CraneBin,
+			config.SourceContext,
+			config.TargetContext,
+		)
+
+		if scenario.SrcAppNonAdmin.Context == "" {
+			Skip("source-nonadmin-context is required for non-admin stateless migration test")
+		}
+		if scenario.TgtAppNonAdmin.Context == "" {
+			Skip("target-nonadmin-context is required for non-admin stateless migration test")
+		}
+		srcApp := scenario.SrcAppNonAdmin
+		tgtApp := scenario.TgtAppNonAdmin
+		runner := scenario.CraneNonAdmin
+		srcApp.ExtraVars = map[string]any{
+			"non_admin_user": "true",
+		}
+		tgtApp.ExtraVars = srcApp.ExtraVars
+		By("Grant ns admin permissions to nonadmin user on source and target")
+		kubectlSrcNonAdmin, _, cleanup, err := SetupNamespaceAdminUsersForScenario(scenario, namespace)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			By("Delete test namespace on source and target (wait for completion)")
+			for _, k := range []KubectlRunner{scenario.KubectlSrc, scenario.KubectlTgt} {
+				if _, err := k.Run("delete", "namespace", namespace, "--ignore-not-found=true", "--wait=true"); err != nil {
+					log.Printf("cleanup: failed to delete namespace %q on context %q: %v", namespace, k.Context, err)
+				}
+			}
+		})
+		DeferCleanup(cleanup) // Cleanup rolebindings
+		By("Prepare source app")
+		log.Printf("Preparing source app %s in namespace %s\n", srcApp.Name, srcApp.Namespace)
+		Expect(PrepareSourceApp(srcApp, kubectlSrcNonAdmin)).NotTo(HaveOccurred())
+		log.Printf("Source app %s prepared successfully\n", srcApp.Name)
+		paths, err := NewScenarioPaths("crane-pipeline-*")
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			By("Cleanup source and target resources")
+			if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
+				log.Printf("cleanup: %v", err)
+			}
+		})
+
+		runner.WorkDir = paths.TempDir
+		By("Run crane export/transform/apply pipeline")
+		log.Printf("Running crane pipeline for namespace %s\n", srcApp.Namespace)
+		Expect(RunCranePipelineWithChecks(runner, srcApp.Namespace, paths)).NotTo(HaveOccurred())
+		log.Printf("Crane pipeline completed for namespace %s\n", srcApp.Namespace)
+
+		By("Mutate deployment apiversion to extensions/v1beta1")
+		deploymentPattern := filepath.Join(paths.OutputDir, "resources", namespace, "Deployment_*.yaml")
+		matches, err := filepath.Glob(deploymentPattern)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(matches).NotTo(BeEmpty(), "expected at least one Deployment manifest in output")
+
+		deploymentPath := matches[0]
+		deploymentBytes, err := os.ReadFile(deploymentPath)
+		Expect(err).NotTo(HaveOccurred())
+
+		mutatedDeployment := strings.Replace(string(deploymentBytes), "apiVersion: apps/v1", "apiVersion: extensions/v1beta1", 1) // Replace apiVersion
+		Expect(mutatedDeployment).NotTo(Equal(string(deploymentBytes)), "expected to replace Deployment apiVersion")
+		Expect(os.WriteFile(deploymentPath, []byte(mutatedDeployment), 0o644)).NotTo(HaveOccurred())
+
+		By("Capture target cluster api surface in a api-surface.json file")
+		apiSurfaceFile := filepath.Join(paths.TempDir, "api-surface.json")
+		captureScript, err := utils.CaptureAPISurfaceScriptPath()
+		Expect(err).NotTo(HaveOccurred())
+		captureCmd := exec.Command("bash", captureScript, "--context", scenario.KubectlTgtNonAdmin.Context, "-o", apiSurfaceFile)
+		captureOut, err := captureCmd.CombinedOutput()
+		Expect(err).NotTo(HaveOccurred(), "failed to capture API surface %s", string(captureOut))
+		By("Verify captured API surface file exists and is valid JSON")
+		Expect(apiSurfaceFile).To(BeAnExistingFile(), "expected api surface file at %s", apiSurfaceFile)
+
+		apiSurfaceData, err := os.ReadFile(apiSurfaceFile)
+		Expect(err).NotTo(HaveOccurred())
+
+		var apiSurface map[string]any
+		err = json.Unmarshal(apiSurfaceData, &apiSurface)
+		Expect(err).NotTo(HaveOccurred(), "api-surface.json should contain valid JSON")
+
+		By("Run crane validate in offline mode using captured API surface")
+		stdout, err := runner.Validate(ValidateOptions{
+			InputDir:         filepath.Join(paths.OutputDir, "resources", namespace),
+			ValidateDir:      paths.ValidateDir,
+			APIResourcesFile: apiSurfaceFile,
+		})
+
+		Expect(err).To(HaveOccurred(), "validate should fail for deprecated Deployment apiVersion")
+		Expect(stdout).To(ContainSubstring("Mode: offline"))
+		Expect(stdout).To(ContainSubstring("available as apps/v1"))
+
+		By("Assert report.json includes incompatible deployment with suggestion")
+		reportPath := filepath.Join(paths.ValidateDir, "report.json")
+		reportBytes, err := os.ReadFile(reportPath)
+		Expect(err).NotTo(HaveOccurred())
+		report := string(reportBytes)
+		Expect(report).To(ContainSubstring(`"apiResourcesSource"`))
+		Expect(report).To(ContainSubstring(`"apiVersion": "extensions/v1beta1"`))
+		Expect(report).To(ContainSubstring(`"kind": "Deployment"`))
+		Expect(report).To(ContainSubstring(`"status": "Incompatible"`))
+		Expect(report).To(ContainSubstring(`"suggestion": "available as apps/v1"`))
+
+		By("Assert failures directory contains deployment failure with suggestion")
+		failurePattern := filepath.Join(paths.ValidateDir, "failures", "Deployment_extensions_v1beta1_*.yaml")
+		failureMatches, err := filepath.Glob(failurePattern)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(failureMatches).NotTo(BeEmpty(), "expected at least one validation failure file")
+
+		failureBytes, err := os.ReadFile(failureMatches[0])
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(failureBytes)).To(ContainSubstring("suggestion: available as apps/v1"))
+	})
+})

--- a/e2e-tests/utils/utils.go
+++ b/e2e-tests/utils/utils.go
@@ -880,3 +880,25 @@ func AssertKindsNotInActiveKustomizeResources(transformDir string, deniedKinds [
 		return nil
 	})
 }
+
+// CaptureAPISurfaceScriptPath returns the absolute path to scripts/capture-api-surface.sh.
+// The path is resolved relative to this source file so tests do not depend on the
+// process working directory or crane binary location. It also verifies the script
+// exists and returns an error when it cannot be found.
+func CaptureAPISurfaceScriptPath() (string, error) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("runtime.Caller failed")
+	}
+
+	// thisFile => <repo>/e2e-tests/utils/utils.go
+	// repo root => <repo>
+	baseDir := filepath.Dir(thisFile)
+	scriptPath := filepath.Join(baseDir, "..", "..", "scripts", "capture-api-surface.sh")
+
+	if _, err := os.Stat(scriptPath); err != nil {
+		return "", fmt.Errorf("capture script not found at %s: %w", scriptPath, err)
+	}
+
+	return scriptPath, nil
+}

--- a/e2e-tests/utils/utils_test.go
+++ b/e2e-tests/utils/utils_test.go
@@ -309,6 +309,27 @@ func TestGoldenManifestsDir(t *testing.T) {
 	}
 }
 
+func TestCaptureAPISurfaceScriptPath(t *testing.T) {
+	// Ensure helper returns an absolute, existing path to scripts/capture-api-surface.sh.
+	scriptPath, err := CaptureAPISurfaceScriptPath()
+	if err != nil {
+		t.Fatalf("CaptureAPISurfaceScriptPath: %v", err)
+	}
+
+	if !filepath.IsAbs(scriptPath) {
+		t.Fatalf("script path must be absolute, got %q", scriptPath)
+	}
+
+	wantSuffix := filepath.Join("scripts", "capture-api-surface.sh")
+	if !strings.HasSuffix(filepath.Clean(scriptPath), wantSuffix) {
+		t.Fatalf("script path %q must end with %q", scriptPath, wantSuffix)
+	}
+
+	if _, err := os.Stat(scriptPath); err != nil {
+		t.Fatalf("os.Stat(%q): %v", scriptPath, err)
+	}
+}
+
 func TestCreateTempDir(t *testing.T) {
 	// Ensure temp dir creation succeeds and preserves the requested prefix.
 	dir, err := CreateTempDir("utils-test-")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end test for offline validation that detects deprecated API versions and suggests the appropriate alternatives.
  * Added a utility and accompanying test to locate and verify the API-surface capture script used during end-to-end validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/migtools/crane/pull/448?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->