### PR TITLE
Fix bug 431: validate directory overwrites without warning

### DIFF
--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -123,18 +123,10 @@ func (o *ValidateOptions) Run() error {
 	reportPath := filepath.Join(o.validateDir, "report."+reportExt)
 	failuresDir := filepath.Join(o.validateDir, "failures")
 
-	// Archive previous results using report's timestamp so report and failures
-	// are grouped by the same timestamp even if they were written at slightly
-	// different times within the same run.
-	if ts, err := getArchiveTimestamp(reportPath); err != nil {
-		return fmt.Errorf("checking previous report: %w", err)
-	} else if ts != "" {
-		if err := archiveWithTimestamp(reportPath, ts, log); err != nil {
-			return fmt.Errorf("archiving previous report: %w", err)
-		}
-		if err := archiveWithTimestamp(failuresDir, ts, log); err != nil {
-			return fmt.Errorf("archiving previous failures: %w", err)
-		}
+	// Archive previous results. Check for report in any format (json or yaml)
+	// to handle the case where the user switches --output format between runs.
+	if err := archivePreviousResults(o.validateDir, failuresDir, log); err != nil {
+		return err
 	}
 
 	reportFile, err := os.Create(reportPath)
@@ -203,6 +195,50 @@ func archiveWithTimestamp(path, timestamp string, log logrus.FieldLogger) error 
 		return fmt.Errorf("renaming %q to %q: %w", path, archivePath, err)
 	}
 	log.Infof("Archived previous results: %s", filepath.Base(archivePath))
+	return nil
+}
+
+// archivePreviousResults finds any existing report file (json or yaml) in
+// validateDir and archives it along with the failures directory using a shared
+// timestamp. This handles the case where the user switches --output format
+// between runs (e.g., first run -o json, second run -o yaml).
+func archivePreviousResults(validateDir, failuresDir string, log logrus.FieldLogger) error {
+	// Look for report in any format
+	matches, err := filepath.Glob(filepath.Join(validateDir, "report.json"))
+	if err != nil {
+		return fmt.Errorf("checking for previous json report: %w", err)
+	}
+	yamlMatches, err := filepath.Glob(filepath.Join(validateDir, "report.yaml"))
+	if err != nil {
+		return fmt.Errorf("checking for previous yaml report: %w", err)
+	}
+	matches = append(matches, yamlMatches...)
+
+	if len(matches) == 0 {
+		return nil
+	}
+
+	// Use the first found report's timestamp for both report and failures
+	ts, err := getArchiveTimestamp(matches[0])
+	if err != nil {
+		return fmt.Errorf("checking previous report: %w", err)
+	}
+	if ts == "" {
+		return nil
+	}
+
+	// Archive all found report files (could be both json and yaml from different runs)
+	for _, reportFile := range matches {
+		if err := archiveWithTimestamp(reportFile, ts, log); err != nil {
+			return fmt.Errorf("archiving previous report: %w", err)
+		}
+	}
+
+	// Archive failures directory with the same timestamp
+	if err := archiveWithTimestamp(failuresDir, ts, log); err != nil {
+		return fmt.Errorf("archiving previous failures: %w", err)
+	}
+
 	return nil
 }
 

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/konveyor/crane/internal/flags"
 	internalValidate "github.com/konveyor/crane/internal/validate"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -116,8 +118,25 @@ func (o *ValidateOptions) Run() error {
 	if err := os.MkdirAll(o.validateDir, 0700); err != nil {
 		return fmt.Errorf("creating validate directory: %w", err)
 	}
+
 	reportExt := o.outputFormat
 	reportPath := filepath.Join(o.validateDir, "report."+reportExt)
+	failuresDir := filepath.Join(o.validateDir, "failures")
+
+	// Archive previous results using report's timestamp so report and failures
+	// are grouped by the same timestamp even if they were written at slightly
+	// different times within the same run.
+	if ts, err := getArchiveTimestamp(reportPath); err != nil {
+		return fmt.Errorf("checking previous report: %w", err)
+	} else if ts != "" {
+		if err := archiveWithTimestamp(reportPath, ts, log); err != nil {
+			return fmt.Errorf("archiving previous report: %w", err)
+		}
+		if err := archiveWithTimestamp(failuresDir, ts, log); err != nil {
+			return fmt.Errorf("archiving previous failures: %w", err)
+		}
+	}
+
 	reportFile, err := os.Create(reportPath)
 	if err != nil {
 		return fmt.Errorf("creating validation report %q: %w", reportPath, err)
@@ -139,13 +158,51 @@ func (o *ValidateOptions) Run() error {
 	log.Infof("Wrote validation report to %s", reportPath)
 
 	if report.HasIncompatible() {
-		failuresDir := filepath.Join(o.validateDir, "failures")
 		if err := internalValidate.WriteFailures(failuresDir, report, log); err != nil {
 			return fmt.Errorf("writing validation failures to %q: %w", failuresDir, err)
 		}
 		return internalValidate.ErrValidationFailed
 	}
 
+	return nil
+}
+
+// getArchiveTimestamp returns the modification time of the given path formatted
+// as a timestamp string. Returns empty string if the path does not exist.
+func getArchiveTimestamp(path string) (string, error) {
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("checking %q: %w", path, err)
+	}
+	return info.ModTime().Format("20060102-150405"), nil
+}
+
+// archiveWithTimestamp renames an existing file or directory by appending the
+// given timestamp, preserving previous results across runs.
+// For example, report.json becomes report-20260603-100942.json.
+// Does nothing if the path does not exist.
+func archiveWithTimestamp(path, timestamp string, log logrus.FieldLogger) error {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("checking %q: %w", path, err)
+	}
+
+	ext := filepath.Ext(path)
+	var archivePath string
+	if ext != "" {
+		archivePath = strings.TrimSuffix(path, ext) + "-" + timestamp + ext
+	} else {
+		archivePath = path + "-" + timestamp
+	}
+
+	if err := os.Rename(path, archivePath); err != nil {
+		return fmt.Errorf("renaming %q to %q: %w", path, archivePath, err)
+	}
+	log.Infof("Archived previous results: %s", filepath.Base(archivePath))
 	return nil
 }
 

