### PR TITLE
Fix bug 487: plugin-manager add should download correct binary accord…

### DIFF
--- a/cmd/plugin-manager/add/add.go
+++ b/cmd/plugin-manager/add/add.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"syscall"
 
 	"github.com/konveyor/crane/internal/flags"
@@ -155,7 +156,11 @@ func (o *Options) run(args []string) error {
 				for _, value := range pluginsMap[args[0]] {
 					// check if the version is mentioned and matches the version in pluginsMap file
 					if value.Name != "" && (o.Version == "" || string(value.Version) == o.Version) {
-						return downloadBinary(o.PluginDir, value.Name, value.Binaries[0].URI, log)
+						uri, err := binaryURIForPlatform(value)
+						if err != nil {
+							return err
+						}
+						return downloadBinary(o.PluginDir, value.Name, uri, log)
 					} else {
 						log.Errorf("The version %s of plugin %s is not available", installVersion, value.Name)
 						fmt.Printf("Run \"crane plugin-manager list --name %s --params\" to see available versions along with additional information \n", args[0])
@@ -173,7 +178,11 @@ func (o *Options) run(args []string) error {
 				}
 				for _, value := range pluginsMap[args[0]] {
 					if string(value.Version) == installVersion {
-						return downloadBinary(o.PluginDir, value.Name, value.Binaries[0].URI, log)
+						uri, err := binaryURIForPlatform(value)
+						if err != nil {
+							return err
+						}
+						return downloadBinary(o.PluginDir, value.Name, uri, log)
 					}
 				}
 				log.Errorf("The %s version of the plugin %s is not found", installVersion, args[0])
@@ -237,4 +246,15 @@ func downloadBinary(filepath string, filename string, url string, log *logrus.Lo
 	}
 	log.Infof("pluginBinary %s added to the path - %s", filename, filepath)
 	return err
+}
+
+// binaryURIForPlatform returns the download URI for the current OS/arch.
+// Returns an error if no matching binary is available.
+func binaryURIForPlatform(version plugin.PluginVersion) (string, error) {
+	for _, binary := range version.Binaries {
+		if binary.OS == runtime.GOOS && binary.Arch == runtime.GOARCH {
+			return binary.URI, nil
+		}
+	}
+	return "", fmt.Errorf("plugin %s %s has no binary for %s/%s", version.Name, version.Version, runtime.GOOS, runtime.GOARCH)
 }

--- a/internal/plugin/plugin_manager_helper.go
+++ b/internal/plugin/plugin_manager_helper.go
@@ -102,15 +102,12 @@ func YamlToManifest(URL string) ([]PluginVersion, error) {
 
 // takes manifest as input and filters manifest for current os/arch
 func FilterPluginForOsArch(plugin *Plugin) bool {
-	// filter manifests for current os/arch
 	isPluginAvailable := false
-	for _, version := range plugin.Versions {
-		for _, binary := range version.Binaries {
+	for i := range plugin.Versions {
+		for _, binary := range plugin.Versions[i].Binaries {
 			if binary.OS == runtime.GOOS && binary.Arch == runtime.GOARCH {
 				isPluginAvailable = true
-				version.Binaries = []Binary{
-					binary,
-				}
+				plugin.Versions[i].Binaries = []Binary{binary}
 				break
 			}
 		}

--- a/internal/plugin/plugin_manager_helper_test.go
+++ b/internal/plugin/plugin_manager_helper_test.go
@@ -109,6 +109,61 @@ func TestGetYamlFromUrlWithFile(t *testing.T) {
 	assert.DeepEqual(t, index, resp)
 }
 
+func TestFilterPluginForOsArch_PersistsFilter(t *testing.T) {
+	p := Plugin{
+		Versions: []PluginVersion{
+			{
+				Name:    "TestPlugin",
+				Version: "0.0.1",
+				Binaries: []Binary{
+					{OS: "linux", Arch: "amd64", URI: "https://example.com/linux-amd64"},
+					{OS: "darwin", Arch: "amd64", URI: "https://example.com/darwin-amd64"},
+					{OS: "darwin", Arch: "arm64", URI: "https://example.com/darwin-arm64"},
+				},
+			},
+		},
+	}
+
+	available := FilterPluginForOsArch(&p)
+
+	if !available {
+		t.Fatal("expected plugin to be available for current platform")
+	}
+
+	// After filtering, each version should have exactly 1 binary matching current OS/arch
+	for _, version := range p.Versions {
+		if len(version.Binaries) != 1 {
+			t.Fatalf("expected 1 binary after filter, got %d", len(version.Binaries))
+		}
+		if version.Binaries[0].OS != runtime.GOOS {
+			t.Errorf("binary OS = %q, want %q", version.Binaries[0].OS, runtime.GOOS)
+		}
+		if version.Binaries[0].Arch != runtime.GOARCH {
+			t.Errorf("binary Arch = %q, want %q", version.Binaries[0].Arch, runtime.GOARCH)
+		}
+	}
+}
+
+func TestFilterPluginForOsArch_NoPlatformMatch(t *testing.T) {
+	p := Plugin{
+		Versions: []PluginVersion{
+			{
+				Name:    "TestPlugin",
+				Version: "0.0.1",
+				Binaries: []Binary{
+					{OS: "plan9", Arch: "mips", URI: "https://example.com/plan9-mips"},
+				},
+			},
+		},
+	}
+
+	available := FilterPluginForOsArch(&p)
+
+	if available {
+		t.Fatal("expected plugin to be unavailable for non-matching platform")
+	}
+}
+
 func TestYamlToManifestWithFile(t *testing.T) {
 	if runtime.GOOS != "linux" || runtime.GOARCH != "amd64" {
 		t.Skip("original fixture is linux/amd64-only; assertions run on linux/amd64")


### PR DESCRIPTION
 # PR: Fix bug 487: plugin-manager add downloads wrong platform binary

  Fixes [#487](https://github.com/migtools/crane/issues/487). `crane plugin-manager add` always downloaded `linux/amd64` binary regardless of the user's platform.

  ## Root Cause

  `FilterPluginForOsArch` used a value-based range loop (`for _, version := range`), so the filtered binary was never persisted back to the struct. Additionally, `add.go` hardcoded `Binaries[0]` instead of selecting by platform.

  ## The Fix

  - Fixed `FilterPluginForOsArch` to use index-based iteration so the filter persists
  - Replaced `Binaries[0]` with `binaryURIForPlatform()` that matches `runtime.GOOS`/`runtime.GOARCH` and errors clearly when no binary exists for the current platform

  ## Manual Testing

  | Test | Before | After |
  |------|--------|-------|
  | `crane plugin-manager add OpenShiftPlugin` on darwin/arm64 | `ELF 64-bit x86-64` (wrong) | `Mach-O 64-bit arm64` (correct) |
  | `crane plugin-manager add ImageStreamPlugin` on darwin/arm64 | `ELF 64-bit x86-64` (wrong) | `Mach-O 64-bit arm64` (correct) |
  | Downloaded plugin executes | `exec format error` | Runs correctly |

  ## Files Changed

  | File | Change |
  |------|--------|
  | `internal/plugin/plugin_manager_helper.go` | Fixed range loop to persist filter |
  | `cmd/plugin-manager/add/add.go` | Platform-aware binary selection with clear error |
  | `internal/plugin/plugin_manager_helper_test.go` | 2 tests for filter persistence and no-match case |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin installation now correctly selects the appropriate version for your operating system and CPU architecture rather than defaulting to a generic option.
  * Enhanced error handling and messaging when a plugin version is unavailable for your platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->