### PR TITLE
Fix bug 418: Validation around --context and other flags

### DIFF
--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -89,6 +89,21 @@ func (o *ExportOptions) Complete(c *cobra.Command, args []string) error {
 
 // Validate checks flag combinations (e.g. --as-extras requires impersonation).
 func (o *ExportOptions) Validate() error {
+	if o.configFlags.Context != nil && *o.configFlags.Context != "" {
+		for _, f := range []struct {
+			flag string
+			val  *string
+		}{
+			{"--cluster", o.configFlags.ClusterName},
+			{"--server", o.configFlags.APIServer},
+			{"--user", o.configFlags.AuthInfoName},
+			{"--token", o.configFlags.BearerToken},
+		} {
+			if f.val != nil && *f.val != "" {
+				return fmt.Errorf("cannot use --context with %s; it overrides the value defined in the context", f.flag)
+			}
+		}
+	}
 	if o.asExtras != "" && *o.configFlags.Impersonate == "" && len(*o.configFlags.ImpersonateGroup) == 0 {
 		return fmt.Errorf("extras requires specifying a user or group to impersonate")
 	}

--- a/cmd/export/export_test.go
+++ b/cmd/export/export_test.go
@@ -197,6 +197,101 @@ func TestValidate(t *testing.T) {
 	}
 }
 
+func TestValidate_ContextConflicts(t *testing.T) {
+	ptr := func(s string) *string { return &s }
+
+	tests := []struct {
+		name       string
+		context    *string
+		cluster    *string
+		server     *string
+		user       *string
+		token      *string
+		wantErr    bool
+		wantSubstr string
+	}{
+		{
+			name:    "context alone - ok",
+			context: ptr("my-ctx"),
+		},
+		{
+			name:       "context with cluster - error",
+			context:    ptr("my-ctx"),
+			cluster:    ptr("my-cluster"),
+			wantErr:    true,
+			wantSubstr: "--cluster",
+		},
+		{
+			name:       "context with server - error",
+			context:    ptr("my-ctx"),
+			server:     ptr("https://localhost:6443"),
+			wantErr:    true,
+			wantSubstr: "--server",
+		},
+		{
+			name:       "context with user - error",
+			context:    ptr("my-ctx"),
+			user:       ptr("admin"),
+			wantErr:    true,
+			wantSubstr: "--user",
+		},
+		{
+			name:       "context with token - error",
+			context:    ptr("my-ctx"),
+			token:      ptr("my-token"),
+			wantErr:    true,
+			wantSubstr: "--token",
+		},
+		{
+			name:    "no context with cluster - ok",
+			cluster: ptr("my-cluster"),
+		},
+		{
+			name:   "no context with server - ok",
+			server: ptr("https://localhost:6443"),
+		},
+		{
+			name:    "empty context with cluster - ok",
+			context: ptr(""),
+			cluster: ptr("my-cluster"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := &ExportOptions{
+				configFlags: genericclioptions.NewConfigFlags(true),
+			}
+			if tt.context != nil {
+				o.configFlags.Context = tt.context
+			}
+			if tt.cluster != nil {
+				o.configFlags.ClusterName = tt.cluster
+			}
+			if tt.server != nil {
+				o.configFlags.APIServer = tt.server
+			}
+			if tt.user != nil {
+				o.configFlags.AuthInfoName = tt.user
+			}
+			if tt.token != nil {
+				o.configFlags.BearerToken = tt.token
+			}
+
+			err := o.Validate()
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantErr && err != nil && !strings.Contains(err.Error(), tt.wantSubstr) {
+				t.Fatalf("error = %q, want substring %q", err.Error(), tt.wantSubstr)
+			}
+		})
+	}
+}
+
 func TestNewExportCommand(t *testing.T) {
 	streams := genericclioptions.NewTestIOStreamsDiscard()
 	cmd := NewExportCommand(streams, nil)


### PR DESCRIPTION
 ## Summary

  - Add validation in `ExportOptions.Validate()` to reject conflicting flag combinations when `--context` is used together with `--cluster`, `--server`, `--user`, or `--token`
  - These flags silently override parts of the context (cluster endpoint or credentials), creating a risk of exporting from the wrong cluster or authenticating as the wrong user
  - Add 8 unit test cases covering all conflict and non-conflict combinations

  Fixes #418

  ## Test plan

  - [x] Unit tests pass (`go test ./cmd/export/ -run TestValidate`)
  - [x] Manual verification against minikube:
    - `--context` + `--cluster` → rejected with clear error, exit 1
    - `--context` + `--server` → rejected, exit 1
    - `--context` + `--user` → rejected, exit 1
    - `--context` + `--token` → rejected, exit 1
    - `--context` alone → passes validation, export succeeds
    - No context (defaults) → succeeds
    - `--cluster` alone (no context) → succeeds
    - `--server` alone (no context) → succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration validation now prevents conflicting settings when using context configuration alongside explicit cluster, server, user, or token values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->