### PR TITLE
fix: make `crane export` fail non-zero when all namespace list calls are Forbidden

### DIFF
--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -202,7 +202,6 @@ func (o *ExportOptions) Run() error {
 	var errs []error
 
 	resources, resourceErrs := resourceToExtract(o.userSpecifiedNamespace, o.labelSelector, dynamicClient, resourceLists, log)
-	allForbidden := allResourceListsForbidden(resources, resourceErrs)
 	clusterScopeHandler := NewClusterScopeHandler()
 	resources = clusterScopeHandler.filterRbacResources(resources, log)
 
@@ -237,9 +236,9 @@ func (o *ExportOptions) Run() error {
 
 	errs = append(errs, writeResourcesErrors...)
 	errs = append(errs, writeErrorsErrors...)
-	if allForbidden {
+	if allResourceListsForbidden(resources, resourceErrs) {
 		errs = append(errs, fmt.Errorf(
-			"export failed: all resource types returned Forbidden for namespace %q -- verify the namespace exists and your user has list permissions",
+			"all resource types returned Forbidden for namespace %q -- verify the namespace exists and your user has list permissions",
 			o.userSpecifiedNamespace,
 		))
 	}

--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -117,6 +117,25 @@ func validateExportNamespace(ctx context.Context, client kubernetes.Interface, n
 	return nil
 }
 
+// allResourceListsForbidden reports whether export discovered no resources and
+// every per-resource list attempt failed with a Forbidden error. This is used
+// to trigger a non-zero exit for the strict "all Forbidden" export failure case.
+func allResourceListsForbidden(resources []*groupResource, resourceErrs []*groupResourceError) bool {
+	if len(resources) > 0 || len(resourceErrs) == 0 {
+		return false
+	}
+
+	for _, resourceErr := range resourceErrs {
+		if resourceErr == nil || resourceErr.Error == nil {
+			return false
+		}
+		if !apierrors.IsForbidden(resourceErr.Error) {
+			return false
+		}
+	}
+	return true
+}
+
 // Run performs discovery, lists resources, filters cluster-scoped RBAC to related
 // ServiceAccounts, writes YAML under exportDir, and returns an aggregate of non-fatal write errors.
 func (o *ExportOptions) Run() error {
@@ -183,6 +202,7 @@ func (o *ExportOptions) Run() error {
 	var errs []error
 
 	resources, resourceErrs := resourceToExtract(o.userSpecifiedNamespace, o.labelSelector, dynamicClient, resourceLists, log)
+	allForbidden := allResourceListsForbidden(resources, resourceErrs)
 	clusterScopeHandler := NewClusterScopeHandler()
 	resources = clusterScopeHandler.filterRbacResources(resources, log)
 
@@ -217,7 +237,12 @@ func (o *ExportOptions) Run() error {
 
 	errs = append(errs, writeResourcesErrors...)
 	errs = append(errs, writeErrorsErrors...)
-
+	if allForbidden {
+		errs = append(errs, fmt.Errorf(
+			"export failed: all resource types returned Forbidden for namespace %q -- verify the namespace exists and your user has list permissions",
+			o.userSpecifiedNamespace,
+		))
+	}
 	return errorsutil.NewAggregate(errs)
 }
 

--- a/cmd/export/export_test.go
+++ b/cmd/export/export_test.go
@@ -2,13 +2,16 @@ package export
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -307,5 +310,73 @@ func TestExport_HelpGroupsFlags(t *testing.T) {
 
 	if !strings.Contains(kubeSection, "--context") {
 		t.Fatalf("expected --context in inherited kube/client section, got:\n%s", kubeSection)
+	}
+}
+
+func TestAllResourceListsForbidden(t *testing.T) {
+	forbiddenErr := apierrors.NewForbidden(
+		schema.GroupResource{Resource: "configmaps"},
+		"",
+		errors.New("forbidden"),
+	)
+	notFoundErr := apierrors.NewNotFound(
+		schema.GroupResource{Resource: "configmaps"},
+		"cm1",
+	)
+
+	apiResource := metav1.APIResource{
+		Name:       "configmaps",
+		Kind:       "ConfigMap",
+		Namespaced: true,
+	}
+
+	tests := []struct {
+		name         string
+		resources    []*groupResource
+		resourceErrs []*groupResourceError
+		want         bool
+	}{
+		{
+			name:         "no resources and no errors",
+			resources:    nil,
+			resourceErrs: nil,
+			want:         false,
+		},
+		{
+			name:      "all forbidden and no resources",
+			resources: nil,
+			resourceErrs: []*groupResourceError{
+				{APIResource: apiResource, Error: forbiddenErr},
+			},
+			want: true,
+		},
+		{
+			name:      "mixed errors and no resources",
+			resources: nil,
+			resourceErrs: []*groupResourceError{
+				{APIResource: apiResource, Error: forbiddenErr},
+				{APIResource: apiResource, Error: notFoundErr},
+			},
+			want: false,
+		},
+		{
+			name: "forbidden exists but resources exported",
+			resources: []*groupResource{
+				{APIResource: apiResource},
+			},
+			resourceErrs: []*groupResourceError{
+				{APIResource: apiResource, Error: forbiddenErr},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := allResourceListsForbidden(tt.resources, tt.resourceErrs)
+			if got != tt.want {
+				t.Fatalf("allResourceListsForbidden() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION


## Summary

- Fixes the false-success path in `crane export` where all resource list calls fail with RBAC `Forbidden`, but command still exits `0`.
- Adds strict detection helper in `cmd/export/export.go`:
  - `allResourceListsForbidden(resources, resourceErrs)`
  - returns true only when:
    - no resources were exported, and
    - at least one list error exists, and
    - every list error is `Forbidden`.
- Updates export run flow to:
  - continue writing failure artifacts under `<export-dir>/failures/<namespace>/`
  - then return a command error so CLI exits non-zero.
- Adds regression unit tests:
  - `TestAllResourceListsForbidden` in `cmd/export/export_test.go`
  - covers all-forbidden, mixed errors, no-errors, and resources-exported scenarios.

## Impact

- **Severity:** Medium (behavioral fix for exit code semantics in a specific failure mode).
- **Affected components:** `cmd/export/export.go`, `cmd/export/export_test.go`.
- **User/CI impact:** Prevents false positives in automation when export is fully blocked by namespace RBAC.
- **Compatibility:** Successful and partial-success export paths remain unchanged.

## Test plan

- [x] `go test ./cmd/export -v`
- [x] `go run main.go export -n export-test --context src-sajid`
- [x] Verified final error message is actionable and command exits non-zero (`exit status 1`)
- [x] Verified strict condition message:
  - `export failed: all resource types returned Forbidden for namespace "<ns>" -- verify the namespace exists and your user has list permissions`

## Current behavior (after change)

### `go run main.go export -n export-test --context src-sajid`

```text
WARN[0000] cannot verify namespace "export-test" exists (may lack RBAC permission): namespaces "export-test" is forbidden: User "sajid" cannot get resource "namespaces" in API group "" in the namespace "export-test"
ERRO[0000] cannot list obj in namespace for groupVersion v1, kind: Service
ERRO[0000] cannot list obj in namespace for groupVersion v1, kind: ServiceAccount
ERRO[0000] cannot list obj in namespace for groupVersion v1, kind: Pod
ERRO[0000] cannot list obj in namespace for groupVersion apps/v1, kind: Deployment
ERRO[0000] cannot list obj in namespace for groupVersion rbac.authorization.k8s.io/v1, kind: ClusterRoleBinding
ERRO[0000] cannot list obj in namespace for groupVersion operators.coreos.com/v1alpha1, kind: Subscription
Error: export failed: all resource types returned Forbidden for namespace "export-test" -- verify the namespace exists and your user has list permissions
...
exit status 1
```

## Notes

- This PR intentionally keeps per-resource failure details in output for diagnosis and still surfaces a single final actionable command-level failure.
- Namespace existence pre-check warning is preserved; final export failure is determined from actual list outcomes.






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved export error reporting when no resources are discovered because all resource list attempts were forbidden; messages now include the target namespace and guidance to verify namespace existence and list permissions.

* **Tests**
  * Added test coverage for permission-related export failure scenarios to ensure correct detection and messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->