### PR TITLE
bug-fix: separate command-specific and inherited kube/client flags in help output

### DIFF
--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -261,26 +261,6 @@ func NewExportCommand(streams genericclioptions.IOStreams, f *flags.GlobalFlags)
 	cmd.Flags().Float32VarP(&o.QPS, "qps", "q", 100, "Query Per Second Rate.")
 	cmd.Flags().IntVarP(&o.Burst, "burst", "b", 1000, "API Burst Rate.")
 	o.configFlags.AddFlags(cmd.Flags())
-	flags.SetGroupedHelp(cmd, []string{
-		"as",
-		"as-group",
-		"as-uid",
-		"as-user-extra",
-		"cache-dir",
-		"certificate-authority",
-		"client-certificate",
-		"client-key",
-		"cluster",
-		"context",
-		"disable-compression",
-		"insecure-skip-tls-verify",
-		"kubeconfig",
-		"namespace",
-		"request-timeout",
-		"server",
-		"tls-server-name",
-		"token",
-		"user",
-	})
+	flags.SetGroupedHelp(cmd, flags.KubernetesClientInheritedFlagNames())
 	return cmd
 }

--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -261,6 +261,26 @@ func NewExportCommand(streams genericclioptions.IOStreams, f *flags.GlobalFlags)
 	cmd.Flags().Float32VarP(&o.QPS, "qps", "q", 100, "Query Per Second Rate.")
 	cmd.Flags().IntVarP(&o.Burst, "burst", "b", 1000, "API Burst Rate.")
 	o.configFlags.AddFlags(cmd.Flags())
-
+	flags.SetGroupedHelp(cmd, []string{
+		"as",
+		"as-group",
+		"as-uid",
+		"as-user-extra",
+		"cache-dir",
+		"certificate-authority",
+		"client-certificate",
+		"client-key",
+		"cluster",
+		"context",
+		"disable-compression",
+		"insecure-skip-tls-verify",
+		"kubeconfig",
+		"namespace",
+		"request-timeout",
+		"server",
+		"tls-server-name",
+		"token",
+		"user",
+	})
 	return cmd
 }

--- a/cmd/export/export_test.go
+++ b/cmd/export/export_test.go
@@ -2,6 +2,7 @@ package export
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -259,4 +260,52 @@ func TestValidateExportNamespace(t *testing.T) {
 			t.Fatal("expected error")
 		}
 	})