--- a/cmd/validate/validate_test.go
+++ b/cmd/validate/validate_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/konveyor/crane/internal/flags"
+	"github.com/sirupsen/logrus"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
@@ -240,6 +241,139 @@ func TestValidateCommand_RejectsArgs(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unknown command") {
 		t.Fatalf("expected 'unknown command' error, got: %v", err)
+	}
+}
+
+func TestArchiveWithTimestamp_FileExists(t *testing.T) {
+	dir := t.TempDir()
+	reportPath := filepath.Join(dir, "report.json")
+
+	if err := os.WriteFile(reportPath, []byte(`{"totalScanned":5}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	err := archiveWithTimestamp(reportPath, "20260603-100942", log)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Original should be gone
+	if _, err := os.Stat(reportPath); !os.IsNotExist(err) {
+		t.Error("original report.json should not exist after archiving")
+	}
+
+	// Archived file should have exact name
+	archivedPath := filepath.Join(dir, "report-20260603-100942.json")
+	data, err := os.ReadFile(archivedPath)
+	if err != nil {
+		t.Fatalf("archived file not found: %v", err)
+	}
+	if string(data) != `{"totalScanned":5}` {
+		t.Errorf("archived content mismatch: got %q", string(data))
+	}
+}
+
+func TestArchiveWithTimestamp_DirectoryExists(t *testing.T) {
+	dir := t.TempDir()
+	failuresDir := filepath.Join(dir, "failures")
+
+	if err := os.MkdirAll(failuresDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(failuresDir, "Deployment.yaml"), []byte("test"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	err := archiveWithTimestamp(failuresDir, "20260603-100942", log)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Original should be gone
+	if _, err := os.Stat(failuresDir); !os.IsNotExist(err) {
+		t.Error("original failures/ should not exist after archiving")
+	}
+
+	// Archived directory should have exact name and contents
+	archivedFile := filepath.Join(dir, "failures-20260603-100942", "Deployment.yaml")
+	if _, err := os.Stat(archivedFile); os.IsNotExist(err) {
+		t.Error("archived directory should contain Deployment.yaml")
+	}
+}
+
+func TestArchiveWithTimestamp_NothingToArchive(t *testing.T) {
+	dir := t.TempDir()
+	nonexistent := filepath.Join(dir, "report.json")
+
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	err := archiveWithTimestamp(nonexistent, "20260603-100942", log)
+	if err != nil {
+		t.Fatalf("should not error when file doesn't exist: %v", err)
+	}
+}
+
+func TestArchiveTimestamp_ReportAndFailuresShareTimestamp(t *testing.T) {
+	dir := t.TempDir()
+	reportPath := filepath.Join(dir, "report.json")
+	failuresDir := filepath.Join(dir, "failures")
+
+	if err := os.WriteFile(reportPath, []byte(`{"totalScanned":1}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(failuresDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(failuresDir, "Deployment.yaml"), []byte("fail"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	// Get timestamp from report
+	ts, err := getArchiveTimestamp(reportPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ts == "" {
+		t.Fatal("expected non-empty timestamp")
+	}
+
+	// Archive both with same timestamp
+	if err := archiveWithTimestamp(reportPath, ts, log); err != nil {
+		t.Fatalf("archive report: %v", err)
+	}
+	if err := archiveWithTimestamp(failuresDir, ts, log); err != nil {
+		t.Fatalf("archive failures: %v", err)
+	}
+
+	// Both should have the same timestamp suffix
+	archivedReport := filepath.Join(dir, "report-"+ts+".json")
+	archivedFailures := filepath.Join(dir, "failures-"+ts)
+
+	if _, err := os.Stat(archivedReport); os.IsNotExist(err) {
+		t.Error("archived report not found")
+	}
+	if _, err := os.Stat(archivedFailures); os.IsNotExist(err) {
+		t.Error("archived failures not found")
+	}
+}
+
+func TestGetArchiveTimestamp_FileNotFound(t *testing.T) {
+	ts, err := getArchiveTimestamp(filepath.Join(t.TempDir(), "nonexistent"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ts != "" {
+		t.Errorf("expected empty timestamp for nonexistent file, got %q", ts)
 	}
 }
 

--- a/cmd/validate/validate_test.go
+++ b/cmd/validate/validate_test.go
@@ -377,3 +377,76 @@ func TestGetArchiveTimestamp_FileNotFound(t *testing.T) {
 	}
 }
 
+func TestArchivePreviousResults_FormatSwitch(t *testing.T) {
+	dir := t.TempDir()
+
+	// Simulate first run with -o json
+	if err := os.WriteFile(filepath.Join(dir, "report.json"), []byte(`{"mode":"live"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	failuresDir := filepath.Join(dir, "failures")
+	if err := os.MkdirAll(failuresDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(failuresDir, "Deployment.yaml"), []byte("fail"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	// Now archive as if user switched to -o yaml
+	// The function should find report.json even though current format is yaml
+	err := archivePreviousResults(dir, failuresDir, log)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// report.json should be archived
+	if _, err := os.Stat(filepath.Join(dir, "report.json")); !os.IsNotExist(err) {
+		t.Error("report.json should have been archived")
+	}
+
+	// failures/ should be archived
+	if _, err := os.Stat(failuresDir); !os.IsNotExist(err) {
+		t.Error("failures/ should have been archived")
+	}
+
+	// Archived files should exist
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	foundReport := false
+	foundFailures := false
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), "report-") && strings.HasSuffix(entry.Name(), ".json") {
+			foundReport = true
+		}
+		if strings.HasPrefix(entry.Name(), "failures-") && entry.IsDir() {
+			foundFailures = true
+		}
+	}
+
+	if !foundReport {
+		t.Error("expected archived report-<timestamp>.json")
+	}
+	if !foundFailures {
+		t.Error("expected archived failures-<timestamp>/ directory")
+	}
+}
+
+func TestArchivePreviousResults_NoPreviousResults(t *testing.T) {
+	dir := t.TempDir()
+	failuresDir := filepath.Join(dir, "failures")
+
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	err := archivePreviousResults(dir, failuresDir, log)
+	if err != nil {
+		t.Fatalf("should not error when no previous results exist: %v", err)
+	}
+}
+


### PR DESCRIPTION
 # PR: Fix bug 431: --validate-dir silently overwrites existing report on consecutive runs

  Fixes [#431](https://github.com/migtools/crane/issues/431). 
  Previous validation reports and failures were silently overwritten on consecutive runs, losing audit history.

  ## The Problem

  ```bash
  crane validate --context tgt -i output/ --validate-dir validate/
  # writes validate/report.json

  crane validate --context tgt -i output/ --validate-dir validate/
  # silently overwrites report.json — previous results lost
 ```
 
 ## The Fix

  Before writing new results, existing report.json and failures/ are renamed using the report's modification timestamp. Both are archived with the same timestamp derived from report.json to guarantee they stay grouped.

  First run:
  validate/
  ├── report.json
  └── failures/

  Second run:
  validate/
  ├── report.json                       ← latest
  ├── report-20260603-100942.json       ← previous (renamed)
  ├── failures/                         ← latest
  └── failures-20260603-100942/         ← previous (renamed, same timestamp)

  Third run:
  validate/
  ├── report.json                       ← latest
  ├── report-20260603-100942.json       ← first run
  ├── report-20260603-112015.json       ← second run
  ├── failures/                         ← latest
  ├── failures-20260603-100942/         ← first run
  └── failures-20260603-112015/         ← second run

  - report.json always exists at a stable path for scripts
  - Previous results preserved with timestamps for audit
  - Timestamp is the report file's modification time (when it was originally written), not the current time
  - Report and failures share the same timestamp so they stay paired
  - No data duplication on disk

  Manual Testing on Minikube (all PASS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Previous validation reports and failure directories are now automatically archived before new reports are generated. Archived items use a shared timestamp-based naming to preserve validation run history and avoid overwriting.

* **Tests**
  * Added unit tests covering timestamp computation and archiving behavior, including cases for files, directories, format switches, and no-previous-results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->