### PR TITLE
fix label selector issue for cluster scoped resources

### DIFF
--- a/cmd/export/discover.go
+++ b/cmd/export/discover.go
@@ -332,7 +332,7 @@ func getObjects(g *groupResource, namespace string, labelSelector string, d dyna
 		}
 	})
 	listOptions := metav1.ListOptions{}
-	if labelSelector != "" {
+	if labelSelector != "" && g.APIResource.Namespaced {
 		listOptions.LabelSelector = labelSelector
 	}
 

--- a/cmd/export/discover_test.go
+++ b/cmd/export/discover_test.go
@@ -1230,6 +1230,36 @@ func TestGetObjects_passesLabelSelectorToList(t *testing.T) {
 	}
 }
 
+func TestGetObjects_clusterScopedSkipsLabelSelector(t *testing.T) {
+	crb := &unstructured.Unstructured{}
+	crb.SetAPIVersion("rbac.authorization.k8s.io/v1")
+	crb.SetKind("ClusterRoleBinding")
+	crb.SetName("test-binding")
+	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), crb)
+	var sawLabel string
+	client.PrependReactor("list", "clusterrolebindings", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+		la, ok := action.(kubetesting.ListActionImpl)
+		if !ok {
+			t.Fatalf("expected ListActionImpl, got %T", action)
+		}
+		sawLabel = la.GetListOptions().LabelSelector
+		return false, nil, nil
+	})
+	g := &groupResource{
+		APIGroup:        "rbac.authorization.k8s.io",
+		APIVersion:      "v1",
+		APIGroupVersion: "rbac.authorization.k8s.io/v1",
+		APIResource:     metav1.APIResource{Name: "clusterrolebindings", Kind: "ClusterRoleBinding", Namespaced: false},
+	}
+	_, err := getObjects(g, "", "app=test", client, testLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sawLabel != "" {
+		t.Fatalf("cluster-scoped resource got LabelSelector = %q, want empty", sawLabel)
+	}
+}
+
 func TestGetObjects_imageStreamTags_getFailure(t *testing.T) {
 	ist := &unstructured.Unstructured{}
 	ist.SetAPIVersion("image.openshift.io/v1")


### PR DESCRIPTION
## Fix

  - Fix label selector being applied to cluster-scoped RBAC resources (ClusterRoleBindings, ClusterRoles, SCCs) during `crane export -l <selector>`, which silently dropped the entire SA permission chain
  - Add unit test verifying label selector is not passed to the API for cluster-scoped resources

  ## Problem

  When using `crane export -l <label>`, the label selector was applied to **all** resource types including cluster-scoped resources. Since users typically don't label RBAC resources with app-level labels (e.g.
  `app=mysql`), the cluster-scoped List calls returned empty results and `filterRbacResources` never ran. ServiceAccounts were exported but their associated ClusterRoleBindings and ClusterRoles were silently dropped,
  causing permission errors on the target cluster.

  Test plan

  - [x] Unit test TestGetObjects_clusterScopedSkipsLabelSelector confirms label selector is not passed for cluster-scoped resources
  - [x] Unit test TestGetObjects_passesLabelSelectorToList confirms label selector is still applied for namespaced resources
  - [x] go build ./... passes
  - [x] go test ./... passes (all unit tests)
  - [x] Manual verification on minikube (src context): crane export -n crane-test -l app=mysql correctly exports SA + ClusterRoleBinding + ClusterRole

  Fixes: #470 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected label selector handling for cluster-scoped Kubernetes resources to prevent incorrect filtering behavior.

* **Tests**
  * Added test coverage to verify proper label selector handling across different resource types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->