### PR TITLE
refactor: replace positional args with typed option structs in e2e te…

### DIFF
--- a/e2e-tests/framework/crane.go
+++ b/e2e-tests/framework/crane.go
@@ -32,9 +32,67 @@ type ValidateOptions struct {
 	ExtraArgs        []string
 }
 
+type ExportOptions struct {
+	Namespace        string
+	ExportDir        string
+	LabelSelector    string
+	CRDSkipGroups    []string
+	CRDIncludeGroups []string
+	AsExtras         string
+	QPS              float32
+	Burst            int
+}
+
+type TransformOptions struct {
+	ExportDir         string
+	TransformDir      string
+	PluginDir         string
+	IgnoredPatchesDir string
+	SkipPlugins       []string
+	OptionalFlags     string
+	Force             bool
+	KustomizeArgs     string
+	InstructionsFile  string
+	Stages            []string
+}
+
+type ApplyOptions struct {
+	ExportDir         string
+	TransformDir      string
+	OutputDir         string
+	KustomizeArgs     string
+	SkipClusterScoped bool
+	Stages            []string
+}
+
 // Export runs crane export for a namespace into the given export directory.
-func (c CraneRunner) Export(namespace, exportDir string) error {
-	args := []string{"export", "--context", c.SourceContext, "--namespace", namespace, "--export-dir", exportDir}
+func (c CraneRunner) Export(opts ExportOptions) error {
+	args := []string{"export", "--context", c.SourceContext}
+
+	if opts.Namespace != "" {
+		args = append(args, "--namespace", opts.Namespace)
+	}
+	if opts.ExportDir != "" {
+		args = append(args, "--export-dir", opts.ExportDir)
+	}
+	if opts.LabelSelector != "" {
+		args = append(args, "--label-selector", opts.LabelSelector)
+	}
+	for _, g := range opts.CRDSkipGroups {
+		args = append(args, "--crd-skip-group", g)
+	}
+	for _, g := range opts.CRDIncludeGroups {
+		args = append(args, "--crd-include-group", g)
+	}
+	if opts.AsExtras != "" {
+		args = append(args, "--as-extras", opts.AsExtras)
+	}
+	if opts.QPS > 0 {
+		args = append(args, "--qps", fmt.Sprintf("%g", opts.QPS))
+	}
+	if opts.Burst > 0 {
+		args = append(args, "--burst", fmt.Sprintf("%d", opts.Burst))
+	}
 	logVerboseCommand(c.Bin, args)
 	cmd := exec.Command(c.Bin, args...)
 	cmd.Dir = c.WorkDir
@@ -47,8 +105,38 @@ func (c CraneRunner) Export(namespace, exportDir string) error {
 }
 
 // Transform runs crane transform from export directory to transform directory.
-func (c CraneRunner) Transform(exportDir, transformDir string) error {
-	args := []string{"transform", "--export-dir", exportDir, "--transform-dir", transformDir}
+func (c CraneRunner) Transform(opts TransformOptions) error {
+	args := []string{"transform"}
+
+	if opts.ExportDir != "" {
+		args = append(args, "--export-dir", opts.ExportDir)
+	}
+	if opts.TransformDir != "" {
+		args = append(args, "--transform-dir", opts.TransformDir)
+	}
+	if opts.PluginDir != "" {
+		args = append(args, "--plugin-dir", opts.PluginDir)
+	}
+	if opts.IgnoredPatchesDir != "" {
+		args = append(args, "--ignored-patches-dir", opts.IgnoredPatchesDir)
+	}
+	for _, p := range opts.SkipPlugins {
+		args = append(args, "--skip-plugins", p)
+	}
+	if opts.OptionalFlags != "" {
+		args = append(args, "--optional-flags", opts.OptionalFlags)
+	}
+	if opts.Force {
+		args = append(args, "--force")
+	}
+	if opts.KustomizeArgs != "" {
+		args = append(args, "--kustomize-args", opts.KustomizeArgs)
+	}
+	if opts.InstructionsFile != "" {
+		args = append(args, "--instructions-file", opts.InstructionsFile)
+	}
+	args = append(args, opts.Stages...)
+
 	logVerboseCommand(c.Bin, args)
 	cmd := exec.Command(c.Bin, args...)
 	cmd.Dir = c.WorkDir
@@ -60,56 +148,27 @@ func (c CraneRunner) Transform(exportDir, transformDir string) error {
 	return nil
 }
 
-// TransformStage runs crane transform with a specific stage.
-func (c CraneRunner) TransformStage(exportDir, transformDir, stage string) error {
-	if stage == "" {
-		return fmt.Errorf("crane transform requires a non-empty stage")
-	}
-	args := []string{
-		"transform",
-		"--export-dir", exportDir,
-		"--transform-dir", transformDir,
-		stage,
-	}
-	logVerboseCommand(c.Bin, args)
-	cmd := exec.Command(c.Bin, args...)
-	cmd.Dir = c.WorkDir
-	out, err := cmd.CombinedOutput()
-	logVerboseOutput("crane transform with stage", out)
-	if err != nil {
-		return fmt.Errorf("crane transform with stage %q failed: %v, output: %s", stage, err, string(out))
-	}
-	return nil
-}
-
-// TransformWithInstructionsFile runs crane transform using an instructions file.
-func (c CraneRunner) TransformWithInstructionsFile(exportDir, transformDir, instructionsFile string, force bool) error {
-	if instructionsFile == "" {
-		return fmt.Errorf("crane transform --instructions-file requires a non-empty instructions file path")
-	}
-	args := []string{
-		"transform",
-		"--export-dir", exportDir,
-		"--transform-dir", transformDir,
-		"--instructions-file", instructionsFile,
-	}
-	if force {
-		args = append(args, "--force")
-	}
-	logVerboseCommand(c.Bin, args)
-	cmd := exec.Command(c.Bin, args...)
-	cmd.Dir = c.WorkDir
-	out, err := cmd.CombinedOutput()
-	logVerboseOutput("crane transform --instructions-file", out)
-	if err != nil {
-		return fmt.Errorf("crane transform --instructions-file failed: %w, output: %s", err, string(out))
-	}
-	return nil
-}
-
 // Apply runs crane apply to render manifests into the output directory.
-func (c CraneRunner) Apply(exportDir, transformDir string, outputDir string) error {
-	args := []string{"apply", "--export-dir", exportDir, "--transform-dir", transformDir, "--output-dir", outputDir}
+func (c CraneRunner) Apply(opts ApplyOptions) error {
+	args := []string{"apply"}
+
+	if opts.ExportDir != "" {
+		args = append(args, "--export-dir", opts.ExportDir)
+	}
+	if opts.TransformDir != "" {
+		args = append(args, "--transform-dir", opts.TransformDir)
+	}
+	if opts.OutputDir != "" {
+		args = append(args, "--output-dir", opts.OutputDir)
+	}
+	if opts.KustomizeArgs != "" {
+		args = append(args, "--kustomize-args", opts.KustomizeArgs)
+	}
+	if opts.SkipClusterScoped {
+		args = append(args, "--skip-cluster-scoped")
+	}
+	args = append(args, opts.Stages...)
+
 	logVerboseCommand(c.Bin, args)
 	cmd := exec.Command(c.Bin, args...)
 	cmd.Dir = c.WorkDir

--- a/e2e-tests/framework/pipeline.go
+++ b/e2e-tests/framework/pipeline.go
@@ -16,6 +16,9 @@ const (
 
 // RunCranePipeline executes export, transform, and apply in sequence.
 func RunCranePipeline(runner CraneRunner, e ExportOptions, t TransformOptions, a ApplyOptions) error {
+	if (e.ExportDir != t.ExportDir) || (e.ExportDir != a.ExportDir) || (t.TransformDir != a.TransformDir) {
+		return fmt.Errorf("pipeline directory mismatch: export/transform/apply options must agree on shared directories (exportDir, transformDir)")
+	}
 	if err := runner.Export(e); err != nil {
 		return err
 	}
@@ -29,18 +32,18 @@ func RunCranePipeline(runner CraneRunner, e ExportOptions, t TransformOptions, a
 }
 
 // RunCranePipelineWithChecks runs the pipeline and verifies generated stage files.
-func RunCranePipelineWithChecks(runner CraneRunner, e ExportOptions, t TransformOptions, a ApplyOptions) error {
-	if err := RunCranePipeline(runner, e, t, a); err != nil {
+func RunCranePipelineWithChecks(runner CraneRunner, exportOpts ExportOptions, transformOps TransformOptions, applyOpts ApplyOptions) error {
+	if err := RunCranePipeline(runner, exportOpts, transformOps, applyOpts); err != nil {
 		return err
 	}
 
-	if err := checkAndLogStageFiles("export", e.ExportDir); err != nil {
+	if err := checkAndLogStageFiles("export", exportOpts.ExportDir); err != nil {
 		return err
 	}
-	if err := checkAndLogStageFiles("transform", t.TransformDir); err != nil {
+	if err := checkAndLogStageFiles("transform", transformOps.TransformDir); err != nil {
 		return err
 	}
-	if err := checkAndLogStageFiles("output", a.OutputDir); err != nil {
+	if err := checkAndLogStageFiles("output", applyOpts.OutputDir); err != nil {
 		return err
 	}
 	return nil

--- a/e2e-tests/framework/pipeline.go
+++ b/e2e-tests/framework/pipeline.go
@@ -15,32 +15,32 @@ const (
 )
 
 // RunCranePipeline executes export, transform, and apply in sequence.
-func RunCranePipeline(runner CraneRunner, namespace, exportDir, transformDir, outputDir string) error {
-	if err := runner.Export(namespace, exportDir); err != nil {
+func RunCranePipeline(runner CraneRunner, e ExportOptions, t TransformOptions, a ApplyOptions) error {
+	if err := runner.Export(e); err != nil {
 		return err
 	}
-	if err := runner.Transform(exportDir, transformDir); err != nil {
+	if err := runner.Transform(t); err != nil {
 		return err
 	}
-	if err := runner.Apply(exportDir, transformDir, outputDir); err != nil {
+	if err := runner.Apply(a); err != nil {
 		return err
 	}
 	return nil
 }
 
 // RunCranePipelineWithChecks runs the pipeline and verifies generated stage files.
-func RunCranePipelineWithChecks(runner CraneRunner, namespace string, paths ScenarioPaths) error {
-	if err := RunCranePipeline(runner, namespace, paths.ExportDir, paths.TransformDir, paths.OutputDir); err != nil {
+func RunCranePipelineWithChecks(runner CraneRunner, e ExportOptions, t TransformOptions, a ApplyOptions) error {
+	if err := RunCranePipeline(runner, e, t, a); err != nil {
 		return err
 	}
 
-	if err := checkAndLogStageFiles("export", paths.ExportDir); err != nil {
+	if err := checkAndLogStageFiles("export", e.ExportDir); err != nil {
 		return err
 	}
-	if err := checkAndLogStageFiles("transform", paths.TransformDir); err != nil {
+	if err := checkAndLogStageFiles("transform", t.TransformDir); err != nil {
 		return err
 	}
-	if err := checkAndLogStageFiles("output", paths.OutputDir); err != nil {
+	if err := checkAndLogStageFiles("output", a.OutputDir); err != nil {
 		return err
 	}
 	return nil

--- a/e2e-tests/tests/tier0/mta_801_stateful_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_801_stateful_migration_test.go
@@ -35,6 +35,10 @@ var _ = Describe("Stateful app migration", func() {
 
 		paths, err := NewScenarioPaths("crane-export-*")
 		Expect(err).NotTo(HaveOccurred())
+		exportOpts := ExportOptions{Namespace: namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
 		DeferCleanup(func() {
 			By("Cleanup source and target resources")
 			if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
@@ -56,7 +60,7 @@ var _ = Describe("Stateful app migration", func() {
 		log.Printf("Running crane pipeline for namespace %s\n", srcApp.Namespace)
 		runner := scenario.Crane
 		runner.WorkDir = paths.TempDir
-		Expect(RunCranePipelineWithChecks(runner, srcApp.Namespace, paths)).NotTo(HaveOccurred())
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 		log.Printf("Crane pipeline completed for namespace %s\n", srcApp.Namespace)
 		By("Compare YAML semantic diff of golden and actual export files")
 		goldenExportDir, err := utils.GoldenManifestsDir(appName, "export")

--- a/e2e-tests/tests/tier0/mta_802_ignored_resources_test.go
+++ b/e2e-tests/tests/tier0/mta_802_ignored_resources_test.go
@@ -34,7 +34,10 @@ var _ = Describe("Default Ignored resources", func() {
 
 		paths, err := NewScenarioPaths("crane-export-*")
 		Expect(err).NotTo(HaveOccurred())
-
+		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
 		DeferCleanup(func() {
 			By("Cleanup manual Endpoints resource on source")
 			_, err := kubectlSrc.Run("delete", "endpoints", "manual-endpoint", "-n", namespace, "--ignore-not-found=true")
@@ -74,7 +77,7 @@ var _ = Describe("Default Ignored resources", func() {
 
 		By("Run crane export/transform/apply pipeline")
 		log.Printf("Running crane pipeline for namespace %s\n", srcApp.Namespace)
-		Expect(RunCranePipelineWithChecks(runner, srcApp.Namespace, paths)).NotTo(HaveOccurred())
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 		log.Printf("Crane pipeline completed for namespace %s\n", srcApp.Namespace)
 		By("Verify output directory does not contain ignored resource manifests")
 		outputFiles, err := utils.ListFilesRecursivelyAsList(paths.OutputDir)

--- a/e2e-tests/tests/tier0/mta_804_empty_pvc_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_804_empty_pvc_migration_test.go
@@ -53,6 +53,10 @@ var _ = Describe("Empty PVC migration", func() {
 
 		paths, err := NewScenarioPaths("crane-export-*")
 		Expect(err).NotTo(HaveOccurred())
+		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
 		DeferCleanup(func() {
 			By("Cleanup temp directory")
 			if paths.TempDir != "" {
@@ -90,7 +94,7 @@ var _ = Describe("Empty PVC migration", func() {
 		log.Printf("Running crane pipeline for namespace %s\n", srcApp.Namespace)
 		runner := scenario.CraneNonAdmin
 		runner.WorkDir = paths.TempDir
-		Expect(RunCranePipelineWithChecks(runner, srcApp.Namespace, paths)).NotTo(HaveOccurred())
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 		log.Printf("Crane pipeline completed for source namespace %s\n", srcApp.Namespace)
 
 		By("Transfer PVCs")

--- a/e2e-tests/tests/tier0/mta_805_sets_test.go
+++ b/e2e-tests/tests/tier0/mta_805_sets_test.go
@@ -71,6 +71,10 @@ var _ = Describe("Sets resources migration", func() {
 
 		paths, err := NewScenarioPaths("crane-export-*")
 		Expect(err).NotTo(HaveOccurred())
+		exportOpts := ExportOptions{Namespace: namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
 
 		DeferCleanup(func() {
 			By("Cleanup source and target resources")
@@ -83,7 +87,7 @@ var _ = Describe("Sets resources migration", func() {
 
 		By("Run crane export/transform/apply pipeline")
 		log.Printf("Running crane pipeline for namespace %s\n", srcApp.Namespace)
-		Expect(RunCranePipelineWithChecks(runner, namespace, paths)).NotTo(HaveOccurred())
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 		log.Printf("Crane pipeline completed for namespace %s\n", srcApp.Namespace)
 
 		By("Validate output directory contains DaemonSet , ReplicaSet and StatefulSet resource manifest")

--- a/e2e-tests/tests/tier0/mta_806_pvc_data_integrity_test.go
+++ b/e2e-tests/tests/tier0/mta_806_pvc_data_integrity_test.go
@@ -59,6 +59,10 @@ var _ = Describe("PVC data integrity migration", func() {
 
 		paths, err := NewScenarioPaths("crane-export-*")
 		Expect(err).NotTo(HaveOccurred())
+		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
 		DeferCleanup(func() {
 			By("Cleanup temp directory")
 			if paths.TempDir != "" {
@@ -103,7 +107,7 @@ var _ = Describe("PVC data integrity migration", func() {
 		log.Printf("Running crane pipeline for namespace %s\n", srcApp.Namespace)
 		runner := scenario.CraneNonAdmin
 		runner.WorkDir = paths.TempDir
-		Expect(RunCranePipelineWithChecks(runner, srcApp.Namespace, paths)).NotTo(HaveOccurred())
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 		log.Printf("Crane pipeline completed for source namespace %s\n", srcApp.Namespace)
 
 		By("Transfer PVCs")

--- a/e2e-tests/tests/tier0/mta_807_data_validation_test.go
+++ b/e2e-tests/tests/tier0/mta_807_data_validation_test.go
@@ -182,6 +182,10 @@ var _ = Describe("Data validation with indirect migration of MySQL DB", func() {
 
 		paths, err := NewScenarioPaths("crane-export-*")
 		Expect(err).NotTo(HaveOccurred())
+		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
 
 		DeferCleanup(func() {
 			By("Cleanup source and target resources")
@@ -235,7 +239,7 @@ var _ = Describe("Data validation with indirect migration of MySQL DB", func() {
 		By("Run crane export/transform/apply pipeline")
 		log.Printf("Running crane pipeline for namespace %s\n", srcApp.Namespace)
 		runner.WorkDir = paths.TempDir
-		Expect(RunCranePipelineWithChecks(runner, srcApp.Namespace, paths)).NotTo(HaveOccurred())
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 		log.Printf("Crane pipeline completed for namespace %s\n", srcApp.Namespace)
 
 		By("Transfer PVCs")

--- a/e2e-tests/tests/tier0/mta_808_cronjob_quiesced_test.go
+++ b/e2e-tests/tests/tier0/mta_808_cronjob_quiesced_test.go
@@ -110,6 +110,10 @@ var _ = Describe("Cronjob Quiesced", func() {
 		var err error
 		paths, err = NewScenarioPaths("crane-export-*")
 		Expect(err).NotTo(HaveOccurred())
+		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
 
 		By("Verify source cronjob runs and emits expected log")
 		sourcePodName := waitForLatestCronPod(kubectlSrc)
@@ -127,7 +131,7 @@ var _ = Describe("Cronjob Quiesced", func() {
 		runner.WorkDir = paths.TempDir
 		By("Run crane export/transform/apply pipeline")
 		log.Printf("Running crane pipeline for namespace %s\n", srcApp.Namespace)
-		Expect(RunCranePipelineWithChecks(runner, srcApp.Namespace, paths)).NotTo(HaveOccurred())
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 		log.Printf("Crane pipeline completed for namespace %s\n", srcApp.Namespace)
 
 		By("Apply rendered manifests to target")

--- a/e2e-tests/tests/tier0/mta_809_initcontainer_test.go
+++ b/e2e-tests/tests/tier0/mta_809_initcontainer_test.go
@@ -62,6 +62,10 @@ var _ = Describe("InitContainer Migration", func() {
 
 		paths, err := NewScenarioPaths("crane-export-*")
 		Expect(err).NotTo(HaveOccurred())
+		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
 		DeferCleanup(func() {
 			By("Cleanup source and target resources")
 			if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
@@ -72,7 +76,7 @@ var _ = Describe("InitContainer Migration", func() {
 		runner.WorkDir = paths.TempDir
 		By("Run crane export/transform/apply pipeline")
 		log.Printf("Running crane pipeline for namespace %s\n", srcApp.Namespace)
-		Expect(RunCranePipelineWithChecks(runner, srcApp.Namespace, paths)).NotTo(HaveOccurred())
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 		log.Printf("Crane pipeline completed for namespace %s\n", srcApp.Namespace)
 
 		By("Validate the output directory Deployment has an init container")

--- a/e2e-tests/tests/tier0/mta_810_configmap_test.go
+++ b/e2e-tests/tests/tier0/mta_810_configmap_test.go
@@ -61,6 +61,10 @@ var _ = Describe("ConfigMap Migration", func() {
 
 		paths, err := NewScenarioPaths("crane-export-*")
 		Expect(err).NotTo(HaveOccurred())
+		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
 		DeferCleanup(func() {
 			By("Cleanup source and target resources")
 			if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
@@ -70,7 +74,7 @@ var _ = Describe("ConfigMap Migration", func() {
 		runner.WorkDir = paths.TempDir
 		By("Run crane export/transform/apply pipeline")
 		log.Printf("Running crane pipeline for namespace %s\n", srcApp.Namespace)
-		Expect(RunCranePipelineWithChecks(runner, srcApp.Namespace, paths)).NotTo(HaveOccurred())
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 		log.Printf("Crane pipeline completed for namespace %s\n", srcApp.Namespace)
 
 		By("Verify the output directory ConfigMap has the correct data")

--- a/e2e-tests/tests/tier0/mta_811_mongodb_non_admin_test.go
+++ b/e2e-tests/tests/tier0/mta_811_mongodb_non_admin_test.go
@@ -146,7 +146,10 @@ var _ = Describe("MongoDB Migration", func() {
 
 		paths, err := NewScenarioPaths("crane-export-*")
 		Expect(err).NotTo(HaveOccurred())
-		
+		exportOpts := ExportOptions{Namespace: namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
 		DeferCleanup(func() {
 			By("Cleanup source and target resources")
 			if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
@@ -201,7 +204,7 @@ var _ = Describe("MongoDB Migration", func() {
 
 		By("Run crane export/transform/apply pipeline")
 		runner.WorkDir = paths.TempDir
-		Expect(RunCranePipelineWithChecks(runner, namespace, paths)).NotTo(HaveOccurred())
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 		log.Printf("Crane pipeline completed for namespace %s", namespace)
 
 		By("Apply rendered manifests to target")

--- a/e2e-tests/tests/tier0/mta_812_role_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_812_role_migration_test.go
@@ -95,6 +95,10 @@ var _ = Describe("Role and RoleBinding migration", func() {
 
 		paths, err := NewScenarioPaths("crane-export-*")
 		Expect(err).NotTo(HaveOccurred())
+		exportOpts := ExportOptions{Namespace: namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
 		DeferCleanup(func() {
 			By("Cleanup source and target resources")
 			if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
@@ -106,7 +110,7 @@ var _ = Describe("Role and RoleBinding migration", func() {
 
 		By("Run crane export/transform/apply pipeline")
 		log.Printf("Running crane pipeline for namespace %s\n", namespace)
-		Expect(RunCranePipelineWithChecks(runner, namespace, paths)).NotTo(HaveOccurred())
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 		log.Printf("Crane pipeline completed for namespace %s\n", namespace)
 
 		By("Verify Role manifest is present in output directory")

--- a/e2e-tests/tests/tier0/mta_813_cronJob_PVC_test.go
+++ b/e2e-tests/tests/tier0/mta_813_cronJob_PVC_test.go
@@ -70,6 +70,10 @@ var _ = Describe("CronJob with attached PVC migration as non-admin user", func()
 
 		paths, err := NewScenarioPaths("crane-export-*")
 		Expect(err).NotTo(HaveOccurred())
+		exportOpts := ExportOptions{Namespace: namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
 		DeferCleanup(func() {
 			By("Cleanup source and target resources")
 			if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
@@ -162,7 +166,7 @@ var _ = Describe("CronJob with attached PVC migration as non-admin user", func()
 		runner.WorkDir = paths.TempDir
 		By("Run crane export/transform/apply pipeline as non-admin")
 		log.Printf("Running crane pipeline for namespace %s\n", srcApp.Namespace)
-		Expect(RunCranePipelineWithChecks(runner, srcApp.Namespace, paths)).NotTo(HaveOccurred())
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 		log.Printf("Crane pipeline completed for namespace %s\n", srcApp.Namespace)
 
 		By("Transfer PVC from source to target")
@@ -205,7 +209,7 @@ var _ = Describe("CronJob with attached PVC migration as non-admin user", func()
 
 		By("Apply rendered manifests to target as non-admin")
 		log.Printf("Applying manifests from %s to namespace %s\n", paths.OutputDir, tgtApp.Namespace)
-		Expect(ApplyOutputToTargetNonAdmin(scenario.KubectlTgtNonAdmin	, paths.OutputDir)).NotTo(HaveOccurred())
+		Expect(ApplyOutputToTargetNonAdmin(scenario.KubectlTgtNonAdmin, paths.OutputDir)).NotTo(HaveOccurred())
 		log.Printf("Manifests applied to target\n")
 
 		By("Verify CronJob landed on target with correct schedule")

--- a/e2e-tests/tests/tier0/mta_817_stateless_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_817_stateless_migration_test.go
@@ -35,6 +35,10 @@ var _ = Describe("Stateless migration", func() {
 
 		paths, err := NewScenarioPaths("crane-export-*")
 		Expect(err).NotTo(HaveOccurred())
+		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
 		DeferCleanup(func() {
 			By("Cleanup source and target resources")
 			if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
@@ -48,7 +52,7 @@ var _ = Describe("Stateless migration", func() {
 		WaitForSourceQuiesce(kubectlSrc, namespace, "app="+appName, serviceName)
 
 		log.Printf("Running crane pipeline for namespace %s\n", srcApp.Namespace)
-		Expect(RunCranePipelineWithChecks(runner, srcApp.Namespace, paths)).NotTo(HaveOccurred())
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 		log.Printf("Crane pipeline completed for namespace %s\n", srcApp.Namespace)
 
 		By("Compare YAML semantic diff of golden and actual export files")

--- a/e2e-tests/tests/tier0/mta_827_custom_transformation_stage_test.go
+++ b/e2e-tests/tests/tier0/mta_827_custom_transformation_stage_test.go
@@ -94,12 +94,12 @@ var _ = Describe("Custom transformation stage", func() {
 		WaitForSourceQuiesce(kubectlSrcNonAdmin, namespace, "app="+appName, serviceName)
 
 		log.Printf("Running crane export for namespace %s\n", srcApp.Namespace)
-		Expect(runner.Export(srcApp.Namespace, paths.ExportDir)).NotTo(HaveOccurred())
+		Expect(runner.Export(ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir})).NotTo(HaveOccurred())
 		log.Printf("Running crane transform default stage for namespace %s\n", srcApp.Namespace)
-		Expect(runner.Transform(paths.ExportDir, paths.TransformDir)).NotTo(HaveOccurred())
+		Expect(runner.Transform(TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir})).NotTo(HaveOccurred())
 		log.Printf("Running crane transform with specific stage for namespace %s\n", srcApp.Namespace)
-		Expect(runner.TransformStage(paths.ExportDir, paths.TransformDir, "50_CustomModifications")).NotTo(HaveOccurred())
-
+		Expect(runner.Transform(TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			Stages: []string{"50_CustomModifications"}})).NotTo(HaveOccurred())
 		By("Update custom stage kustomization with namespace, labels, and image override")
 		stageDir := filepath.Join(paths.TransformDir, "50_CustomModifications")
 		kustomizationPath := filepath.Join(stageDir, "kustomization.yaml")
@@ -159,7 +159,8 @@ var _ = Describe("Custom transformation stage", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		log.Printf("Running crane apply for namespace %s\n", srcApp.Namespace)
-		Expect(runner.Apply(paths.ExportDir, paths.TransformDir, paths.OutputDir)).NotTo(HaveOccurred())
+		Expect(runner.Apply(ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir})).NotTo(HaveOccurred())
 		log.Printf("Crane pipeline completed for namespace %s\n", srcApp.Namespace)
 
 		By("Verify rendered output contains custom stage changes")

--- a/e2e-tests/tests/tier0/mta_828_instructions_file_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_828_instructions_file_migration_test.go
@@ -72,11 +72,13 @@ var _ = Describe("Instructions-file migration", func() {
 		runner.WorkDir = paths.TempDir
 		By("Run crane export/transform/apply pipeline with instructions file")
 		log.Printf("Running crane export for namespace %s\n", srcApp.Namespace)
-		Expect(runner.Export(srcApp.Namespace, paths.ExportDir)).NotTo(HaveOccurred())
+		Expect(runner.Export(ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir})).NotTo(HaveOccurred())
 		log.Printf("Running crane transform --instructions-file for namespace %s\n", srcApp.Namespace)
 		instructionsFile, err := utils.TestdataFilePath("basic-instructions-file.yaml")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(runner.TransformWithInstructionsFile(paths.ExportDir, paths.TransformDir, instructionsFile, false)).NotTo(HaveOccurred())
+		Expect(runner.Transform(TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			InstructionsFile: instructionsFile, Force: false})).NotTo(HaveOccurred())
+
 		By("Assert instructions-file stages are present as stage-directories in transform dir")
 		stageDirectories := []string{"10_KubernetesPlugin", "20_CustomStage"}
 		for _, stageDir := range stageDirectories {
@@ -148,7 +150,8 @@ var _ = Describe("Instructions-file migration", func() {
 		}
 
 		log.Printf("Running crane apply for namespace %s\n", srcApp.Namespace)
-		Expect(runner.Apply(paths.ExportDir, paths.TransformDir, paths.OutputDir)).NotTo(HaveOccurred())
+		Expect(runner.Apply(ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir})).NotTo(HaveOccurred())
 		log.Printf("Crane pipeline completed for namespace %s\n", srcApp.Namespace)
 
 		By("Apply rendered manifests to target")

--- a/e2e-tests/tests/tier0/mta_831_validate_compatible_resources_offline_test.go
+++ b/e2e-tests/tests/tier0/mta_831_validate_compatible_resources_offline_test.go
@@ -62,6 +62,10 @@ var _ = Describe("Crane validate: all compatible standard resources in offline m
 
 		paths, err := NewScenarioPaths("crane-validate-offline-*")
 		Expect(err).NotTo(HaveOccurred())
+		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
 		DeferCleanup(func() {
 			By("Cleanup source and target resources")
 			if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
@@ -72,7 +76,7 @@ var _ = Describe("Crane validate: all compatible standard resources in offline m
 		runner.WorkDir = paths.TempDir
 		By("Run crane export/transform/apply pipeline")
 		log.Printf("Running crane pipeline for namespace %s\n", srcApp.Namespace)
-		Expect(RunCranePipelineWithChecks(runner, srcApp.Namespace, paths)).NotTo(HaveOccurred())
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 		log.Printf("Crane pipeline completed for namespace %s\n", srcApp.Namespace)
 
 		By("Capture API surface from target cluster")

--- a/e2e-tests/tests/tier0/mta_833_compatible_resources_live_test.go
+++ b/e2e-tests/tests/tier0/mta_833_compatible_resources_live_test.go
@@ -59,17 +59,21 @@ var _ = Describe("Crane validate: all compatible standard resources in live mode
 
 		paths, err := NewScenarioPaths("crane-validate-*")
 		Expect(err).NotTo(HaveOccurred())
+		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
 		DeferCleanup(func() {
 			By("Cleanup source and target resources")
 			if err := CleanupScenario(paths.TempDir, srcApp, scenario.TgtApp); err != nil {
 				log.Printf("cleanup: %v", err)
 			}
 		})
-		
+
 		runner.WorkDir = paths.TempDir
 		By("Run crane export/transform/apply pipeline")
 		log.Printf("Running crane pipeline for namespace %s\n", srcApp.Namespace)
-		Expect(RunCranePipelineWithChecks(runner, srcApp.Namespace, paths)).NotTo(HaveOccurred())
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 		log.Printf("Crane pipeline completed for namespace %s\n", srcApp.Namespace)
 
 		By("Verify output resource manifests exist for all expected kinds")
@@ -207,15 +211,15 @@ var _ = Describe("Crane validate: all compatible standard resources in live mode
 		}
 		log.Printf("All resourcePlural mappings correct ✓")
 
-		log.Printf("\n" +
-			"========================================\n" +
-			"VALIDATION SUCCESS\n" +
-			"========================================\n" +
-			"Mode: %s\n" +
-			"Context: %s\n" +
-			"Total Scanned: %d\n" +
-			"Compatible: %d\n" +
-			"Incompatible: %d\n" +
+		log.Printf("\n"+
+			"========================================\n"+
+			"VALIDATION SUCCESS\n"+
+			"========================================\n"+
+			"Mode: %s\n"+
+			"Context: %s\n"+
+			"Total Scanned: %d\n"+
+			"Compatible: %d\n"+
+			"Incompatible: %d\n"+
 			"========================================\n",
 			report.Mode, report.ClusterContext,
 			report.TotalScanned, report.Compatible, report.Incompatible)

--- a/e2e-tests/tests/tier0/mta_837_hpa_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_837_hpa_migration_test.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"path/filepath"
 
-
 	"github.com/konveyor/crane/e2e-tests/config"
 	. "github.com/konveyor/crane/e2e-tests/framework"
 	"github.com/konveyor/crane/e2e-tests/utils"
@@ -23,9 +22,9 @@ var _ = Describe("HPA migration", func() {
 		serviceName := "my-" + appName
 
 		const (
-			hpaMinReplicas     = 1
-			hpaMaxReplicas     = 5
-			hpaCPUUtilization  = 50
+			hpaMinReplicas    = 1
+			hpaMaxReplicas    = 5
+			hpaCPUUtilization = 50
 		)
 
 		scenario := NewMigrationScenario(
@@ -55,6 +54,10 @@ var _ = Describe("HPA migration", func() {
 		Expect(json.Unmarshal([]byte(hpaOut), &hpaSrc)).NotTo(HaveOccurred())
 
 		paths, err := NewScenarioPaths("crane-export-*")
+		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() {
 			By("Cleanup source and target resources")
@@ -71,7 +74,7 @@ var _ = Describe("HPA migration", func() {
 
 		By("Run crane export/transform/apply pipeline")
 		log.Printf("Running crane pipeline for namespace %s\n", srcApp.Namespace)
-		Expect(RunCranePipelineWithChecks(runner, srcApp.Namespace, paths)).NotTo(HaveOccurred())
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 		log.Printf("Crane pipeline completed for namespace %s\n", srcApp.Namespace)
 
 		By("Verify HPA manifest is present in output directory")

--- a/e2e-tests/tests/tier0/mta_844_validate_mixed_resources_live_test.go
+++ b/e2e-tests/tests/tier0/mta_844_validate_mixed_resources_live_test.go
@@ -61,6 +61,10 @@ var _ = Describe("Crane validate: mixed compatible and incompatible resources in
 		log.Printf("Source app %s prepared successfully\n", srcApp.Name)
 
 		paths, err := NewScenarioPaths("crane-validate-mixed-*")
+		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() {
 			By("Cleanup source and target resources")
@@ -72,7 +76,7 @@ var _ = Describe("Crane validate: mixed compatible and incompatible resources in
 		runner.WorkDir = paths.TempDir
 		By("Run crane export/transform/apply pipeline")
 		log.Printf("Running crane pipeline for namespace %s\n", srcApp.Namespace)
-		Expect(RunCranePipelineWithChecks(runner, srcApp.Namespace, paths)).NotTo(HaveOccurred())
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 		log.Printf("Crane pipeline completed for namespace %s\n", srcApp.Namespace)
 
 		By("Mutate Deployment to deprecated extensions/v1beta1 API version")
@@ -109,9 +113,9 @@ var _ = Describe("Crane validate: mixed compatible and incompatible resources in
 		By("Run crane validate in live mode against target context")
 		validateDir := filepath.Join(paths.TempDir, "validate")
 		stdout, err := runner.Validate(ValidateOptions{
-			Context:     scenario.KubectlTgtNonAdmin.Context,
-			InputDir:    filepath.Join(paths.OutputDir, "resources", namespace),
-			ValidateDir: validateDir,
+			Context:      scenario.KubectlTgtNonAdmin.Context,
+			InputDir:     filepath.Join(paths.OutputDir, "resources", namespace),
+			ValidateDir:  validateDir,
 			OutputFormat: "json",
 		})
 
@@ -139,7 +143,7 @@ var _ = Describe("Crane validate: mixed compatible and incompatible resources in
 		Expect(report.TotalScanned).To(BeNumerically(">=", 4), "expected at least 4 resources scanned")
 		Expect(report.Compatible).To((Equal(3)), "expected 3 compatible resources")
 		Expect(report.Incompatible).To(Equal(2), "expected exactly 2 incompatible resources (Deployment and ConfigMap)")
-		Expect(report.Compatible + report.Incompatible).To(Equal(report.TotalScanned),
+		Expect(report.Compatible+report.Incompatible).To(Equal(report.TotalScanned),
 			"expected Compatible + Incompatible to equal TotalScanned (found %d + %d != %d)",
 			report.Compatible, report.Incompatible, report.TotalScanned)
 		log.Printf("Total: %d, Compatible: %d, Incompatible: %d", report.TotalScanned, report.Compatible, report.Incompatible)

--- a/e2e-tests/tests/tier0/mta_845_validate_mixed_resources_offline_test.go
+++ b/e2e-tests/tests/tier0/mta_845_validate_mixed_resources_offline_test.go
@@ -59,6 +59,10 @@ var _ = Describe("Crane validate: mixed compatible and incompatible resources in
 
 		paths, err := NewScenarioPaths("crane-validate-mixed-offline-*")
 		Expect(err).NotTo(HaveOccurred())
+		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
 		DeferCleanup(func() {
 			By("Cleanup source and target resources")
 			if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
@@ -74,7 +78,7 @@ var _ = Describe("Crane validate: mixed compatible and incompatible resources in
 		runner.WorkDir = paths.TempDir
 		By("Run crane export/transform pipeline")
 		log.Printf("Running crane pipeline for namespace %s\n", srcApp.Namespace)
-		Expect(RunCranePipelineWithChecks(runner, srcApp.Namespace, paths)).NotTo(HaveOccurred())
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 		log.Printf("Crane pipeline completed for namespace %s\n", srcApp.Namespace)
 
 		By("Mutate Deployment to deprecated extensions/v1beta1 API version")
@@ -158,7 +162,7 @@ var _ = Describe("Crane validate: mixed compatible and incompatible resources in
 		Expect(report.TotalScanned).To(BeNumerically(">=", 4), "expected at least 4 resources scanned")
 		Expect(report.Compatible).To(BeNumerically(">", 0), "expected some compatible resources")
 		Expect(report.Incompatible).To(Equal(1), "expected exactly 1 incompatible resource (Deployment)")
-		Expect(report.Compatible + report.Incompatible).To(Equal(report.TotalScanned),
+		Expect(report.Compatible+report.Incompatible).To(Equal(report.TotalScanned),
 			"expected Compatible + Incompatible to equal TotalScanned (found %d + %d != %d)",
 			report.Compatible, report.Incompatible, report.TotalScanned)
 		log.Printf("Total: %d, Compatible: %d, Incompatible: %d", report.TotalScanned, report.Compatible, report.Incompatible)

--- a/e2e-tests/tests/tier0/olm_whiteout_base_test.go
+++ b/e2e-tests/tests/tier0/olm_whiteout_base_test.go
@@ -52,7 +52,10 @@ var _ = Describe("OLM whiteout", func() {
 
 			paths, err := NewScenarioPaths("crane-export-*")
 			Expect(err).NotTo(HaveOccurred())
-
+			exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
+			transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+			applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+				OutputDir: paths.OutputDir}
 			DeferCleanup(func() {
 				By("Cleanup source and target resources")
 				if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
@@ -77,7 +80,7 @@ var _ = Describe("OLM whiteout", func() {
 
 			By("Run crane export/transform/apply pipeline")
 			log.Printf("Running crane pipeline for namespace %s\n", srcApp.Namespace)
-			Expect(RunCranePipelineWithChecks(runner, srcApp.Namespace, paths)).NotTo(HaveOccurred())
+			Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 			log.Printf("Crane pipeline completed for namespace %s", srcApp.Namespace)
 
 			By("Verify output directory does not contain OLM whiteout kinds")

--- a/e2e-tests/tests/tier1/mta_829_validate_alternative_gv_suggestion_test.go
+++ b/e2e-tests/tests/tier1/mta_829_validate_alternative_gv_suggestion_test.go
@@ -57,6 +57,10 @@ var _ = Describe("Validate alternative GV suggestion [Live Mode]", func() {
 		log.Printf("Source app %s prepared successfully\n", srcApp.Name)
 		paths, err := NewScenarioPaths("crane-pipeline-*")
 		Expect(err).NotTo(HaveOccurred())
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
+		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
 		DeferCleanup(func() {
 			By("Cleanup source and target resources")
 			if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
@@ -67,7 +71,7 @@ var _ = Describe("Validate alternative GV suggestion [Live Mode]", func() {
 		runner.WorkDir = paths.TempDir
 		By("Run crane export/transform/apply pipeline")
 		log.Printf("Running crane pipeline for namespace %s\n", srcApp.Namespace)
-		Expect(RunCranePipelineWithChecks(runner, srcApp.Namespace, paths)).NotTo(HaveOccurred())
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 		log.Printf("Crane pipeline completed for namespace %s\n", srcApp.Namespace)
 
 		By("Mutate deployment apiversion to extensions/v1beta1")

--- a/e2e-tests/tests/tier1/mta_830_instructions_file_force_reconcile_test.go
+++ b/e2e-tests/tests/tier1/mta_830_instructions_file_force_reconcile_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Instructions-file force reconcile migration", func() {
 		runner.WorkDir = paths.TempDir
 		By("Run crane export/transform/apply pipeline with instructions file")
 		log.Printf("Running crane export for namespace %s\n", srcApp.Namespace)
-		Expect(runner.Export(srcApp.Namespace, paths.ExportDir)).NotTo(HaveOccurred())
+		Expect(runner.Export(ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir})).NotTo(HaveOccurred())
 
 		By("Create transform dir with orphan stage and existing stage present in instructions-file")
 		err = os.MkdirAll(paths.TransformDir, 0o755)
@@ -116,7 +116,8 @@ var _ = Describe("Instructions-file force reconcile migration", func() {
 		log.Printf("Running crane transform --instructions-file for namespace %s\n", srcApp.Namespace)
 		instructionsFile, err := utils.TestdataFilePath("basic-instructions-file.yaml")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(runner.TransformWithInstructionsFile(paths.ExportDir, paths.TransformDir, instructionsFile, true)).NotTo(HaveOccurred())
+		Expect(runner.Transform(TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			InstructionsFile: instructionsFile, Force: true})).NotTo(HaveOccurred())
 
 		By("Assert post transform orphan stage is removed and existing CustomStage is overwritten ")
 		By("Assert orphan stage dir is removed by --force")
@@ -141,7 +142,8 @@ var _ = Describe("Instructions-file force reconcile migration", func() {
 		}
 
 		log.Printf("Running crane apply for namespace %s\n", srcApp.Namespace)
-		Expect(runner.Apply(paths.ExportDir, paths.TransformDir, paths.OutputDir)).NotTo(HaveOccurred())
+		Expect(runner.Apply(ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir})).NotTo(HaveOccurred())
 		log.Printf("Crane pipeline completed for namespace %s\n", srcApp.Namespace)
 
 		By("Apply rendered manifests to target")

--- a/e2e-tests/tests/tier1/mta_832_validate_alternative_gv_suggestion_offline_test.go
+++ b/e2e-tests/tests/tier1/mta_832_validate_alternative_gv_suggestion_offline_test.go
@@ -60,6 +60,11 @@ var _ = Describe("Validate alternative GV suggestion [Offline Mode]", func() {
 		log.Printf("Source app %s prepared successfully\n", srcApp.Name)
 		paths, err := NewScenarioPaths("crane-pipeline-*")
 		Expect(err).NotTo(HaveOccurred())
+		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
+			
 		DeferCleanup(func() {
 			By("Cleanup source and target resources")
 			if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
@@ -70,7 +75,7 @@ var _ = Describe("Validate alternative GV suggestion [Offline Mode]", func() {
 		runner.WorkDir = paths.TempDir
 		By("Run crane export/transform/apply pipeline")
 		log.Printf("Running crane pipeline for namespace %s\n", srcApp.Namespace)
-		Expect(RunCranePipelineWithChecks(runner, srcApp.Namespace, paths)).NotTo(HaveOccurred())
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 		log.Printf("Crane pipeline completed for namespace %s\n", srcApp.Namespace)
 
 		By("Mutate deployment apiversion to extensions/v1beta1")

--- a/e2e-tests/tests/tier1/mta_836_validate_core_group_omitted_offline_test.go
+++ b/e2e-tests/tests/tier1/mta_836_validate_core_group_omitted_offline_test.go
@@ -64,6 +64,11 @@ var _ = Describe("Validate core group omission [Offline Mode]", func() {
 
 		paths, err := NewScenarioPaths("crane-validate-offline-*")
 		Expect(err).NotTo(HaveOccurred())
+		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
+
 		DeferCleanup(func() {
 			By("Cleanup source and target resources")
 			if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
@@ -74,7 +79,7 @@ var _ = Describe("Validate core group omission [Offline Mode]", func() {
 		runner.WorkDir = paths.TempDir
 		By("Run crane export/transform/apply pipeline")
 		log.Printf("Running crane pipeline for namespace %s\n", srcApp.Namespace)
-		Expect(RunCranePipelineWithChecks(runner, srcApp.Namespace, paths)).NotTo(HaveOccurred())
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 		log.Printf("Crane pipeline completed for namespace %s\n", srcApp.Namespace)
 
 		By("Capture target cluster api surface in a api-surface.json file")

--- a/e2e-tests/tests/tier1/olm_whiteout_auditability_test.go
+++ b/e2e-tests/tests/tier1/olm_whiteout_auditability_test.go
@@ -90,11 +90,10 @@ var _ = Describe("OLM whiteout", func() {
 			runner.WorkDir = paths.TempDir
 
 			By("Run crane export")
-			Expect(runner.Export(namespace, paths.ExportDir)).NotTo(HaveOccurred())
+			Expect(runner.Export(ExportOptions{Namespace: namespace, ExportDir: paths.ExportDir})).NotTo(HaveOccurred())
 
 			By("Run crane transform")
-			Expect(runner.Transform(paths.ExportDir, paths.TransformDir)).NotTo(HaveOccurred())
-
+			Expect(runner.Transform(TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir})).NotTo(HaveOccurred())
 			olmKindsDeployed := []string{"Subscription", "CatalogSource", "OperatorGroup"}
 
 			By("Verify whiteout resource files exist in transform input/ directory")
@@ -107,7 +106,8 @@ var _ = Describe("OLM whiteout", func() {
 			Expect(utils.AssertKindsNotInActiveKustomizeResources(paths.TransformDir, olmWhiteoutKinds)).NotTo(HaveOccurred())
 
 			By("Run crane apply")
-			Expect(runner.Apply(paths.ExportDir, paths.TransformDir, paths.OutputDir)).NotTo(HaveOccurred())
+			Expect(runner.Apply(ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+				OutputDir: paths.OutputDir})).NotTo(HaveOccurred())
 
 			By("Verify output does not contain OLM whiteout kinds")
 			Expect(utils.AssertNoKindsInOutput(paths.OutputDir, olmWhiteoutKinds)).NotTo(HaveOccurred())
@@ -139,7 +139,10 @@ var _ = Describe("OLM whiteout", func() {
 
 			paths, err := NewScenarioPaths("crane-multi-op-*")
 			Expect(err).NotTo(HaveOccurred())
-
+			applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+				OutputDir: paths.OutputDir}
+			exportOpts := ExportOptions{Namespace: namespace, ExportDir: paths.ExportDir}
+			transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
 			DeferCleanup(func() {
 				By("Cleanup OLM resources on source")
 				for _, res := range []struct {
@@ -200,7 +203,7 @@ var _ = Describe("OLM whiteout", func() {
 
 			By("Run crane export/transform/apply pipeline")
 			log.Printf("Running crane pipeline for namespace %s\n", namespace)
-			Expect(RunCranePipelineWithChecks(runner, namespace, paths)).NotTo(HaveOccurred())
+			Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 
 			By("Verify no OLM whiteout kinds in output")
 			Expect(utils.AssertNoKindsInOutput(paths.OutputDir, olmWhiteoutKinds)).NotTo(HaveOccurred())
@@ -246,7 +249,10 @@ var _ = Describe("OLM whiteout", func() {
 
 			paths, err := NewScenarioPaths("crane-export-*")
 			Expect(err).NotTo(HaveOccurred())
-
+			applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+				OutputDir: paths.OutputDir}
+			exportOpts := ExportOptions{Namespace: namespace, ExportDir: paths.ExportDir}
+			transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
 			DeferCleanup(func() {
 				By("Cleanup OLM resources on source")
 				for _, res := range []struct {
@@ -295,7 +301,7 @@ var _ = Describe("OLM whiteout", func() {
 
 			By("Run crane export/transform/apply pipeline")
 			log.Printf("Running crane pipeline for namespace %s\n", namespace)
-			Expect(RunCranePipelineWithChecks(runner, namespace, paths)).NotTo(HaveOccurred())
+			Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 			log.Printf("Crane pipeline completed for namespace %s", namespace)
 
 			By("Verify output does not contain OLM whiteout kinds")


### PR DESCRIPTION
## Summary

- Add `ExportOptions`, `TransformOptions`, and `ApplyOptions` structs to `e2e-tests/framework/crane.go` with fields matching the product's CLI flags
- Add struct-based `Export()`, `Transform()`, and `Apply()` methods on `CraneRunner` that build CLI args from the new structs
- Update `RunCranePipeline` and `RunCranePipelineWithChecks` in `pipeline.go` to accept the new option structs instead of individual string args
- Refactor all 22 test files across `tier0/` and `tier1/` to construct option structs and pass them to the updated framework functions
- Remove the now-unused `TransformStage()` and `TransformWithInstructionsFile()` methods, consolidating their behavior into `TransformOptions` fields (`Stages`, `InstructionsFile`, `Force`)

## Why

The old framework API passed directories and flags as positional string arguments (`Export(namespace, exportDir)`, `Transform(exportDir, transformDir)`, etc.). Adding a new flag meant changing every caller. The new struct-based API keeps the test infrastructure consistent and makes it straightforward to expose new options without touching test call sites that don't need them.

## Test plan

- [ ] Verify `go build ./e2e-tests/...` compiles without errors
- [ ] Run a subset of tier0 tests (e.g. mta_817 stateless migration) to confirm the refactored pipeline calls work end-to-end
- [ ] Verify that tests using non-pipeline calls (mta_827 custom stage, mta_828 instructions file, olm_whiteout_auditability) still pass with the new `Export(ExportOptions{...})` / `Transform(TransformOptions{...})` / `Apply(ApplyOptions{...})` signatures



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the crane export/transform/apply pipeline and runner APIs to use structured option objects for each stage, standardizing which CLI flags are applied (including namespace, selectors, CRD include/skip groups, QPS/burst, plugin/patch controls, and stage selection).
  * Added option-based pipeline execution with cross-option directory consistency checks.
* **Bug Fixes**
  * Improved transform error reporting by using the generic crane transform failure format.
* **Tests**
  * Refreshed tier0/tier1 end-to-end test wiring to call the new options-based pipeline and runner APIs; test assertions and flows remain the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->