### PR TITLE
fix: Apply cleanup changes to the apply command

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -137,7 +137,10 @@ func (o *Options) run() error {
 		return err
 	}
 
-	// Create output directory
+	// Clean and recreate output directory so stale files from previous runs don't survive
+	if err := os.RemoveAll(outputDir); err != nil {
+		return fmt.Errorf("failed to clear output directory: %w", err)
+	}
 	if err := os.MkdirAll(outputDir, 0700); err != nil {
 		return fmt.Errorf("failed to create output directory: %w", err)
 	}


### PR DESCRIPTION
Fixed proper cleanup of apply command directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The apply command now clears the output directory at startup to ensure a clean state. Error handling has been added if the clearing process fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->