### PR TITLE
Proper cleanup of export directories on rewrite

### DIFF
--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -144,19 +144,18 @@ func (o *ExportOptions) Run() error {
 		return err
 	}
 
-	// create export directory if it doesnt exist
+	if err = os.RemoveAll(o.exportDir); err != nil {
+		log.Errorf("error clearing export directory: %#v", err)
+		return err
+	}
 	resourceDir := filepath.Join(o.exportDir, "resources", o.userSpecifiedNamespace)
-	err = os.MkdirAll(resourceDir, 0700)
-	switch {
-	case os.IsExist(err):
-	case err != nil:
+	if err = os.MkdirAll(resourceDir, 0700); err != nil {
 		log.Errorf("error creating the resources directory: %#v", err)
 		return err
 	}
-	// create failures directory if it doesnt exist
 	failuresDir := filepath.Join(o.exportDir, "failures", o.userSpecifiedNamespace)
-	if err = prepareFailuresDir(failuresDir); err != nil {
-		log.Errorf("error preparing the failures directory: %#v", err)
+	if err = os.MkdirAll(failuresDir, 0700); err != nil {
+		log.Errorf("error creating the failures directory: %#v", err)
 		return err
 	}
 
@@ -192,10 +191,11 @@ func (o *ExportOptions) Run() error {
 	resourceErrs = append(resourceErrs, crdErrs...)
 	resources = append(resources, crdResources...)
 
-	// After merging CRDs: prepare _cluster so hasClusterScopedManifests sees cluster-scoped CRD objects.
-	if err = prepareClusterResourceDir(clusterResourceDir, resources); err != nil {
-		log.Errorf("error preparing cluster resources directory: %#v", err)
-		return err
+	if hasClusterScopedManifests(resources) {
+		if err = os.MkdirAll(clusterResourceDir, 0700); err != nil {
+			log.Errorf("error creating cluster resources directory: %#v", err)
+			return err
+		}
 	}
 
 	//count and log the no of crds


### PR DESCRIPTION
## Summary

  - Clean up the entire `--export-dir` on every `crane export` run by calling `os.RemoveAll` before recreating subdirectories
  - Previously, `resources/<namespace>/` was never cleaned — stale YAML files from deleted resources survived re-exports and could be silently applied to the target cluster
  - `failures/<namespace>/` and `_cluster/` already had cleanup; this makes `resources/<namespace>/` consistent and simplifies the logic by wiping the whole export directory upfront
  - Remove now-redundant `prepareClusterResourceDir` and `prepareFailuresDir` calls — all subdirectories are created with plain `os.MkdirAll` after the single wipe

  Fixes #468

  ## Test plan

  - [x] Unit tests pass (`go test ./cmd/export/`)
  - [x] Manual verification against minikube (12/12 scenarios passed):
    - Fresh export to non-existent dir — `resources/`, `failures/` dirs created
    - Delete one resource, re-export — stale file gone, other files present
    - Delete all custom resources, re-export — no stale files remain
    - Plant rogue files in export dir — wiped on re-export
    - Two rapid re-exports — second run is clean
    - No cluster-scoped resources — `_cluster/` dir not created
    - Dir structure correct after clean export — `resources/<ns>/` and `failures/<ns>/` both exist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Export directory is now properly cleared before each export run, ensuring previous exports don't interfere with new ones.
  * Improved directory structure setup for exported resources and failures, with more reliable and consistent handling of namespaced and cluster-scoped resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->