### PR TITLE
fix log level for cluster resources error

### DIFF
--- a/cmd/export/discover.go
+++ b/cmd/export/discover.go
@@ -281,11 +281,11 @@ func resourceToExtract(namespace string, labelSelector string, dynamicClient dyn
 			if err != nil {
 				switch {
 				case apierrors.IsForbidden(err):
-					log.Errorf("cannot list obj in namespace for groupVersion %s, kind: %s\n", g.APIGroupVersion, g.APIResource.Kind)
+					log.Debugf("access denied for groupVersion %s, kind: %s (expected for namespace-admin users)\n", g.APIGroupVersion, g.APIResource.Kind)
 				case apierrors.IsMethodNotSupported(err):
-					log.Errorf("list method not supported on the groupVersion %s, kind: %s\n", g.APIGroupVersion, g.APIResource.Kind)
+					log.Warnf("list method not supported on the groupVersion %s, kind: %s\n", g.APIGroupVersion, g.APIResource.Kind)
 				case apierrors.IsNotFound(err):
-					log.Errorf("could not find the resource, most likely this is a virtual resource, groupVersion %s, kind: %s\n", g.APIGroupVersion, g.APIResource.Kind)
+					log.Debugf("resource not found (virtual resource), groupVersion %s, kind: %s\n", g.APIGroupVersion, g.APIResource.Kind)
 				default:
 					log.Errorf("error listing objects: %#v, groupVersion %s, kind: %s\n", err, g.APIGroupVersion, g.APIResource.Kind)
 				}


### PR DESCRIPTION
FIxes #475 
Log Level changed to Debug / Warn to reduce noise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging for Kubernetes API operations by adjusting log levels for common scenarios, reducing unnecessary error-level messages and providing more appropriate verbosity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->