### PR TITLE
fix #461: validate displays empty context in live mode

### DIFF
--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -51,6 +51,35 @@ func (o *ValidateOptions) Complete(c *cobra.Command, args []string) error {
 	return nil
 }
 
+// Returns the cluster context string based on the method used to target
+// the cluster, following the priority order documented in issue #430.
+func determineClusterContext(cf *genericclioptions.ConfigFlags) (string, error) {
+	// Priority (from highest to lowest):
+	// 1. Explicit --context flag
+	// 2. --server flag (direct API endpoint)
+	// 3. --cluster flag (cluster name from kubeconfig)
+	// 4. --user flag (auth info from kubeconfig)
+	// 5. Current context from kubeconfig (default fallback)
+	if cf.Context != nil && *cf.Context != "" {
+		return *cf.Context, nil
+	}
+	if cf.APIServer != nil && *cf.APIServer != "" {
+		return fmt.Sprintf("server=%s", *cf.APIServer), nil
+	}
+	if cf.ClusterName != nil && *cf.ClusterName != "" {
+		return fmt.Sprintf("cluster=%s", *cf.ClusterName), nil
+	}
+	if cf.AuthInfoName != nil && *cf.AuthInfoName != "" {
+		return fmt.Sprintf("user=%s", *cf.AuthInfoName), nil
+	}
+	// Default: use current context from kubeconfig
+	rawConfig, err := cf.ToRawKubeConfigLoader().RawConfig()
+	if err != nil {
+		return "", fmt.Errorf("loading kubeconfig: %w", err)
+	}
+	return rawConfig.CurrentContext, nil
+}
+
 // Validate checks that flags have valid values.
 func (o *ValidateOptions) Validate(cmd *cobra.Command) error {
 	info, err := os.Stat(o.inputDir)
@@ -143,17 +172,14 @@ func (o *ValidateOptions) Run() error {
 			return fmt.Errorf("matching against target cluster: %w", err)
 		}
 		report.Mode = "live"
-		// Get the actual context being used (either from flag or current-context)
-		rawConfig, err := o.configFlags.ToRawKubeConfigLoader().RawConfig()
-		if err == nil {
-			report.ClusterContext = rawConfig.CurrentContext
-		}
-		// Override with explicit --context flag if provided
-		if o.configFlags.Context != nil && *o.configFlags.Context != "" {
-			report.ClusterContext = *o.configFlags.Context
-			log.Infof("Validating in live mode against context %q", *o.configFlags.Context)
+		clusterContext, err := determineClusterContext(o.configFlags)
+		if err != nil {
+			log.Warnf("Could not determine cluster context from kubeconfig: %v", err)
+		} else if clusterContext != "" {
+			report.ClusterContext = clusterContext
+			log.Infof("Validating in live mode against context %q", clusterContext)
 		} else {
-			log.Infof("Validating in live mode against current kubeconfig context")
+			log.Warn("No current context set in kubeconfig; ClusterContext will be empty")
 		}
 	}
 

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -143,6 +143,12 @@ func (o *ValidateOptions) Run() error {
 			return fmt.Errorf("matching against target cluster: %w", err)
 		}
 		report.Mode = "live"
+		// Get the actual context being used (either from flag or current-context)
+		rawConfig, err := o.configFlags.ToRawKubeConfigLoader().RawConfig()
+		if err == nil {
+			report.ClusterContext = rawConfig.CurrentContext
+		}
+		// Override with explicit --context flag if provided
 		if o.configFlags.Context != nil && *o.configFlags.Context != "" {
 			report.ClusterContext = *o.configFlags.Context
 			log.Infof("Validating in live mode against context %q", *o.configFlags.Context)

--- a/cmd/validate/validate_test.go
+++ b/cmd/validate/validate_test.go
@@ -491,6 +491,9 @@ current-context: existing-context
 	}
 
 	cmd := &cobra.Command{}
+	// Add kubeconfig flag and mark it as changed so Complete() preserves the fixture
+	cmd.Flags().String("kubeconfig", "", "")
+	cmd.Flags().Set("kubeconfig", kc)
 	err := o.Complete(cmd, nil)
 
 	if err == nil {
@@ -515,5 +518,119 @@ func TestComplete_SkippedInOfflineMode(t *testing.T) {
 
 	if err != nil {
 		t.Fatalf("Complete() should skip in offline mode, got: %v", err)
+	}
+}
+
+// TestClusterContextPopulation_AllScenarios verifies that ClusterContext is populated
+// correctly for all cluster targeting methods from issue #430.
+// This test exercises the actual cluster-context selection logic and verifies
+// report.ClusterContext is set correctly based on the branch in validate.go:145-178.
+func TestClusterContextPopulation_AllScenarios(t *testing.T) {
+	// Create a temporary kubeconfig with a known current-context for fallback test
+	kcDir := t.TempDir()
+	kc := filepath.Join(kcDir, "config")
+	kubeconfig := `
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://localhost:6443
+  name: test-cluster
+users:
+- name: test-user
+  user:
+    token: test-token
+contexts:
+- name: test-context
+  context:
+    cluster: test-cluster
+    user: test-user
+current-context: test-context
+`
+	if err := os.WriteFile(kc, []byte(kubeconfig), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name                 string
+		setupConfigFlags     func() *genericclioptions.ConfigFlags
+		expectedContextMatch string // exact match for report.ClusterContext
+		description          string
+	}{
+		{
+			name: "Scenario 1: Explicit --context flag",
+			setupConfigFlags: func() *genericclioptions.ConfigFlags {
+				cf := genericclioptions.NewConfigFlags(true)
+				ctx := "my-explicit-context"
+				cf.Context = &ctx
+				cf.KubeConfig = &kc
+				return cf
+			},
+			expectedContextMatch: "my-explicit-context",
+			description:          "Should use explicit --context value",
+		},
+		{
+			name: "Scenario 2: --server flag",
+			setupConfigFlags: func() *genericclioptions.ConfigFlags {
+				cf := genericclioptions.NewConfigFlags(true)
+				server := "https://api.example.com:6443"
+				cf.APIServer = &server
+				cf.KubeConfig = &kc
+				return cf
+			},
+			expectedContextMatch: "server=https://api.example.com:6443",
+			description:          "Should record server URL when --server is used",
+		},
+		{
+			name: "Scenario 3: --cluster flag",
+			setupConfigFlags: func() *genericclioptions.ConfigFlags {
+				cf := genericclioptions.NewConfigFlags(true)
+				cluster := "production-cluster"
+				cf.ClusterName = &cluster
+				cf.KubeConfig = &kc
+				return cf
+			},
+			expectedContextMatch: "cluster=production-cluster",
+			description:          "Should record cluster name when --cluster is used",
+		},
+		{
+			name: "Scenario 4: --user flag",
+			setupConfigFlags: func() *genericclioptions.ConfigFlags {
+				cf := genericclioptions.NewConfigFlags(true)
+				user := "admin-user"
+				cf.AuthInfoName = &user
+				cf.KubeConfig = &kc
+				return cf
+			},
+			expectedContextMatch: "user=admin-user",
+			description:          "Should record user name when --user is used",
+		},
+		{
+			name: "Scenario 5: No flags (current-context fallback)",
+			setupConfigFlags: func() *genericclioptions.ConfigFlags {
+				cf := genericclioptions.NewConfigFlags(true)
+				cf.KubeConfig = &kc
+				return cf
+			},
+			expectedContextMatch: "test-context",
+			description:          "Should use current-context from kubeconfig when no flags set",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test the production cluster context selection logic by calling
+			// the shared helper used by Run().
+			cf := tt.setupConfigFlags()
+
+			actualContext, err := determineClusterContext(cf)
+			if err != nil {
+				t.Fatalf("determineClusterContext() failed: %v", err)
+			}
+
+			if actualContext != tt.expectedContextMatch {
+				t.Errorf("ClusterContext = %q, want %q", actualContext, tt.expectedContextMatch)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes #461 and https://github.com/migtools/crane/issues/430

* **Bug Fixes**
  *   Fix validation reports to capture cluster context for all connection methods (--context, --server, --cluster, --user), not just --context.
* **Tests**
  * Added coverage for multiple context-targeting scenarios to help prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->