### PR TITLE
Fix bug 426: Improved debug logging for validate command

### DIFF
--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -88,6 +88,15 @@ func (o *ValidateOptions) Validate() error {
 func (o *ValidateOptions) Run() error {
 	log := o.globalFlags.GetLogger()
 
+	log.Debugf("Input directory: %s", o.inputDir)
+	log.Debugf("Validate directory: %s", o.validateDir)
+	log.Debugf("Output format: %s", o.outputFormat)
+	if o.apiResourcesFile != "" {
+		log.Debugf("Mode: offline (api-resources: %s)", o.apiResourcesFile)
+	} else {
+		log.Debugf("Mode: live")
+	}
+
 	entries, err := internalValidate.ScanManifests(internalValidate.ScanOptions{Dirs: []string{o.inputDir}}, log)
 	if err != nil {
 		return fmt.Errorf("scanning manifests: %w", err)
@@ -102,13 +111,14 @@ func (o *ValidateOptions) Run() error {
 	var report *internalValidate.ValidationReport
 
 	if o.apiResourcesFile != "" {
-		index, err := internalValidate.ParseAPIResourcesJSON(o.apiResourcesFile)
+		index, err := internalValidate.ParseAPIResourcesJSON(o.apiResourcesFile, log)
 		if err != nil {
 			return fmt.Errorf("loading api-resources: %w", err)
 		}
-		report = internalValidate.MatchResultsFromIndex(entries, index)
+		report = internalValidate.MatchResultsFromIndex(entries, index, log)
 		report.Mode = "offline"
 		report.APIResourcesSource = o.apiResourcesFile
+		log.Infof("Validating in offline mode using api-resources file %q", o.apiResourcesFile)
 	} else {
 		discoveryClient, err := o.configFlags.ToDiscoveryClient()
 		if err != nil {
@@ -123,6 +133,9 @@ func (o *ValidateOptions) Run() error {
 		report.Mode = "live"
 		if o.configFlags.Context != nil && *o.configFlags.Context != "" {
 			report.ClusterContext = *o.configFlags.Context
+			log.Infof("Validating in live mode against context %q", *o.configFlags.Context)
+		} else {
+			log.Infof("Validating in live mode against current kubeconfig context")
 		}
 	}
 
@@ -228,9 +241,11 @@ func archivePreviousResults(validateDir, failuresDir string, log logrus.FieldLog
 	matches = append(matches, yamlMatches...)
 
 	if len(matches) == 0 {
+		log.Debugf("No previous report files found in %s", validateDir)
 		return nil
 	}
 
+	log.Debugf("Found %d previous report file(s) to archive: %v", len(matches), matches)
 	// Use the first found report's timestamp for both report and failures
 	ts, err := getArchiveTimestamp(matches[0])
 	if err != nil {

--- a/internal/validate/api_resources.go
+++ b/internal/validate/api_resources.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -20,11 +21,13 @@ type apiSurfaceJSON struct {
 // and builds a DiscoveryIndex suitable for offline validation.
 // The file format is: {"apiResourceLists": [ <APIResourceList>, ... ]}
 // where each APIResourceList has a groupVersion field and a resources array.
-func ParseAPIResourcesJSON(path string) (DiscoveryIndex, error) {
+func ParseAPIResourcesJSON(path string, log logrus.FieldLogger) (DiscoveryIndex, error) {
+	log.Debugf("Loading API resources from %s", path)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading api-resources file %q: %w", path, err)
 	}
+	log.Debugf("Read %d bytes from API resources file", len(data))
 
 	var surface apiSurfaceJSON
 	if err := json.Unmarshal(data, &surface); err != nil {
@@ -34,11 +37,14 @@ func ParseAPIResourcesJSON(path string) (DiscoveryIndex, error) {
 	if len(surface.APIResourceLists) == 0 {
 		return nil, fmt.Errorf("api-resources file %q contains no API resource lists", path)
 	}
+	log.Debugf("Parsed %d API resource lists from file", len(surface.APIResourceLists))
 
 	index := DiscoveryIndex{}
+	totalKinds := 0
 	for _, list := range surface.APIResourceLists {
 		gv := list.GroupVersion
 		if gv == "" {
+			log.Debugf("Skipping API resource list with empty groupVersion")
 			continue
 		}
 		if _, ok := index[gv]; !ok {
@@ -49,6 +55,7 @@ func ParseAPIResourcesJSON(path string) (DiscoveryIndex, error) {
 				continue
 			}
 			index[gv][res.Kind] = discoveryEntry{Resource: res}
+			totalKinds++
 		}
 	}
 
@@ -56,5 +63,6 @@ func ParseAPIResourcesJSON(path string) (DiscoveryIndex, error) {
 		return nil, fmt.Errorf("api-resources file %q contains no usable resources", path)
 	}
 
+	log.Debugf("Built offline discovery index: %d group-versions, %d kinds", len(index), totalKinds)
 	return index, nil
 }

--- a/internal/validate/api_resources_test.go
+++ b/internal/validate/api_resources_test.go
@@ -3,6 +3,8 @@ package validate
 import (
 	"path/filepath"
 	"testing"
+
+	"github.com/sirupsen/logrus"
 )
 
 func TestParseAPIResourcesJSON_Valid(t *testing.T) {
@@ -30,7 +32,7 @@ func TestParseAPIResourcesJSON_Valid(t *testing.T) {
   ]
 }`)
 
-	index, err := ParseAPIResourcesJSON(path)
+	index, err := ParseAPIResourcesJSON(path, logrus.New())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -69,7 +71,7 @@ func TestParseAPIResourcesJSON_CoreResources(t *testing.T) {
   ]
 }`)
 
-	index, err := ParseAPIResourcesJSON(path)
+	index, err := ParseAPIResourcesJSON(path, logrus.New())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -95,7 +97,7 @@ func TestParseAPIResourcesJSON_NonCoreResources(t *testing.T) {
   ]
 }`)
 
-	index, err := ParseAPIResourcesJSON(path)
+	index, err := ParseAPIResourcesJSON(path, logrus.New())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -121,7 +123,7 @@ func TestParseAPIResourcesJSON_ResourcePlural(t *testing.T) {
   ]
 }`)
 
-	index, err := ParseAPIResourcesJSON(path)
+	index, err := ParseAPIResourcesJSON(path, logrus.New())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -140,7 +142,7 @@ func TestParseAPIResourcesJSON_EmptyResources(t *testing.T) {
 	path := filepath.Join(dir, "api-surface.json")
 	writeFile(t, path, `{"apiResourceLists": []}`)
 
-	_, err := ParseAPIResourcesJSON(path)
+	_, err := ParseAPIResourcesJSON(path, logrus.New())
 	if err == nil {
 		t.Fatal("expected error for empty api resource lists, got nil")
 	}
@@ -151,14 +153,14 @@ func TestParseAPIResourcesJSON_MalformedJSON(t *testing.T) {
 	path := filepath.Join(dir, "api-surface.json")
 	writeFile(t, path, `{not valid json`)
 
-	_, err := ParseAPIResourcesJSON(path)
+	_, err := ParseAPIResourcesJSON(path, logrus.New())
 	if err == nil {
 		t.Fatal("expected error for malformed JSON, got nil")
 	}
 }
 
 func TestParseAPIResourcesJSON_FileNotFound(t *testing.T) {
-	_, err := ParseAPIResourcesJSON("/nonexistent/file.json")
+	_, err := ParseAPIResourcesJSON("/nonexistent/file.json", logrus.New())
 	if err == nil {
 		t.Fatal("expected error for missing file, got nil")
 	}
@@ -188,7 +190,7 @@ func TestParseAPIResourcesJSON_DuplicateKindAcrossGroups(t *testing.T) {
   ]
 }`)
 
-	index, err := ParseAPIResourcesJSON(path)
+	index, err := ParseAPIResourcesJSON(path, logrus.New())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -218,7 +220,7 @@ func TestParseAPIResourcesJSON_VerifyNamespaced(t *testing.T) {
   ]
 }`)
 
-	index, err := ParseAPIResourcesJSON(path)
+	index, err := ParseAPIResourcesJSON(path, logrus.New())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -249,7 +251,7 @@ func TestParseAPIResourcesJSON_SubresourcesFiltered(t *testing.T) {
   ]
 }`)
 
-	index, err := ParseAPIResourcesJSON(path)
+	index, err := ParseAPIResourcesJSON(path, logrus.New())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/validate/matcher.go
+++ b/internal/validate/matcher.go
@@ -27,13 +27,14 @@ func MatchResults(entries []ManifestEntry, opts MatchOptions, log logrus.FieldLo
 	if err != nil {
 		return nil, err
 	}
-	return MatchResultsFromIndex(entries, index), nil
+	return MatchResultsFromIndex(entries, index, log), nil
 }
 
 // MatchResultsFromIndex compares each ManifestEntry against a pre-built
 // DiscoveryIndex and returns a validation report. Use this when the index
 // is built from an offline source (e.g. kubectl api-resources JSON output).
-func MatchResultsFromIndex(entries []ManifestEntry, index DiscoveryIndex) *ValidationReport {
+func MatchResultsFromIndex(entries []ManifestEntry, index DiscoveryIndex, log logrus.FieldLogger) *ValidationReport {
+	log.Debugf("Matching %d entries against discovery index (%d group-versions)", len(entries), len(index))
 	kindIndex := buildKindIndex(index)
 
 	results := make([]ValidationResult, 0, len(entries))
@@ -41,6 +42,9 @@ func MatchResultsFromIndex(entries []ManifestEntry, index DiscoveryIndex) *Valid
 		result := matchEntry(entry, index)
 		if result.Status == StatusIncompatible {
 			addSuggestion(&result, entry, kindIndex)
+			log.Debugf("  INCOMPATIBLE: %s/%s (namespace: %q) — %s", entry.APIVersion, entry.Kind, entry.Namespace, result.Reason)
+		} else {
+			log.Debugf("  OK: %s/%s (namespace: %q) → %s", entry.APIVersion, entry.Kind, entry.Namespace, result.ResourcePlural)
 		}
 		results = append(results, result)
 	}
@@ -82,7 +86,9 @@ func buildDiscoveryIndex(client discovery.DiscoveryInterface, log logrus.FieldLo
 		}
 	}
 
+	log.Debugf("Building discovery index from %d API resource lists", len(lists))
 	index := DiscoveryIndex{}
+	totalKinds := 0
 	for _, list := range lists {
 		gv := list.GroupVersion
 		if _, ok := index[gv]; !ok {
@@ -93,8 +99,10 @@ func buildDiscoveryIndex(client discovery.DiscoveryInterface, log logrus.FieldLo
 				continue
 			}
 			index[gv][res.Kind] = discoveryEntry{Resource: res}
+			totalKinds++
 		}
 	}
+	log.Debugf("Built live discovery index: %d group-versions, %d kinds", len(index), totalKinds)
 	return index, nil
 }
 

--- a/internal/validate/matcher_test.go
+++ b/internal/validate/matcher_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	clienttesting "k8s.io/client-go/testing"
@@ -222,7 +223,7 @@ func TestMatchResultsFromIndex_AllOK(t *testing.T) {
 		{APIVersion: "v1", Kind: "Service", Group: "", Version: "v1", Namespace: "prod"},
 	}
 
-	report := MatchResultsFromIndex(entries, index)
+	report := MatchResultsFromIndex(entries, index, logrus.New())
 	if report.Incompatible != 0 {
 		t.Fatalf("Incompatible = %d, want 0", report.Incompatible)
 	}
@@ -243,7 +244,7 @@ func TestMatchResultsFromIndex_Incompatible(t *testing.T) {
 		{APIVersion: "route.openshift.io/v1", Kind: "Route", Group: "route.openshift.io", Version: "v1", Namespace: "prod"},
 	}
 
-	report := MatchResultsFromIndex(entries, index)
+	report := MatchResultsFromIndex(entries, index, logrus.New())
 	if report.Compatible != 1 || report.Incompatible != 1 {
 		t.Fatalf("Compatible=%d Incompatible=%d, want 1/1", report.Compatible, report.Incompatible)
 	}
@@ -260,7 +261,7 @@ func TestMatchResultsFromIndex_Suggestion(t *testing.T) {
 		{APIVersion: "extensions/v1beta1", Kind: "Deployment", Group: "extensions", Version: "v1beta1", Namespace: "prod"},
 	}
 
-	report := MatchResultsFromIndex(entries, index)
+	report := MatchResultsFromIndex(entries, index, logrus.New())
 	if report.Incompatible != 1 {
 		t.Fatalf("Incompatible = %d, want 1", report.Incompatible)
 	}

--- a/internal/validate/scanner.go
+++ b/internal/validate/scanner.go
@@ -35,21 +35,25 @@ func ScanManifests(opts ScanOptions, log logrus.FieldLogger) ([]ManifestEntry, e
 	index := map[string]*ManifestEntry{}
 
 	for _, dir := range opts.Dirs {
+		log.Debugf("Scanning directory: %s", dir)
 		if err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
 			if err != nil {
 				return err
 			}
 			if d.IsDir() {
 				if d.Name() == "failures" {
+					log.Debugf("Skipping failures/ directory: %s", path)
 					return filepath.SkipDir
 				}
 				return nil
 			}
 			ext := strings.ToLower(filepath.Ext(path))
 			if ext != ".yaml" && ext != ".yml" && ext != ".json" {
+				log.Debugf("Skipping non-manifest file: %s", path)
 				return nil
 			}
 
+			log.Debugf("Reading manifest file: %s", path)
 			data, err := os.ReadFile(path)
 			if err != nil {
 				return fmt.Errorf("read %s: %w", path, err)
@@ -82,6 +86,7 @@ func ScanManifests(opts ScanOptions, log logrus.FieldLogger) ([]ManifestEntry, e
 					continue
 				}
 				if meta.APIVersion == "" || meta.Kind == "" {
+					log.Debugf("  Skipping document #%d in %s: missing apiVersion or kind", docIdx, path)
 					continue
 				}
 
@@ -94,6 +99,7 @@ func ScanManifests(opts ScanOptions, log logrus.FieldLogger) ([]ManifestEntry, e
 				key := fmt.Sprintf("%s/%s/%s/%s", gv.Group, gv.Version, meta.Kind, meta.Metadata.Namespace)
 				if entry, ok := index[key]; ok {
 					entry.SourceFiles = append(entry.SourceFiles, path)
+					log.Debugf("  Duplicate GVK+ns %s (additional source: %s)", key, path)
 				} else {
 					index[key] = &ManifestEntry{
 						APIVersion:  meta.APIVersion,
@@ -103,6 +109,7 @@ func ScanManifests(opts ScanOptions, log logrus.FieldLogger) ([]ManifestEntry, e
 						Namespace:   meta.Metadata.Namespace,
 						SourceFiles: []string{path},
 					}
+					log.Debugf("  Found %s/%s (namespace: %q) in %s", meta.APIVersion, meta.Kind, meta.Metadata.Namespace, path)
 				}
 			}
 			return nil


### PR DESCRIPTION
# PR: Fix bug 426: --debug flag has no effect on validate command

  Fixes [#426](https://github.com/migtools/crane/issues/426). The `--debug` flag was accepted but produced identical output because the validate pipeline had zero `log.Debugf` calls.

  ## The Fix

  Added comprehensive debug logging across the entire validate pipeline, and added logger parameters to internal functions that previously couldn't log.

  ### Without `--debug`
  INFO Scanned 1 distinct GVK+namespace tuples
  INFO Validating in live mode against context "tgt"
  INFO Wrote validation report to validate/report.json

  ### With `--debug`
  DEBUG Input directory: output/
  DEBUG Validate directory: validate/
  DEBUG Output format: json
  DEBUG Mode: live
  DEBUG Scanning directory: output/
  DEBUG Reading manifest file: output/svc.yaml
  DEBUG   Found v1/Service (namespace: "default") in output/svc.yaml
  DEBUG   Skipping document 1 in output/data.json: missing apiVersion or kind
  INFO  Scanned 1 distinct GVK+namespace tuples
  DEBUG Building discovery index from 27 API resource lists
  DEBUG Built live discovery index: 27 group-versions, 76 kinds
  DEBUG Matching 1 entries against discovery index (27 group-versions)
  DEBUG   OK: v1/Service (namespace: "default") → services
  INFO  Validating in live mode against context "tgt"
  DEBUG No previous report files found in validate/
  INFO  Wrote validation report to validate/report.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced debugging output for the validation process with detailed logs for resource discovery, manifest file scanning, and validation checking operations. Provides better visibility into the validation workflow when running in offline mode (with API resources) or live mode (with cluster contexts), improving troubleshooting capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->