### PR TITLE
Add cluster-admin e2e tests for RBAC and CRD migration (CA-3, CA-9)

### DIFF
--- a/e2e-tests/framework/pipeline.go
+++ b/e2e-tests/framework/pipeline.go
@@ -3,6 +3,7 @@ package framework
 import (
 	"fmt"
 	"log"
+	"path/filepath"
 	"strings"
 
 	"github.com/konveyor/crane/e2e-tests/utils"
@@ -154,5 +155,55 @@ func checkAndLogStageFiles(stage, dir string) error {
 		return fmt.Errorf("expected crane %s to produce files in %s", stage, dir)
 	}
 	log.Printf("%s files:\n%s\n", stage, files)
+	return nil
+}
+
+type ExpectedResource struct {
+	Kind          string
+	Name          string
+	ClusterScoped bool
+}
+
+func checkExpectedResources(dir string, resources []ExpectedResource) error {
+	for _, r := range resources {
+		if err := utils.HasFileWithKindAndNameInDir(dir, r.Kind, r.Name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RunCranePipelineWithDeepChecks runs the pipeline and verifies that specific
+// resources exist in the expected stage directories.
+func RunCranePipelineWithDeepChecks(runner CraneRunner, namespace string, paths ScenarioPaths, expected []ExpectedResource) error {
+	if err := RunCranePipeline(runner, namespace, paths.ExportDir, paths.TransformDir, paths.OutputDir); err != nil {
+		return err
+	}
+
+	var clusterScoped, namespaceScoped []ExpectedResource
+	for _, r := range expected {
+		if r.ClusterScoped {
+			clusterScoped = append(clusterScoped, r)
+		} else {
+			namespaceScoped = append(namespaceScoped, r)
+		}
+	}
+
+	if err := checkExpectedResources(filepath.Join(paths.ExportDir, "resources", namespace, "_cluster"), clusterScoped); err != nil {
+		return err
+	}
+	if err := checkExpectedResources(filepath.Join(paths.ExportDir, "resources", namespace), namespaceScoped); err != nil {
+		return err
+	}
+	if err := checkExpectedResources(paths.TransformDir, expected); err != nil {
+		return err
+	}
+	if err := checkExpectedResources(filepath.Join(paths.OutputDir, "resources", "_cluster"), clusterScoped); err != nil {
+		return err
+	}
+	if err := checkExpectedResources(filepath.Join(paths.OutputDir, "resources", namespace), namespaceScoped); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/e2e-tests/framework/rbac.go
+++ b/e2e-tests/framework/rbac.go
@@ -140,3 +140,47 @@ func SetupNamespaceAdminUsersForScenario(scenario MigrationScenario, namespace s
 
 	return srcNonAdminKubectl, tgtNonAdminKubectl, cleanup, nil
 }
+
+type ExpectedClusterRoleBinding struct {
+	ClusterRoleBindingName string
+	ClusterRoleName        string
+	SubjectName            string
+}
+
+// ValidateClusterRBAC verifies that each CRB exists, references the expected ClusterRole, and has the expected subject.
+func ValidateClusterRBAC(kubectl KubectlRunner, namespace string, bindings []ExpectedClusterRoleBinding) error {
+	clusterRoles := map[string]bool{}
+	for _, b := range bindings {
+		clusterRoles[b.ClusterRoleName] = true
+	}
+	for cr := range clusterRoles {
+		if _, err := kubectl.Run("get", "clusterrole", cr); err != nil {
+			return fmt.Errorf("ClusterRole %s not found: %w", cr, err)
+		}
+		log.Printf("ClusterRole %s exists", cr)
+	}
+
+	for _, b := range bindings {
+		if _, err := kubectl.Run("get", "clusterrolebinding", b.ClusterRoleBindingName); err != nil {
+			return fmt.Errorf("ClusterRoleBinding %s not found: %w", b.ClusterRoleBindingName, err)
+		}
+
+		roleRef, err := kubectl.Run("get", "clusterrolebinding", b.ClusterRoleBindingName, "-o", "jsonpath={.roleRef.name}")
+		if err != nil {
+			return fmt.Errorf("failed to get roleRef for CRB %s: %w", b.ClusterRoleBindingName, err)
+		}
+		if roleRef != b.ClusterRoleName {
+			return fmt.Errorf("CRB %s references %s, expected %s", b.ClusterRoleBindingName, roleRef, b.ClusterRoleName)
+		}
+
+		subject, err := kubectl.Run("get", "clusterrolebinding", b.ClusterRoleBindingName, "-o", "jsonpath={.subjects[0].name}")
+		if err != nil {
+			return fmt.Errorf("failed to get subject for CRB %s: %w", b.ClusterRoleBindingName, err)
+		}
+		if subject != b.SubjectName {
+			return fmt.Errorf("CRB %s subject is %s, expected %s", b.ClusterRoleBindingName, subject, b.SubjectName)
+		}
+		log.Printf("CRB %s -> CR %s (subject: %s) verified", b.ClusterRoleBindingName, b.ClusterRoleName, b.SubjectName)
+	}
+	return nil
+}

--- a/e2e-tests/framework/resources.go
+++ b/e2e-tests/framework/resources.go
@@ -1,0 +1,206 @@
+package framework
+
+import (
+	"fmt"
+	"log"
+	"strings"
+)
+
+type Resource interface {
+	Delete(k KubectlRunner) error
+	Create(k KubectlRunner) error
+}
+
+func ResourceCleanup(clusters []KubectlRunner, resources []Resource) {
+	for _, k := range clusters {
+		for _, r := range resources {
+			if err := r.Delete(k); err != nil {
+				log.Printf("cleanup: %v", err)
+			}
+		}
+	}
+}
+
+type ClusterRole struct {
+	Name       string
+	Permission string
+	Label      string
+}
+
+func (cr ClusterRole) Create(k KubectlRunner) error {
+	var verbs string
+	switch cr.Permission {
+	case "write":
+		verbs = "get,list,watch,create,update,delete"
+	case "patch":
+		verbs = "get,list,watch,patch"
+	default:
+		verbs = "get,list,watch"
+	}
+	_, err := k.Run("create", "clusterrole", cr.Name, "--verb="+verbs, "--resource=pods")
+	if err != nil {
+		log.Printf("failed to create ClusterRole %s: %v", cr.Name, err)
+		return err
+	}
+	log.Printf("created %s ClusterRole %s", cr.Permission, cr.Name)
+	if cr.Label != "" {
+		_, err = k.Run("label", "clusterrole", cr.Name, cr.Label)
+		if err != nil {
+			return fmt.Errorf("failed to label ClusterRole %s: %w", cr.Name, err)
+		}
+	}
+	return nil
+}
+
+func (cr ClusterRole) Delete(k KubectlRunner) error {
+	_, err := k.Run("delete", "clusterrole", cr.Name, "--ignore-not-found=true")
+	if err != nil {
+		return fmt.Errorf("failed to delete ClusterRole %s: %w", cr.Name, err)
+	}
+	return nil
+}
+
+type ClusterRoleBinding struct {
+	Name            string
+	ClusterRoleName string
+	Subject         string
+	Label           string
+}
+
+func (crb ClusterRoleBinding) Create(k KubectlRunner) error {
+	_, err := k.Run("create", "clusterrolebinding", crb.Name, "--clusterrole="+crb.ClusterRoleName, crb.Subject)
+	if err != nil {
+		log.Printf("failed to create ClusterRoleBinding %s: %v", crb.Name, err)
+		return err
+	}
+	log.Printf("created ClusterRoleBinding %s -> ClusterRole %s", crb.Name, crb.ClusterRoleName)
+	if crb.Label != "" {
+		_, err = k.Run("label", "clusterrolebinding", crb.Name, crb.Label)
+		if err != nil {
+			return fmt.Errorf("failed to label ClusterRoleBinding %s: %w", crb.Name, err)
+		}
+	}
+	return nil
+}
+
+func (crb ClusterRoleBinding) Delete(k KubectlRunner) error {
+	_, err := k.Run("delete", "clusterrolebinding", crb.Name, "--ignore-not-found=true")
+	if err != nil {
+		return fmt.Errorf("failed to delete ClusterRoleBinding %s: %w", crb.Name, err)
+	}
+	return nil
+}
+
+type ServiceAccount struct {
+	Name      string
+	Namespace string
+	Label     string
+}
+
+func (sa ServiceAccount) Create(k KubectlRunner) error {
+	_, err := k.Run("create", "serviceaccount", sa.Name, "-n", sa.Namespace)
+	if err != nil {
+		log.Printf("failed to create ServiceAccount %s in %s: %v", sa.Name, sa.Namespace, err)
+		return err
+	}
+	log.Printf("created ServiceAccount %s in %s", sa.Name, sa.Namespace)
+	if sa.Label != "" {
+		_, err = k.Run("label", "serviceaccount", sa.Name, "-n", sa.Namespace, sa.Label)
+		if err != nil {
+			return fmt.Errorf("failed to label ServiceAccount %s: %w", sa.Name, err)
+		}
+	}
+	return nil
+}
+
+func (sa ServiceAccount) Delete(k KubectlRunner) error {
+	_, err := k.Run("delete", "serviceaccount", sa.Name, "-n", sa.Namespace, "--ignore-not-found=true")
+	if err != nil {
+		return fmt.Errorf("failed to delete ServiceAccount %s: %w", sa.Name, err)
+	}
+	return nil
+}
+
+type CustomResourceDefinition struct {
+	Name string
+	YAML string
+}
+
+func (crd CustomResourceDefinition) Create(k KubectlRunner) error {
+	_, err := k.RunWithStdin(crd.YAML, "apply", "-f", "-")
+	if err != nil {
+		log.Printf("failed to create CRD %s: %v", crd.Name, err)
+	} else {
+		log.Printf("created CRD %s", crd.Name)
+	}
+	return err
+}
+
+func (crd CustomResourceDefinition) Delete(k KubectlRunner) error {
+	_, err := k.Run("delete", "crd", crd.Name, "--ignore-not-found=true")
+	if err != nil {
+		return fmt.Errorf("failed to delete CRD %s: %w", crd.Name, err)
+	}
+	return nil
+}
+
+func (crd CustomResourceDefinition) WaitForEstablished(k KubectlRunner) error {
+	_, err := k.Run("wait", "--for=condition=Established", "crd/"+crd.Name, "--timeout=30s")
+	if err != nil {
+		return fmt.Errorf("CRD %s not established: %w", crd.Name, err)
+	}
+	log.Printf("CRD %s is Established", crd.Name)
+	return nil
+}
+
+type CustomResource struct {
+	Name      string
+	Namespace string
+	Kind      string
+	YAML      string
+}
+
+func (cr CustomResource) Create(k KubectlRunner) error {
+	_, err := k.RunWithStdin(cr.YAML, "apply", "-f", "-", "-n", cr.Namespace)
+	if err != nil {
+		log.Printf("failed to create %s %s: %v", cr.Kind, cr.Name, err)
+	} else {
+		log.Printf("created %s %s in %s", cr.Kind, cr.Name, cr.Namespace)
+	}
+	return err
+}
+
+func (cr CustomResource) AssertField(k KubectlRunner, jsonpath, expected string) error {
+	val, err := k.Run("get", strings.ToLower(cr.Kind), cr.Name, "-n", cr.Namespace, "-o", "jsonpath="+jsonpath)
+	if err != nil {
+		return fmt.Errorf("failed to get %s %s field %s: %w", cr.Kind, cr.Name, jsonpath, err)
+	}
+	if val != expected {
+		return fmt.Errorf("%s %s field %s: expected %q, got %q", cr.Kind, cr.Name, jsonpath, expected, val)
+	}
+	return nil
+}
+
+func (cr CustomResource) Delete(k KubectlRunner) error {
+	_, err := k.Run("delete", strings.ToLower(cr.Kind), cr.Name, "-n", cr.Namespace, "--ignore-not-found=true")
+	if err != nil {
+		return fmt.Errorf("failed to delete %s %s: %w", cr.Kind, cr.Name, err)
+	}
+	return nil
+}
+
+type NameSpace struct {
+	Name       string
+	Permission string
+	Label      string
+}
+
+func (n NameSpace) Delete(k KubectlRunner) {
+	if _, err := k.Run("delete", "namespace", n.Name, "--ignore-not-found=true", "--wait=true"); err != nil {
+		log.Printf("cleanup: failed to delete namespace %q: %v", n.Name, err)
+	}
+}
+func (n NameSpace) Create(k KubectlRunner) {
+	log.Printf("Created")
+
+}

--- a/e2e-tests/testdata/widget_cr.yaml
+++ b/e2e-tests/testdata/widget_cr.yaml
@@ -1,0 +1,7 @@
+apiVersion: crane-e2e.example.com/v1
+kind: Widget
+metadata:
+  name: test-widget
+spec:
+  color: blue
+  size: 5

--- a/e2e-tests/testdata/widget_crd.yaml
+++ b/e2e-tests/testdata/widget_crd.yaml
@@ -1,0 +1,27 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.crane-e2e.example.com
+spec:
+  group: crane-e2e.example.com
+  names:
+    kind: Widget
+    listKind: WidgetList
+    plural: widgets
+    singular: widget
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                color:
+                  type: string
+                size:
+                  type: integer

--- a/e2e-tests/tests/ca3_two_clusterroles_test.go
+++ b/e2e-tests/tests/ca3_two_clusterroles_test.go
@@ -1,0 +1,93 @@
+package e2e
+
+import (
+	"log"
+
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Cluster-level RBAC export", func() {
+	It("[CA-3] Should export two ClusterRoles and two ClusterRoleBindings for one Deployment", Label("cluster-admin"), func() {
+		appName := "nginx-with-serviceaccount"
+		namespace := "simple-nginx-nopv"
+		serviceName := "my-" + appName
+		saName := "nginx-sa"
+		readClusterRole := "crane-e2e-pod-reader"
+		writeClusterRole := "crane-e2e-pod-writer"
+		readClusterRoleBindingName := "reader-crane-e2e-pod-binding"
+		writeClusterRoleBindingName := "writer-crane-e2e-pod-binding"
+		subject := "--serviceaccount=" + namespace + ":" + saName
+		scenario := NewMigrationScenario(
+			appName,
+			namespace,
+			config.K8sDeployBin,
+			config.CraneBin,
+			config.SourceContext,
+			config.TargetContext,
+		)
+		srcApp := scenario.SrcApp
+		tgtApp := scenario.TgtApp
+		kubectlSrc := scenario.KubectlSrc
+		kubectlTgt := scenario.KubectlTgt
+		runner := scenario.Crane
+
+		paths, err := NewScenarioPaths("crane-ca3-*")
+		Expect(err).NotTo(HaveOccurred())
+
+		readCR := ClusterRole{Name: readClusterRole, Permission: "read"}
+		writeCR := ClusterRole{Name: writeClusterRole, Permission: "write"}
+		readCRB := ClusterRoleBinding{Name: readClusterRoleBindingName, ClusterRoleName: readClusterRole, Subject: subject}
+		writeCRB := ClusterRoleBinding{Name: writeClusterRoleBindingName, ClusterRoleName: writeClusterRole, Subject: subject}
+
+		DeferCleanup(func() {
+			ResourceCleanup([]KubectlRunner{kubectlSrc, kubectlTgt}, []Resource{
+				readCR, writeCR, readCRB, writeCRB,
+			})
+		})
+
+		DeferCleanup(func() {
+			CleanupScenario(paths.TempDir, srcApp, tgtApp)
+		})
+
+		By("Deploying app with ServiceAccount on source cluster")
+		Expect(PrepareSourceApp(srcApp, kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Creating ClusterRole with pod read permissions")
+		Expect(readCR.Create(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Creating ClusterRole with pod write permissions")
+		Expect(writeCR.Create(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Creating ClusterRoleBinding for read ClusterRole")
+		Expect(readCRB.Create(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Creating ClusterRoleBinding for write ClusterRole")
+		Expect(writeCRB.Create(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Waiting for source pods and endpoints to drain")
+		WaitForSourceQuiesce(kubectlSrc, namespace, "app="+appName, serviceName)
+
+		By("Running crane export, transform, apply")
+		Expect(RunCranePipelineWithChecks(runner, namespace, paths)).NotTo(HaveOccurred())
+
+		By("Create namespace on target, dryrun validate and Applying migrated manifests to target cluster")
+		Expect(ApplyOutputToTarget(kubectlTgt, namespace, paths.OutputDir)).NotTo(HaveOccurred())
+
+		By("Scale target deployment and validate app")
+		log.Printf("Scaling target deployment(s) with label app=%s to 1\n", appName)
+		Expect(kubectlTgt.ScaleDeployment(tgtApp.Namespace, appName, 1)).NotTo(HaveOccurred())
+
+		log.Printf("Validating app %s on target cluster\n", tgtApp.Name)
+		Eventually(tgtApp.Validate, "2m", "10s").Should(Succeed())
+		log.Printf("Target validation completed for app %s\n", tgtApp.Name)
+
+		By("Verifying both ClusterRoleBindings on target reference correct ClusterRoles and ServiceAccount")
+		Expect(ValidateClusterRBAC(kubectlTgt, namespace, []ExpectedClusterRoleBinding{
+			{ClusterRoleBindingName: readClusterRoleBindingName, ClusterRoleName: readClusterRole, SubjectName: saName},
+			{ClusterRoleBindingName: writeClusterRoleBindingName, ClusterRoleName: writeClusterRole, SubjectName: saName},
+		})).NotTo(HaveOccurred())
+	})
+})

--- a/e2e-tests/tests/ca9_crd_custom_resource_test.go
+++ b/e2e-tests/tests/ca9_crd_custom_resource_test.go
@@ -1,0 +1,102 @@
+package e2e
+
+import (
+	"path/filepath"
+
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	"github.com/konveyor/crane/e2e-tests/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Cluster-level RBAC export", func() {
+	It("[CA-9] Should export CRD to _cluster and custom resource to namespace directory", Label("cluster-admin"), func() {
+		appName := "simple-nginx-nopv"
+		namespace := "simple-nginx-nopv"
+		serviceName := "my-" + appName
+		scenario := NewMigrationScenario(
+			appName,
+			namespace,
+			config.K8sDeployBin,
+			config.CraneBin,
+			config.SourceContext,
+			config.TargetContext,
+		)
+		srcApp := scenario.SrcApp
+		tgtApp := scenario.TgtApp
+		kubectlSrc := scenario.KubectlSrc
+		kubectlTgt := scenario.KubectlTgt
+		runner := scenario.Crane
+
+		crName := "test-widget"
+		paths, err := NewScenarioPaths("crane-ca9-*")
+		Expect(err).NotTo(HaveOccurred())
+		crdYAML, err := utils.ReadTestdataFile("widget_crd.yaml")
+		Expect(err).NotTo(HaveOccurred())
+		crYAML, err := utils.ReadTestdataFile("widget_cr.yaml")
+		Expect(err).NotTo(HaveOccurred())
+
+		crd := CustomResourceDefinition{
+			Name: "widgets.crane-e2e.example.com",
+			YAML: crdYAML,
+		}
+		cr := CustomResource{
+			Name:      "test-widget",
+			Namespace: namespace,
+			Kind:      "Widget",
+			YAML:      crYAML,
+		}
+		DeferCleanup(func() {
+			ResourceCleanup([]KubectlRunner{kubectlSrc, kubectlTgt}, []Resource{
+				cr, crd,
+			})
+		})
+
+		DeferCleanup(func() {
+			CleanupScenario(paths.TempDir, srcApp, tgtApp)
+		})
+
+		By("Deploying app on source cluster")
+		Expect(PrepareSourceApp(srcApp, kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Creating Widget CRD on source")
+		Expect(crd.Create(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Waiting for CRD to be established")
+		Expect(crd.WaitForEstablished(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Creating Widget custom resource in namespace")
+		Expect(cr.Create(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Waiting for source pods and endpoints to drain")
+		WaitForSourceQuiesce(kubectlSrc, namespace, "app="+appName, serviceName)
+
+		By("Running crane export, transform, apply")
+		Expect(RunCranePipelineWithDeepChecks(runner, namespace, paths, []ExpectedResource{
+			{Kind: "CustomResourceDefinition", Name: "widgets.crane-e2e.example.com", ClusterScoped: true},
+			{Kind: "Widget", Name: "test-widget"},
+		})).NotTo(HaveOccurred())
+
+		By("Creating namespace on target cluster")
+		Expect(kubectlTgt.CreateNamespace(namespace)).NotTo(HaveOccurred())
+
+		By("Applying cluster resources to target")
+		Expect(kubectlTgt.ApplyDir(filepath.Join(paths.OutputDir, "resources", "_cluster"))).NotTo(HaveOccurred())
+
+		By("Waiting for CRD to be established on target")
+		Expect(crd.WaitForEstablished(kubectlTgt)).NotTo(HaveOccurred())
+
+		By("Applying namespace resources to target")
+		Expect(kubectlTgt.ApplyDir(filepath.Join(paths.OutputDir, "resources", namespace))).NotTo(HaveOccurred())
+
+		By("Verifying Widget CR exists on target")
+		_, err = kubectlTgt.Run("get", "widget", crName, "-n", namespace)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Verifying Widget CR has correct spec values on target")
+		Expect(cr.AssertField(kubectlTgt, "{.spec.color}", "blue")).NotTo(HaveOccurred())
+
+	})
+
+})

--- a/e2e-tests/utils/utils.go
+++ b/e2e-tests/utils/utils.go
@@ -902,3 +902,21 @@ func CaptureAPISurfaceScriptPath() (string, error) {
 
 	return scriptPath, nil
 }
+
+// HasFileWithKindAndNameInDir returns an error if no file under dir (recursively)
+// starts with "<kind>_" and ends with "_<name>.yaml".
+func HasFileWithKindAndNameInDir(dir, kind, name string) error {
+	files, err := ListFilesRecursivelyAsList(dir)
+	if err != nil {
+		return err
+	}
+	prefix := kind + "_"
+	suffix := "_" + name + ".yaml"
+	for _, f := range files {
+		base := filepath.Base(f)
+		if strings.HasPrefix(base, prefix) && strings.HasSuffix(base, suffix) {
+			return nil
+		}
+	}
+	return fmt.Errorf("no file matching kind %q and name %q found in %s", kind, name, dir)
+}


### PR DESCRIPTION
Title: Add cluster-admin e2e test framework and first tests (CA-3, CA-9)

## Summary
- Introduce `Resource` interface and concrete types (`ClusterRole`, `ClusterRoleBinding`, `ServiceAccount`, `CustomResourceDefinition`, `CustomResource`, `NameSpace`) for reusable test setup/teardown
- Add `ValidateClusterRBAC` for verifying ClusterRoleBinding correctness on target clusters
- Add `RunCranePipelineWithDeepChecks` and `HasFileWithKindAndNameInDir` for resource-level pipeline verification
- Add CA-3 test: two ClusterRoles + ClusterRoleBindings migration
- Add CA-9 test: CRD and custom resource export to correct directories

## Notes
Some framework types (e.g. `NameSpace`, `ServiceAccount`) are not yet used by these tests but are included as shared infrastructure for upcoming cluster-admin tests.

## Test plan
- [ ] Run CA-3 test against dual-cluster environment
- [ ] Run CA-9 test against dual-cluster environment
- [ ] Verify `go build ./...` passes with new framework code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded E2E test coverage for Kubernetes RBAC migration scenarios and custom resource definitions
  * Added comprehensive resource validation across pipeline export/transform/apply stages
  * Enhanced test framework with improved resource management and verification capabilities for cluster and namespace-scoped resources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->