### PR TITLE
Inject proper crane version from tag in CI

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -46,6 +46,7 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: "0"
+          BUILD_VERSION: ${{ github.ref_type == 'tag' && github.ref_name || format('main-{0}', github.sha) }}
         run: |
           mkdir -p dist
 
@@ -55,7 +56,13 @@ jobs:
           fi
 
           binary="crane_${GOOS}_${GOARCH}${ext}"
-          go build -trimpath -o "dist/${binary}" .
+          go build -trimpath \
+            -ldflags "-X github.com/konveyor/crane/internal/buildinfo.Version=${BUILD_VERSION}" \
+            -o "dist/${binary}" .
+
+          if [ "$GOOS" = "linux" ] && [ "$GOARCH" = "amd64" ]; then
+            ./dist/${binary} version | rg "Version: ${BUILD_VERSION}" >/dev/null
+          fi
           (
             cd dist
             sha256sum "${binary}" > "${binary}.sha256"

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -47,6 +47,7 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: "0"
           BUILD_VERSION: ${{ github.ref_type == 'tag' && github.ref_name || format('main-{0}', github.sha) }}
+          BUILD_COMMIT: ${{ github.sha }}
         run: |
           mkdir -p dist
 
@@ -57,7 +58,7 @@ jobs:
 
           binary="crane_${GOOS}_${GOARCH}${ext}"
           go build -trimpath \
-            -ldflags "-X github.com/konveyor/crane/internal/buildinfo.Version=${BUILD_VERSION}" \
+            -ldflags "-X github.com/konveyor/crane/internal/buildinfo.Version=${BUILD_VERSION} -X github.com/konveyor/crane/internal/buildinfo.BuildCommit=${BUILD_COMMIT}" \
             -o "dist/${binary}" .
 
           # Validate version injection for each built artifact.

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -60,9 +60,12 @@ jobs:
             -ldflags "-X github.com/konveyor/crane/internal/buildinfo.Version=${BUILD_VERSION}" \
             -o "dist/${binary}" .
 
-          if [ "$GOOS" = "linux" ] && [ "$GOARCH" = "amd64" ]; then
-            ./dist/${binary} version | rg "Version: ${BUILD_VERSION}" >/dev/null
+          # Validate version injection for each built artifact.
+          if ! strings "dist/${binary}" | grep -Fq "${BUILD_VERSION}"; then
+            echo "Injected version ${BUILD_VERSION} not found in ${binary}"
+            exit 1
           fi
+
           (
             cd dist
             sha256sum "${binary}" > "${binary}.sha256"

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -60,6 +60,7 @@ func NewVersionCommand(f *flags.GlobalFlags) *cobra.Command {
 func (o *Options) run() error {
 	fmt.Println("crane:")
 	fmt.Printf("\tVersion: %s\n", buildinfo.Version)
+	fmt.Printf("\tSHA: %s\n", buildinfo.BuildCommit)
 	fmt.Println("crane-lib:")
 	fmt.Printf("\tVersion: %s\n", buildinfo.CranelibVersion)
 	fmt.Println("kustomize:")

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -10,9 +10,12 @@ import (
 )
 
 var (
+	// Version and BuildCommit can be overridden at build time with:
+	// go build -ldflags="-X github.com/konveyor/crane/internal/buildinfo.Version=<version> -X github.com/konveyor/crane/internal/buildinfo.BuildCommit=$(git rev-parse HEAD)"
 	Version string = "v0.0.6"
 
 	CranelibVersion string = cranelibversion.Version
+	BuildCommit     string = ""
 
 	KustomizeVersion string = readKustomizeVersion()
 )

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -15,7 +15,7 @@ var (
 	Version string = "v0.0.6"
 
 	CranelibVersion string = cranelibversion.Version
-	BuildCommit     string = ""
+	BuildCommit     string = "main"
 
 	KustomizeVersion string = readKustomizeVersion()
 )

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -12,7 +12,7 @@ import (
 var (
 	// Version and BuildCommit can be overridden at build time with:
 	// go build -ldflags="-X github.com/konveyor/crane/internal/buildinfo.Version=<version> -X github.com/konveyor/crane/internal/buildinfo.BuildCommit=$(git rev-parse HEAD)"
-	Version string = "v0.0.6"
+	Version string = "main"
 
 	CranelibVersion string = cranelibversion.Version
 	BuildCommit     string = "main"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release builds now write compiled artifacts to a dedicated distribution directory.
  * Build process embeds a computed build version (tag or commit-based) into artifacts and validates its presence.
  * CI will fail if the expected version metadata is not found in the produced binary.

* **New Features**
  * CLI version output now includes the build commit SHA alongside the version for clearer traceability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->