+}
+
+func TestExport_HelpGroupsFlags(t *testing.T) {
+	streams, _, outBuf, _ := genericclioptions.NewTestIOStreams()
+	cmd := NewExportCommand(streams, nil)
+
+	// Ensure help output goes to our buffer for assertions.
+	cmd.SetOut(outBuf)
+	cmd.SetErr(outBuf)
+
+	cmd.SetArgs([]string{"--help"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error running --help: %v", err)
+	}
+
+	help := outBuf.String()
+
+	commandSpecificHeader := "Command-specific Flags:"
+	kubeHeader := "Inherited Kubernetes Client Flags:"
+
+	commandSpecificIdx := strings.Index(help, commandSpecificHeader)
+	if commandSpecificIdx == -1 {
+		t.Fatalf("missing %q section in help output:\n%s", commandSpecificHeader, help)
+	}
+
+	kubeIdx := strings.Index(help, kubeHeader)
+	if kubeIdx == -1 {
+		t.Fatalf("missing %q section in help output:\n%s", kubeHeader, help)
+	}
+
+	if commandSpecificIdx > kubeIdx {
+		t.Fatalf("expected command-specific section before inherited kube/client section")
+	}
+
+	commandSpecificSection := help[commandSpecificIdx:kubeIdx]
+	kubeSection := help[kubeIdx:]
+
+	if !strings.Contains(commandSpecificSection, "--export-dir") {
+		t.Fatalf("expected --export-dir in command-specific section, got:\n%s", commandSpecificSection)
+	}
+
+	if strings.Contains(commandSpecificSection, "--context") {
+		t.Fatalf("did not expect --context in command-specific section, got:\n%s", commandSpecificSection)
+	}
+
+	if !strings.Contains(kubeSection, "--context") {
+		t.Fatalf("expected --context in inherited kube/client section, got:\n%s", kubeSection)
+	}
 }

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -323,26 +323,6 @@ failed (or another error occurred).`,
 	cmd.Flags().StringVarP(&o.outputFormat, "output", "o", "json", "Report file format: json or yaml")
 	cmd.Flags().StringVar(&o.apiResourcesFile, "api-resources", "", "Path to API surface JSON file from capture-api-surface.sh for offline validation (mutually exclusive with --context/--kubeconfig/--server/--token/--cluster/--user)")
 	o.configFlags.AddFlags(cmd.Flags())
-	flags.SetGroupedHelp(cmd, []string{
-		"as",
-		"as-group",
-		"as-uid",
-		"as-user-extra",
-		"cache-dir",
-		"certificate-authority",
-		"client-certificate",
-		"client-key",
-		"cluster",
-		"context",
-		"disable-compression",
-		"insecure-skip-tls-verify",
-		"kubeconfig",
-		"namespace",
-		"request-timeout",
-		"server",
-		"tls-server-name",
-		"token",
-		"user",
-	})
+	flags.SetGroupedHelp(cmd, flags.KubernetesClientInheritedFlagNames())
 	return cmd
 }

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -274,7 +274,7 @@ func archivePreviousResults(validateDir, failuresDir string, log logrus.FieldLog
 func NewValidateCommand(streams genericclioptions.IOStreams, f *flags.GlobalFlags) *cobra.Command {
 	o := &ValidateOptions{
 		configFlags:      genericclioptions.NewConfigFlags(true),
-		IOStreams:         streams,
+		IOStreams:        streams,
 		cobraGlobalFlags: f,
 	}
 	cmd := &cobra.Command{
@@ -323,6 +323,26 @@ failed (or another error occurred).`,
 	cmd.Flags().StringVarP(&o.outputFormat, "output", "o", "json", "Report file format: json or yaml")
 	cmd.Flags().StringVar(&o.apiResourcesFile, "api-resources", "", "Path to API surface JSON file from capture-api-surface.sh for offline validation (mutually exclusive with --context/--kubeconfig/--server/--token/--cluster/--user)")
 	o.configFlags.AddFlags(cmd.Flags())
-
+	flags.SetGroupedHelp(cmd, []string{
+		"as",
+		"as-group",
+		"as-uid",
+		"as-user-extra",
+		"cache-dir",
+		"certificate-authority",
+		"client-certificate",
+		"client-key",
+		"cluster",
+		"context",
+		"disable-compression",
+		"insecure-skip-tls-verify",
+		"kubeconfig",
+		"namespace",
+		"request-timeout",
+		"server",
+		"tls-server-name",
+		"token",
+		"user",
+	})
 	return cmd
 }

--- a/cmd/validate/validate_test.go
+++ b/cmd/validate/validate_test.go
@@ -68,7 +68,7 @@ func TestValidate_Flags(t *testing.T) {
 					t.Fatal(err)
 				}
 				return &ValidateOptions{
-					inputDir:    f,
+					inputDir:     f,
 					outputFormat: "yaml",
 				}
 			},
