### PR TITLE
Fix fail fast

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -45,7 +45,16 @@ func (o *Options) Complete(c *cobra.Command, args []string) error {
 }
 
 func (o *Options) Validate() error {
-	// No validation needed - stages are resolved in run()
+	info, err := os.Stat(o.TransformDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("transform-dir %q does not exist", o.TransformDir)
+		}
+		return fmt.Errorf("transform-dir %q is not accessible: %v", o.TransformDir, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("transform-dir %q is not a directory", o.TransformDir)
+	}
 	return nil
 }
 

--- a/cmd/apply/apply_test.go
+++ b/cmd/apply/apply_test.go
@@ -41,8 +41,17 @@ func TestValidate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			transformDir := filepath.Join(tempDir, "transform")
+			if err := os.MkdirAll(transformDir, 0755); err != nil {
+				t.Fatalf("failed to create transform dir: %v", err)
+			}
+
 			o := &Options{
 				RequestedStages: tt.requestedStages,
+				Flags: Flags{
+					TransformDir: transformDir,
+				},
 			}
 
 			err := o.Validate()

--- a/cmd/apply/apply_test.go
+++ b/cmd/apply/apply_test.go
@@ -63,10 +63,10 @@ func TestValidate(t *testing.T) {
 
 func TestStageSelectionRouting(t *testing.T) {
 	tests := []struct {
-		name             string
-		requestedStages  []string
-		expectCustom     bool     // true if user specified custom selector
-		selectorStages   []string // expected stage values in selector
+		name            string
+		requestedStages []string
+		expectCustom    bool     // true if user specified custom selector
+		selectorStages  []string // expected stage values in selector
 	}{
 		{
 			name:            "default - no stages (all stages)",
@@ -115,23 +115,23 @@ func TestStageSelectionRouting(t *testing.T) {
 
 func TestComplete(t *testing.T) {
 	tests := []struct {
-		name      string
-		args      []string
+		name       string
+		args       []string
 		wantStages []string
 	}{
 		{
-			name:      "no args",
-			args:      []string{},
+			name:       "no args",
+			args:       []string{},
 			wantStages: []string{},
 		},
 		{
-			name:      "single stage",
-			args:      []string{"10_KubernetesPlugin"},
+			name:       "single stage",
+			args:       []string{"10_KubernetesPlugin"},
 			wantStages: []string{"10_KubernetesPlugin"},
 		},
 		{
-			name:      "multiple stages",
-			args:      []string{"10_KubernetesPlugin", "20_OpenshiftPlugin"},
+			name:       "multiple stages",
+			args:       []string{"10_KubernetesPlugin", "20_OpenshiftPlugin"},
 			wantStages: []string{"10_KubernetesPlugin", "20_OpenshiftPlugin"},
 		},
 	}
@@ -188,10 +188,10 @@ func TestRun_UnresolvedStagesError(t *testing.T) {
 	globalFlags := &flags.GlobalFlags{}
 
 	tests := []struct {
-		name             string
-		requestedStages  []string
-		expectError      bool
-		errorContains    string
+		name            string
+		requestedStages []string
+		expectError     bool
+		errorContains   string
 	}{
 		{
 			name:            "valid stage - no error",
@@ -251,5 +251,92 @@ func TestRun_UnresolvedStagesError(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestValidate_TransformDir(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	validDir := filepath.Join(tmpDir, "transform")
+	if err := os.MkdirAll(validDir, 0o755); err != nil {
+		t.Fatalf("failed to create valid dir: %v", err)
+	}
+
+	filePath := filepath.Join(tmpDir, "not-a-dir")
+	if err := os.WriteFile(filePath, []byte("x"), 0o644); err != nil {
+		t.Fatalf("failed to create file fixture: %v", err)
+	}
+
+	tests := []struct {
+		name         string
+		transformDir string
+		wantErrPart  string
+	}{
+		{
+			name:         "missing transform-dir",
+			transformDir: filepath.Join(tmpDir, "missing"),
+			wantErrPart:  "does not exist",
+		},
+		{
+			name:         "transform-dir is file",
+			transformDir: filePath,
+			wantErrPart:  "is not a directory",
+		},
+		{
+			name:         "valid transform-dir",
+			transformDir: validDir,
+			wantErrPart:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := &Options{
+				Flags: Flags{
+					TransformDir: tt.transformDir,
+				},
+			}
+
+			err := o.Validate()
+			if tt.wantErrPart == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErrPart)
+			}
+			if !strings.Contains(err.Error(), tt.wantErrPart) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantErrPart, err)
+			}
+		})
+	}
+}
+
+func TestValidate_MissingTransformDir_DoesNotCreateOutputDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	missingTransformDir := filepath.Join(tmpDir, "missing-transform")
+	outputDir := filepath.Join(tmpDir, "output")
+
+	o := &Options{
+		Flags: Flags{
+			TransformDir: missingTransformDir,
+			OutputDir:    outputDir,
+		},
+	}
+
+	err := o.Validate()
+	if err == nil {
+		t.Fatalf("expected validate to fail for missing transform-dir")
+	}
+	if !strings.Contains(err.Error(), "does not exist") {
+		t.Fatalf("expected missing transform-dir error, got %v", err)
+	}
+
+	// Since Validate fails, run should not be called; ensure no output side effects happened.
+	if _, statErr := os.Stat(outputDir); !os.IsNotExist(statErr) {
+		t.Fatalf("expected output dir to not exist after validation failure, got stat err: %v", statErr)
 	}
 }

--- a/cmd/transform/transform.go
+++ b/cmd/transform/transform.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	cranelib "github.com/konveyor/crane-lib/transform"
 	"github.com/konveyor/crane/cmd/transform/listplugins"
 	"github.com/konveyor/crane/cmd/transform/optionals"
 	"github.com/konveyor/crane/internal/file"
@@ -16,7 +17,6 @@ import (
 	"github.com/konveyor/crane/internal/kustomize"
 	"github.com/konveyor/crane/internal/plugin"
 	internalTransform "github.com/konveyor/crane/internal/transform"
-	cranelib "github.com/konveyor/crane-lib/transform"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -60,7 +60,21 @@ func (o *Options) Complete(c *cobra.Command, args []string) error {
 }
 
 func (o *Options) Validate() error {
-	// No validation needed - stages are resolved in run()
+	exportDir, err := filepath.Abs(o.ExportDir)
+	if err != nil {
+		return fmt.Errorf("resolving export-dir %q: %w", o.ExportDir, err)
+	}
+	o.ExportDir = exportDir
+	info, err := os.Stat(o.ExportDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("export-dir %q does not exist", o.ExportDir)
+		}
+		return fmt.Errorf("export-dir %q is not accessible: %v", o.ExportDir, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("export-dir %q is not a directory", o.ExportDir)
+	}
 	return nil
 }
 
@@ -379,7 +393,6 @@ func (o *Options) reconcileInstructionStages(transformDir string, desiredStages 
 	return nil
 }
 
-
 // ensurePreviousStagesRun ensures all existing stages have been run
 // and have output directories. This prepares the environment for creating a new stage.
 func (o *Options) ensurePreviousStagesRun(orchestrator *internalTransform.Orchestrator, transformDir string, log *logrus.Logger) error {
@@ -645,7 +658,7 @@ func (o *Options) resolveAndValidateStages(
 	nextPriority := maxPriority + 10
 
 	var resolved []string
-	seen := make(map[string]bool) // Prevent duplicates
+	seen := make(map[string]bool)    // Prevent duplicates
 	var allPlugins []cranelib.Plugin // Lazy-loaded on first plugin creation
 
 	for _, requested := range requestedStages {

--- a/cmd/transform/transform_test.go
+++ b/cmd/transform/transform_test.go
@@ -487,7 +487,7 @@ func TestReconcileInstructionStages_Force(t *testing.T) {
 // Test that positional args and --instructions-file are mutually exclusive
 func TestRun_InstructionsFileAndPositionalArgsConflict(t *testing.T) {
 	o := &Options{
-		globalFlags: &flags.GlobalFlags{},
+		globalFlags:     &flags.GlobalFlags{},
 		RequestedStages: []string{"10_KubernetesPlugin"},
 		Flags: Flags{
 			InstructionsFile: "sample-transform-instructor-file.yaml",
@@ -1016,5 +1016,100 @@ func TestResolveAndValidateStages_MultipleBaseNamesIncrementPriority(t *testing.
 		if !env.Orchestrator.NewlyCreatedStages[expectedName] {
 			t.Errorf("stage %q not marked as newly created", expectedName)
 		}
+	}
+}
+
+func TestValidate_ExportDir(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	validExportDir := filepath.Join(tmpDir, "export")
+	if err := os.MkdirAll(validExportDir, 0o755); err != nil {
+		t.Fatalf("failed to create valid export dir: %v", err)
+	}
+
+	notDirPath := filepath.Join(tmpDir, "not-a-dir")
+	if err := os.WriteFile(notDirPath, []byte("x"), 0o644); err != nil {
+		t.Fatalf("failed to create file path test fixture: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		exportDir string
+		wantErr   string
+	}{
+		{
+			name:      "missing export dir",
+			exportDir: filepath.Join(tmpDir, "missing"),
+			wantErr:   "does not exist",
+		},
+		{
+			name:      "export dir is file",
+			exportDir: notDirPath,
+			wantErr:   "is not a directory",
+		},
+		{
+			name:      "valid export dir",
+			exportDir: validExportDir,
+			wantErr:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := &Options{
+				Flags: Flags{
+					ExportDir:    tt.exportDir,
+					PluginDir:    filepath.Join(tmpDir, "plugins"),
+					TransformDir: filepath.Join(tmpDir, "transform"),
+				},
+			}
+
+			err := o.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+			}
+			if !strings.Contains(err.Error(), "export-dir") {
+				t.Fatalf("expected error to mention export-dir, got %v", err)
+			}
+		})
+	}
+}
+
+func TestValidate_MissingExportDir_FailsBeforeRun(t *testing.T) {
+	tmpDir := t.TempDir()
+	transformDir := filepath.Join(tmpDir, "transform")
+
+	o := &Options{
+		Flags: Flags{
+			ExportDir:    filepath.Join(tmpDir, "missing-export"),
+			TransformDir: transformDir,
+			PluginDir:    filepath.Join(tmpDir, "plugins"),
+		},
+	}
+
+	err := o.Validate()
+	if err == nil {
+		t.Fatalf("expected validate to fail for missing export dir")
+	}
+	if !strings.Contains(err.Error(), "does not exist") {
+		t.Fatalf("expected missing export-dir error, got %v", err)
+	}
+
+	// Validate should not create transform artifacts.
+	if _, statErr := os.Stat(transformDir); !os.IsNotExist(statErr) {
+		t.Fatalf("expected transform dir to not exist after validation failure, got stat err: %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(transformDir, ".work")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected .work dir to not exist after validation failure, got stat err: %v", statErr)
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validate now rejects missing or non-directory transform-dir and export-dir with clear errors
  * Configuration issues are detected during validation (before execution); validation no longer creates output/transform directories on failure

* **Tests**
  * Added tests covering directory path validation and ensuring failed validation does not create directories
<!-- end of auto-generated comment: release notes by coderabbit.ai -->