### PR TITLE
fix bug 429: --api resources mutual exclusion for --server, --token, …

### DIFF
--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -63,6 +63,18 @@ func (o *ValidateOptions) Validate() error {
 		if o.configFlags.KubeConfig != nil && *o.configFlags.KubeConfig != "" {
 			return fmt.Errorf("--api-resources and --kubeconfig are mutually exclusive; use --api-resources for offline validation or --kubeconfig for live validation")
 		}
+		if o.configFlags.APIServer != nil && *o.configFlags.APIServer != "" {
+			return fmt.Errorf("--api-resources and --server are mutually exclusive; use --api-resources for offline validation or --server for live validation")
+		}
+		if o.configFlags.BearerToken != nil && *o.configFlags.BearerToken != "" {
+			return fmt.Errorf("--api-resources and --token are mutually exclusive; use --api-resources for offline validation or --token for live validation")
+		}
+		if o.configFlags.ClusterName != nil && *o.configFlags.ClusterName != "" {
+			return fmt.Errorf("--api-resources and --cluster are mutually exclusive; use --api-resources for offline validation or --cluster for live validation")
+		}
+		if o.configFlags.AuthInfoName != nil && *o.configFlags.AuthInfoName != "" {
+			return fmt.Errorf("--api-resources and --user are mutually exclusive; use --api-resources for offline validation or --user for live validation")
+		}
 		if _, err := os.Stat(o.apiResourcesFile); err != nil {
 			return fmt.Errorf("api-resources file %q: %w", o.apiResourcesFile, err)
 		}

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -214,7 +214,7 @@ failed (or another error occurred).`,
 	cmd.Flags().StringVarP(&o.inputDir, "input-dir", "i", "output", "The path to the apply output directory containing final manifests")
 	cmd.Flags().StringVar(&o.validateDir, "validate-dir", "validate", "The path where validation results and failures are saved")
 	cmd.Flags().StringVarP(&o.outputFormat, "output", "o", "json", "Report file format: json or yaml")
-	cmd.Flags().StringVar(&o.apiResourcesFile, "api-resources", "", "Path to API surface JSON file from capture-api-surface.sh for offline validation (mutually exclusive with --context/--kubeconfig)")
+	cmd.Flags().StringVar(&o.apiResourcesFile, "api-resources", "", "Path to API surface JSON file from capture-api-surface.sh for offline validation (mutually exclusive with --context/--kubeconfig/--server/--token/--cluster/--user)")
 	o.configFlags.AddFlags(cmd.Flags())
 
 	return cmd

--- a/cmd/validate/validate_test.go
+++ b/cmd/validate/validate_test.go
@@ -149,7 +149,7 @@ func TestValidate_Flags(t *testing.T) {
 			errMatch: "api-resources file",
 		},
 		{
-			name: "api-resources with context is mutually exclusive",
+			name: "api-resources with --context is mutually exclusive",
 			setup: func(t *testing.T) *ValidateOptions {
 				dir := t.TempDir()
 				f := filepath.Join(dir, "api-resources.json")
@@ -167,10 +167,10 @@ func TestValidate_Flags(t *testing.T) {
 				}
 			},
 			wantErr:  true,
-			errMatch: "mutually exclusive",
+			errMatch: "--api-resources and --context are mutually exclusive",
 		},
 		{
-			name: "api-resources with kubeconfig is mutually exclusive",
+			name: "api-resources with --kubeconfig is mutually exclusive",
 			setup: func(t *testing.T) *ValidateOptions {
 				dir := t.TempDir()
 				f := filepath.Join(dir, "api-resources.json")
@@ -188,10 +188,10 @@ func TestValidate_Flags(t *testing.T) {
 				}
 			},
 			wantErr:  true,
-			errMatch: "mutually exclusive",
+			errMatch: "--api-resources and --kubeconfig are mutually exclusive",
 		},
 		{
-			name: "api-resources with server is mutually exclusive",
+			name: "api-resources with --server is mutually exclusive",
 			setup: func(t *testing.T) *ValidateOptions {
 				dir := t.TempDir()
 				f := filepath.Join(dir, "api-resources.json")
@@ -209,10 +209,10 @@ func TestValidate_Flags(t *testing.T) {
 				}
 			},
 			wantErr:  true,
-			errMatch: "mutually exclusive",
+			errMatch: "--api-resources and --server are mutually exclusive",
 		},
 		{
-			name: "api-resources with token is mutually exclusive",
+			name: "api-resources with --token is mutually exclusive",
 			setup: func(t *testing.T) *ValidateOptions {
 				dir := t.TempDir()
 				f := filepath.Join(dir, "api-resources.json")
@@ -230,10 +230,10 @@ func TestValidate_Flags(t *testing.T) {
 				}
 			},
 			wantErr:  true,
-			errMatch: "mutually exclusive",
+			errMatch: "--api-resources and --token are mutually exclusive",
 		},
 		{
-			name: "api-resources with cluster is mutually exclusive",
+			name: "api-resources with --cluster is mutually exclusive",
 			setup: func(t *testing.T) *ValidateOptions {
 				dir := t.TempDir()
 				f := filepath.Join(dir, "api-resources.json")
@@ -251,10 +251,10 @@ func TestValidate_Flags(t *testing.T) {
 				}
 			},
 			wantErr:  true,
-			errMatch: "mutually exclusive",
+			errMatch: "--api-resources and --cluster are mutually exclusive",
 		},
 		{
-			name: "api-resources with user is mutually exclusive",
+			name: "api-resources with --user is mutually exclusive",
 			setup: func(t *testing.T) *ValidateOptions {
 				dir := t.TempDir()
 				f := filepath.Join(dir, "api-resources.json")
@@ -272,7 +272,7 @@ func TestValidate_Flags(t *testing.T) {
 				}
 			},
 			wantErr:  true,
-			errMatch: "mutually exclusive",
+			errMatch: "--api-resources and --user are mutually exclusive",
 		},
 		{
 			name: "api-resources valid file accepted",

--- a/cmd/validate/validate_test.go
+++ b/cmd/validate/validate_test.go
@@ -191,6 +191,90 @@ func TestValidate_Flags(t *testing.T) {
 			errMatch: "mutually exclusive",
 		},
 		{
+			name: "api-resources with server is mutually exclusive",
+			setup: func(t *testing.T) *ValidateOptions {
+				dir := t.TempDir()
+				f := filepath.Join(dir, "api-resources.json")
+				if err := os.WriteFile(f, []byte(`{}`), 0600); err != nil {
+					t.Fatal(err)
+				}
+				server := "https://127.0.0.1:6443"
+				cf := genericclioptions.NewConfigFlags(true)
+				cf.APIServer = &server
+				return &ValidateOptions{
+					configFlags:      cf,
+					inputDir:         dir,
+					outputFormat:     "json",
+					apiResourcesFile: f,
+				}
+			},
+			wantErr:  true,
+			errMatch: "mutually exclusive",
+		},
+		{
+			name: "api-resources with token is mutually exclusive",
+			setup: func(t *testing.T) *ValidateOptions {
+				dir := t.TempDir()
+				f := filepath.Join(dir, "api-resources.json")
+				if err := os.WriteFile(f, []byte(`{}`), 0600); err != nil {
+					t.Fatal(err)
+				}
+				token := "some-bearer-token"
+				cf := genericclioptions.NewConfigFlags(true)
+				cf.BearerToken = &token
+				return &ValidateOptions{
+					configFlags:      cf,
+					inputDir:         dir,
+					outputFormat:     "json",
+					apiResourcesFile: f,
+				}
+			},
+			wantErr:  true,
+			errMatch: "mutually exclusive",
+		},
+		{
+			name: "api-resources with cluster is mutually exclusive",
+			setup: func(t *testing.T) *ValidateOptions {
+				dir := t.TempDir()
+				f := filepath.Join(dir, "api-resources.json")
+				if err := os.WriteFile(f, []byte(`{}`), 0600); err != nil {
+					t.Fatal(err)
+				}
+				cluster := "some-cluster"
+				cf := genericclioptions.NewConfigFlags(true)
+				cf.ClusterName = &cluster
+				return &ValidateOptions{
+					configFlags:      cf,
+					inputDir:         dir,
+					outputFormat:     "json",
+					apiResourcesFile: f,
+				}
+			},
+			wantErr:  true,
+			errMatch: "mutually exclusive",
+		},
+		{
+			name: "api-resources with user is mutually exclusive",
+			setup: func(t *testing.T) *ValidateOptions {
+				dir := t.TempDir()
+				f := filepath.Join(dir, "api-resources.json")
+				if err := os.WriteFile(f, []byte(`{}`), 0600); err != nil {
+					t.Fatal(err)
+				}
+				user := "some-user"
+				cf := genericclioptions.NewConfigFlags(true)
+				cf.AuthInfoName = &user
+				return &ValidateOptions{
+					configFlags:      cf,
+					inputDir:         dir,
+					outputFormat:     "json",
+					apiResourcesFile: f,
+				}
+			},
+			wantErr:  true,
+			errMatch: "mutually exclusive",
+		},
+		{
 			name: "api-resources valid file accepted",
 			setup: func(t *testing.T) *ValidateOptions {
 				dir := t.TempDir()


### PR DESCRIPTION
 # PR: Fix bug 429: --api-resources mutual exclusion not enforced for --server, --token, --cluster, --user

  Fixes [#429](https://github.com/migtools/crane/issues/429). When `--api-resources` was combined with `--server`, `--token`, `--cluster`, or `--user`, crane silently ran in offline mode — ignoring the live cluster flags. Users
  could believe they were validating against a live cluster while actually validating against a local JSON file.

  ## The Problem

  ```bash
  # User thinks they're validating against a live server — but crane silently uses the JSON file
  crane validate --api-resources api-surface.json --server https://127.0.0.1:6443 -i output/
  # Mode: offline (api-resources: api-surface.json)  ← --server silently ignored
```

  Only --context and --kubeconfig were blocked. Four other connectivity flags were silently ignored.

## The Fix

  Extended the mutual exclusion checks in Validate() to cover all connectivity flags:

 
  Each produces a clear error naming the conflicting flag:
  Error: --api-resources and --server are mutually exclusive; use --api-resources for offline validation or --server for live validation
  
  
  Tested successfully on minikube cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced mutual-exclusivity: `--api-resources` can no longer be used with `--server`, `--token`, `--cluster`, or `--user`, with clearer flag-specific error messages.

* **Tests**
  * Expanded test cases to cover the new mutual-exclusivity validations and updated assertions for existing exclusions.

* **Documentation**
  * Updated `--api-resources` help text to explicitly list the mutually-exclusive live-validation flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->