@@ -79,7 +79,7 @@ func TestValidate_Flags(t *testing.T) {
 			name: "invalid output format",
 			setup: func(t *testing.T) *ValidateOptions {
 				return &ValidateOptions{
-					inputDir:    t.TempDir(),
+					inputDir:     t.TempDir(),
 					outputFormat: "xml",
 				}
 			},
@@ -90,7 +90,7 @@ func TestValidate_Flags(t *testing.T) {
 			name: "valid yaml format",
 			setup: func(t *testing.T) *ValidateOptions {
 				return &ValidateOptions{
-					inputDir:    t.TempDir(),
+					inputDir:     t.TempDir(),
 					outputFormat: "yaml",
 				}
 			},
@@ -100,7 +100,7 @@ func TestValidate_Flags(t *testing.T) {
 			name: "valid json format",
 			setup: func(t *testing.T) *ValidateOptions {
 				return &ValidateOptions{
-					inputDir:    t.TempDir(),
+					inputDir:     t.TempDir(),
 					outputFormat: "json",
 				}
 			},
@@ -328,7 +328,7 @@ func TestRun_EmptyInputDirReturnsError(t *testing.T) {
 
 	o := &ValidateOptions{
 		configFlags:      genericclioptions.NewConfigFlags(true),
-		IOStreams:         genericclioptions.NewTestIOStreamsDiscard(),
+		IOStreams:        genericclioptions.NewTestIOStreamsDiscard(),
 		inputDir:         emptyDir,
 		validateDir:      validateDir,
 		outputFormat:     "json",
@@ -564,3 +564,47 @@ func TestArchivePreviousResults_NoPreviousResults(t *testing.T) {
 	}
 }
 
+func TestValidate_HelpGroupsFlags(t *testing.T) {
+	streams, _, outBuf, _ := genericclioptions.NewTestIOStreams()
+	cmd := NewValidateCommand(streams, nil)
+	cmd.SetOut(outBuf)
+	cmd.SetErr(outBuf)
+	cmd.SetArgs([]string{"--help"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error running --help: %v", err)
+	}
+
+	help := outBuf.String()
+
+	commandSpecificHeader := "Command-specific Flags:"
+	kubeHeader := "Inherited Kubernetes Client Flags:"
+
+	commandSpecificIdx := strings.Index(help, commandSpecificHeader)
+	if commandSpecificIdx == -1 {
+		t.Fatalf("missing %q section in help output:\n%s", commandSpecificHeader, help)
+	}
+
+	kubeIdx := strings.Index(help, kubeHeader)
+	if kubeIdx == -1 {
+		t.Fatalf("missing %q section in help output:\n%s", kubeHeader, help)
+	}
+
+	if commandSpecificIdx > kubeIdx {
+		t.Fatalf("expected command-specific section before inherited kube/client section")
+	}
+
+	commandSpecificSection := help[commandSpecificIdx:kubeIdx]
+	kubeSection := help[kubeIdx:]
+
+	if !strings.Contains(commandSpecificSection, "--validate-dir") {
+		t.Fatalf("expected --validate-dir in command-specific section, got:\n%s", commandSpecificSection)
+	}
+
+	if strings.Contains(commandSpecificSection, "--as-uid") {
+		t.Fatalf("did not expect --as-uid in command-specific section, got:\n%s", commandSpecificSection)
+	}
+
+	if !strings.Contains(kubeSection, "--as-uid") {
+		t.Fatalf("expected --as-uid in inherited kube/client section, got:\n%s", kubeSection)
+	}
+}

--- a/internal/flags/help_groups.go
+++ b/internal/flags/help_groups.go
@@ -1,0 +1,78 @@
+package flags
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// KubernetesClientInheritedFlagNames returns the standard kube/client config
+// flags added by genericclioptions.ConfigFlags.
+func KubernetesClientInheritedFlagNames() []string {
+	return []string{
+		"as",
+		"as-group",
+		"as-uid",
+		"as-user-extra",
+		"cache-dir",
+		"certificate-authority",
+		"client-certificate",
+		"client-key",
+		"cluster",
+		"context",
+		"disable-compression",
+		"insecure-skip-tls-verify",
+		"kubeconfig",
+		"namespace",
+		"request-timeout",
+		"server",
+		"tls-server-name",
+		"token",
+		"user",
+	}
+}
+
+// SetGroupedHelp configures command help output to separate local flags into:
+// 1) command-specific flags
+// 2) inherited Kubernetes/client flags (provided via inheritedFlagNames)
+// Root/global inherited flags remain in Cobra's "Global Flags" section.
+func SetGroupedHelp(cmd *cobra.Command, inheritedFlagNames []string) {
+	inherited := make(map[string]struct{}, len(inheritedFlagNames))
+	for _, name := range inheritedFlagNames {
+		inherited[name] = struct{}{}
+	}
+
+	cmd.SetUsageFunc(func(c *cobra.Command) error {
+		out := c.OutOrStdout()
+		fmt.Fprintf(out, "Usage:\n  %s\n\n", c.UseLine())
+		commandSpecific := pflag.NewFlagSet("command-specific", pflag.ContinueOnError)
+		kubeClient := pflag.NewFlagSet("kube-client", pflag.ContinueOnError)
+
+		c.LocalFlags().VisitAll(func(f *pflag.Flag) {
+			if _, ok := inherited[f.Name]; ok {
+				kubeClient.AddFlag(f)
+				return
+			}
+			commandSpecific.AddFlag(f)
+		})
+
+		if commandSpecific.HasAvailableFlags() {
+			fmt.Fprintln(out, "Command-specific Flags:")
+			fmt.Fprint(out, commandSpecific.FlagUsages())
+			fmt.Fprintln(out)
+		}
+
+		if kubeClient.HasAvailableFlags() {
+			fmt.Fprintln(out, "Inherited Kubernetes Client Flags:")
+			fmt.Fprint(out, kubeClient.FlagUsages())
+			fmt.Fprintln(out)
+		}
+
+		if c.InheritedFlags().HasAvailableFlags() {
+			fmt.Fprintln(out, "Global Flags:")
+			fmt.Fprint(out, c.InheritedFlags().FlagUsages())
+		}
+		return nil
+	})
+}

--- a/internal/flags/help_groups.go
+++ b/internal/flags/help_groups.go
@@ -45,7 +45,9 @@ func SetGroupedHelp(cmd *cobra.Command, inheritedFlagNames []string) {
 
 	cmd.SetUsageFunc(func(c *cobra.Command) error {
 		out := c.OutOrStdout()
-		fmt.Fprintf(out, "Usage:\n  %s\n\n", c.UseLine())
+		if _, err := fmt.Fprintf(out, "Usage:\n  %s\n\n", c.UseLine()); err != nil {
+			return err
+		}
 		commandSpecific := pflag.NewFlagSet("command-specific", pflag.ContinueOnError)
 		kubeClient := pflag.NewFlagSet("kube-client", pflag.ContinueOnError)
 
@@ -58,20 +60,36 @@ func SetGroupedHelp(cmd *cobra.Command, inheritedFlagNames []string) {
 		})
 
 		if commandSpecific.HasAvailableFlags() {
-			fmt.Fprintln(out, "Command-specific Flags:")
-			fmt.Fprint(out, commandSpecific.FlagUsages())
-			fmt.Fprintln(out)
+			if _, err := fmt.Fprintln(out, "Command-specific Flags:"); err != nil {
+				return err
+			}
+			if _, err := fmt.Fprint(out, commandSpecific.FlagUsages()); err != nil {
+				return err
+			}
+			if _, err := fmt.Fprintln(out); err != nil {
+				return err
+			}
 		}
 
 		if kubeClient.HasAvailableFlags() {
-			fmt.Fprintln(out, "Inherited Kubernetes Client Flags:")
-			fmt.Fprint(out, kubeClient.FlagUsages())
-			fmt.Fprintln(out)
+			if _, err := fmt.Fprintln(out, "Inherited Kubernetes Client Flags:"); err != nil {
+				return err
+			}
+			if _, err := fmt.Fprint(out, kubeClient.FlagUsages()); err != nil {
+				return err
+			}
+			if _, err := fmt.Fprintln(out); err != nil {
+				return err
+			}
 		}
 
 		if c.InheritedFlags().HasAvailableFlags() {
-			fmt.Fprintln(out, "Global Flags:")
-			fmt.Fprint(out, c.InheritedFlags().FlagUsages())
+			if _, err := fmt.Fprintln(out, "Global Flags:"); err != nil {
+				return err
+			}
+			if _, err := fmt.Fprint(out, c.InheritedFlags().FlagUsages()); err != nil {
+				return err
+			}
 		}
 		return nil
 	})


### PR DESCRIPTION
## Summary
- Updates `crane validate --help` and `crane export --help` to show flags in clear sections:
  - `Command-specific Flags`
  - `Inherited Kubernetes Client Flags`
  - `Global Flags`
- Adds a reusable helper in `internal/flags/help_groups.go` to avoid duplicated help-grouping logic.
- Centralizes inherited kube/client flag names via `flags.KubernetesClientInheritedFlagNames()` and reuses it in both commands.
- Adds regression tests to verify grouped help output:
  - `TestValidate_HelpGroupsFlags`
  - `TestExport_HelpGroupsFlags`
## Impact
- **Severity:** Low risk (help-text/UX only; no runtime behavior changes).
- **Affected components:** `cmd/validate`, `cmd/export`, `internal/flags`.
- Improves CLI usability by making it obvious which flags are command-owned vs inherited kube/client plumbing.
## Test plan
- [x] `go test ./cmd/validate -v`
- [x] `go test ./cmd/export -v`
- [x] `go run . validate --help` (verified grouped sections)
- [x] `go run . export --help` (verified grouped sections)

## Current help output (after change)

### `crane validate -h`

```text
Usage:
  crane validate [flags]

Command-specific Flags:
      --api-resources string   Path to API surface JSON file from capture-api-surface.sh for offline validation (mutually exclusive with --context/--kubeconfig/--server/--token/--cluster/--user)
  -h, --help                   help for validate
  -i, --input-dir string       The path to the apply output directory containing final manifests (default "output")
  -o, --output string          Report file format: json or yaml (default "json")
      --validate-dir string    The path where validation results and failures are saved (default "validate")

Inherited Kubernetes Client Flags:
      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
      --as-uid string                  UID to impersonate for the operation.
      --as-user-extra stringArray      User extras to impersonate for the operation, this flag can be repeated to specify multiple values for the same key.
      --cache-dir string               Default cache directory (default "/Users/mmansoor/.kube/cache")
      --certificate-authority string   Path to a cert file for the certificate authority
      --client-certificate string      Path to a client certificate file for TLS
      --client-key string              Path to a client key file for TLS
      --cluster string                 The name of the kubeconfig cluster to use
      --context string                 The name of the kubeconfig context to use
      --disable-compression            If true, opt-out of response compression for all requests to the server
      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
  -n, --namespace string               If present, the namespace scope for this CLI request
      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
  -s, --server string                  The address and port of the Kubernetes API server
      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
      --token string                   Bearer token for authentication to the API server
      --user string                    The name of the kubeconfig user to use

Global Flags:
      --debug               Debug the command by printing more information
  -f, --flags-file string   Path to input file which contains a yaml representation of cli flags. Explicit flags take precedence over input file values.
```

### `crane export -h`

```text
Usage:
  crane export [flags]

Command-specific Flags:
      --as-extras string            The extra info for impersonation can only be used with User or Group but is not required. An example is --as-extras key=string1,string2;key2=string3
  -b, --burst int                   API Burst Rate. (default 1000)
      --crd-include-group strings   API groups to force-include for CRD export, even if default-built-in (repeatable)
      --crd-skip-group strings      Additional API groups to skip for CRD export (repeatable)
  -e, --export-dir string           The path where files are to be exported (default "export")
  -h, --help                        help for export
  -l, --label-selector string       Restrict export to resources matching a label selector
  -q, --qps float32                 Query Per Second Rate. (default 100)

Inherited Kubernetes Client Flags:
      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
      --as-uid string                  UID to impersonate for the operation.
      --as-user-extra stringArray      User extras to impersonate for the operation, this flag can be repeated to specify multiple values for the same key.
      --cache-dir string               Default cache directory (default "/Users/mmansoor/.kube/cache")
      --certificate-authority string   Path to a cert file for the certificate authority
      --client-certificate string      Path to a client certificate file for TLS
      --client-key string              Path to a client key file for TLS
      --cluster string                 The name of the kubeconfig cluster to use
      --context string                 The name of the kubeconfig context to use
      --disable-compression            If true, opt-out of response compression for all requests to the server
      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
  -n, --namespace string               If present, the namespace scope for this CLI request
      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
  -s, --server string                  The address and port of the Kubernetes API server
      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
      --token string                   Bearer token for authentication to the API server
      --user string                    The name of the kubeconfig user to use

Global Flags:
      --debug               Debug the command by printing more information
  -f, --flags-file string   Path to input file which contains a yaml representation of cli flags. Explicit flags take precedence over input file values.
```

## Notes
- Reviewed other commands for similar behavior; the mixed inherited kube/client flag problem applies to `validate` and `export` in current code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Help output for the export and validate commands now groups flags into "Command-specific Flags" and "Inherited Kubernetes Client Flags" for clearer CLI help.

* **Tests**
  * Added help-output tests to verify grouped flag sections and that command-specific vs inherited flags appear in the expected sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->