### PR TITLE
Fix export resources with long names

### DIFF
--- a/cmd/export/discover.go
+++ b/cmd/export/discover.go
@@ -172,12 +172,9 @@ func writeErrors(errors []*groupResourceError, failuresDir string, log logrus.Fi
 }
 
 // getFilePath returns a stable filename from kind, group, version, namespace, and name.
-// If the resulting filename would exceed 255 characters (filesystem limit), the resource
-// name is truncated and a hash suffix is added to prevent collisions.
+// If the filename exceeds 255 characters, it is truncated and a hash suffix is added.
 func getFilePath(obj unstructured.Unstructured) string {
 	const maxFilenameLength = 255
-	const hashLength = 8
-	const yamlSuffix = ".yaml"
 
 	namespace := obj.GetNamespace()
 	if namespace == "" {
@@ -189,33 +186,26 @@ func getFilePath(obj unstructured.Unstructured) string {
 	version := obj.GetObjectKind().GroupVersionKind().Version
 	name := obj.GetName()
 
-	// Build prefix without the resource name
-	prefix := strings.Join([]string{kind, group, version, namespace}, "_") + "_"
-	fullPath := prefix + name + yamlSuffix
+	basename := strings.Join([]string{kind, group, version, namespace, name}, "_")
+	filename := basename + ".yaml"
 
-	// If filename fits within limit, return as-is
-	if len(fullPath) <= maxFilenameLength {
-		return fullPath
+	if len(filename) <= maxFilenameLength {
+		return filename
 	}
 
-	// Calculate available space for the resource name
-	// Format: prefix + truncatedName + "_" + hash(8 chars) + ".yaml"
-	hashSuffixLen := 1 + hashLength // "_" + 8 chars
-	availableForName := maxFilenameLength - len(prefix) - hashSuffixLen - len(yamlSuffix)
-
-	// Truncate name and add hash to prevent collisions
-	truncatedName := name
-	if availableForName > 0 {
-		truncatedName = name[:availableForName]
-	} else {
-		truncatedName = ""
+	maxBaseLen := maxFilenameLength - 14 // "_" + 8 hash chars + ".yaml"
+	truncated := basename
+	if len(basename) > maxBaseLen {
+		truncated = basename[:maxBaseLen]
 	}
 
-	// Generate hash from the full original name
-	hash := sha256.Sum256([]byte(name))
-	hashStr := fmt.Sprintf("%x", hash[:4]) // 4 bytes = 8 hex chars
+	hash := sha256.Sum256([]byte(filename))
+	hashStr := fmt.Sprintf("%x", hash[:4])
 
-	return prefix + truncatedName + "_" + hashStr + yamlSuffix
+	if len(truncated) > 0 {
+		return truncated + "_" + hashStr + ".yaml"
+	}
+	return hashStr + ".yaml"
 }
 
 // discoverPreferredResources returns server-preferred API resource lists, filtered to

--- a/cmd/export/discover.go
+++ b/cmd/export/discover.go
@@ -193,14 +193,14 @@ func getFilePath(obj unstructured.Unstructured) string {
 		return filename
 	}
 
-	maxBaseLen := maxFilenameLength - 14 // "_" + 8 hash chars + ".yaml"
+	maxBaseLen := maxFilenameLength - 22 // "_" + 16 hash chars + ".yaml"
 	truncated := basename
 	if len(basename) > maxBaseLen {
 		truncated = basename[:maxBaseLen]
 	}
 
 	hash := sha256.Sum256([]byte(filename))
-	hashStr := fmt.Sprintf("%x", hash[:4])
+	hashStr := fmt.Sprintf("%x", hash[:8])
 
 	if len(truncated) > 0 {
 		return truncated + "_" + hashStr + ".yaml"

--- a/cmd/export/discover.go
+++ b/cmd/export/discover.go
@@ -2,6 +2,7 @@ package export
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -171,12 +172,50 @@ func writeErrors(errors []*groupResourceError, failuresDir string, log logrus.Fi
 }
 
 // getFilePath returns a stable filename from kind, group, version, namespace, and name.
+// If the resulting filename would exceed 255 characters (filesystem limit), the resource
+// name is truncated and a hash suffix is added to prevent collisions.
 func getFilePath(obj unstructured.Unstructured) string {
+	const maxFilenameLength = 255
+	const hashLength = 8
+	const yamlSuffix = ".yaml"
+
 	namespace := obj.GetNamespace()
 	if namespace == "" {
 		namespace = "clusterscoped"
 	}
-	return strings.Join([]string{obj.GetKind(), obj.GetObjectKind().GroupVersionKind().GroupKind().Group, obj.GetObjectKind().GroupVersionKind().Version, namespace, obj.GetName()}, "_") + ".yaml"
+
+	kind := obj.GetKind()
+	group := obj.GetObjectKind().GroupVersionKind().GroupKind().Group
+	version := obj.GetObjectKind().GroupVersionKind().Version
+	name := obj.GetName()
+
+	// Build prefix without the resource name
+	prefix := strings.Join([]string{kind, group, version, namespace}, "_") + "_"
+	fullPath := prefix + name + yamlSuffix
+
+	// If filename fits within limit, return as-is
+	if len(fullPath) <= maxFilenameLength {
+		return fullPath
+	}
+
+	// Calculate available space for the resource name
+	// Format: prefix + truncatedName + "_" + hash(8 chars) + ".yaml"
+	hashSuffixLen := 1 + hashLength // "_" + 8 chars
+	availableForName := maxFilenameLength - len(prefix) - hashSuffixLen - len(yamlSuffix)
+
+	// Truncate name and add hash to prevent collisions
+	truncatedName := name
+	if availableForName > 0 {
+		truncatedName = name[:availableForName]
+	} else {
+		truncatedName = ""
+	}
+
+	// Generate hash from the full original name
+	hash := sha256.Sum256([]byte(name))
+	hashStr := fmt.Sprintf("%x", hash[:4]) // 4 bytes = 8 hex chars
+
+	return prefix + truncatedName + "_" + hashStr + yamlSuffix
 }
 
 // discoverPreferredResources returns server-preferred API resource lists, filtered to

--- a/cmd/export/discover_test.go
+++ b/cmd/export/discover_test.go
@@ -133,6 +133,36 @@ func TestGetFilePath_LongNameCollisionPrevention(t *testing.T) {
 	}
 }
 
+func TestGetFilePath_LongPrefixAndName(t *testing.T) {
+	// Test with very long namespace + group + long name
+	longNamespace := strings.Repeat("n", 63) // Kubernetes max namespace length
+	longGroup := strings.Repeat("g", 100)
+	longName := strings.Repeat("x", 253)
+
+	obj := unstructured.Unstructured{}
+	obj.SetKind("CustomResource")
+	obj.SetName(longName)
+	obj.SetNamespace(longNamespace)
+	obj.SetGroupVersionKind(schema.GroupVersionKind{Group: longGroup, Version: "v1beta1", Kind: "CustomResource"})
+
+	path := getFilePath(obj)
+
+	// Should not exceed filesystem limit
+	if len(path) > 255 {
+		t.Errorf("path length %d exceeds 255: %q", len(path), path)
+	}
+
+	// Should end with .yaml
+	if !strings.HasSuffix(path, ".yaml") {
+		t.Errorf("path does not end with .yaml: %q", path)
+	}
+
+	// Should contain hash (8 hex chars before .yaml)
+	if len(path) < 14 { // at least "_" + 8 chars + ".yaml"
+		t.Errorf("path too short to contain hash: %q", path)
+	}
+}
+
 // ---------- isAdmittedResource ----------
 
 func TestIsAdmittedResource(t *testing.T) {

--- a/cmd/export/discover_test.go
+++ b/cmd/export/discover_test.go
@@ -157,8 +157,8 @@ func TestGetFilePath_LongPrefixAndName(t *testing.T) {
 		t.Errorf("path does not end with .yaml: %q", path)
 	}
 
-	// Should contain hash (8 hex chars before .yaml)
-	if len(path) < 14 { // at least "_" + 8 chars + ".yaml"
+	// Should contain hash (16 hex chars before .yaml)
+	if len(path) < 22 { // at least "_" + 16 chars + ".yaml"
 		t.Errorf("path too short to contain hash: %q", path)
 	}
 }

--- a/cmd/export/discover_test.go
+++ b/cmd/export/discover_test.go
@@ -32,6 +32,7 @@ func TestGetFilePath(t *testing.T) {
 		name      string
 		obj       unstructured.Unstructured
 		wantParts []string // substrings that must appear
+		maxLen    int      // if > 0, verify length is at most this
 	}{
 		{
 			name: "namespaced object",
@@ -56,6 +57,32 @@ func TestGetFilePath(t *testing.T) {
 			}(),
 			wantParts: []string{"ClusterRole", "rbac.authorization.k8s.io", "v1", "clusterscoped", "admin", ".yaml"},
 		},
+		{
+			name: "resource with max-length name (253 chars) gets truncated",
+			obj: func() unstructured.Unstructured {
+				u := unstructured.Unstructured{}
+				u.SetKind("ConfigMap")
+				u.SetName(strings.Repeat("a", 253)) // Kubernetes max name length
+				u.SetNamespace("my-namespace")
+				u.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"})
+				return u
+			}(),
+			wantParts: []string{"ConfigMap", "_v1_", "my-namespace", ".yaml"},
+			maxLen:    255,
+		},
+		{
+			name: "extremely long name gets truncated with hash",
+			obj: func() unstructured.Unstructured {
+				u := unstructured.Unstructured{}
+				u.SetKind("Secret")
+				u.SetName(strings.Repeat("b", 300))
+				u.SetNamespace("production")
+				u.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"})
+				return u
+			}(),
+			wantParts: []string{"Secret", "_v1_", "production", ".yaml"},
+			maxLen:    255,
+		},
 	}
 
 	for _, tt := range tests {
@@ -66,7 +93,43 @@ func TestGetFilePath(t *testing.T) {
 					t.Errorf("getFilePath() = %q, missing %q", got, p)
 				}
 			}
+			if tt.maxLen > 0 && len(got) > tt.maxLen {
+				t.Errorf("getFilePath() = %q (len=%d), exceeds max length %d", got, len(got), tt.maxLen)
+			}
 		})
+	}
+}
+
+func TestGetFilePath_LongNameCollisionPrevention(t *testing.T) {
+	// Two resources with long names that differ only at the end should produce different filenames
+	name1 := strings.Repeat("a", 253)
+	name2 := strings.Repeat("a", 252) + "b"
+
+	obj1 := unstructured.Unstructured{}
+	obj1.SetKind("ConfigMap")
+	obj1.SetName(name1)
+	obj1.SetNamespace("default")
+	obj1.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"})
+
+	obj2 := unstructured.Unstructured{}
+	obj2.SetKind("ConfigMap")
+	obj2.SetName(name2)
+	obj2.SetNamespace("default")
+	obj2.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"})
+
+	path1 := getFilePath(obj1)
+	path2 := getFilePath(obj2)
+
+	if path1 == path2 {
+		t.Errorf("getFilePath() produced identical paths for different resources:\npath1=%q\npath2=%q", path1, path2)
+	}
+
+	// Both should be within filesystem limits
+	if len(path1) > 255 {
+		t.Errorf("path1 length %d exceeds 255", len(path1))
+	}
+	if len(path2) > 255 {
+		t.Errorf("path2 length %d exceeds 255", len(path2))
 	}
 }
 


### PR DESCRIPTION
Adding truncation and hash to resources which exported file name lenght would exceed typically allowed len 255 chars.

Fixes https://github.com/migtools/crane/issues/492

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Export filenames are now filesystem-safe, capped to path length limits, and consistently use the .yaml extension.
  * When truncation is required, a short hash suffix is appended to prevent filename collisions; if truncation would leave no basename, the hash-only name is used.

* **Tests**
  * Added tests validating path length enforcement and collision-avoidance behavior for long resource names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->