### PR TITLE
fix: resolve nil error in custom stage name validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,10 +17,3 @@ vendor/
 
 crane
 .DS_Store
-
-# My Personal Tools and Scripts
-scripts/ship_it.sh
-scripts/mac_refresh.py
-slack-creds-extractor-main/
-crane-test/
-.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,10 @@ vendor/
 
 crane
 .DS_Store
+
+# My Personal Tools and Scripts
+scripts/ship_it.sh
+scripts/mac_refresh.py
+slack-creds-extractor-main/
+crane-test/
+.claude/

--- a/cmd/transform/transform.go
+++ b/cmd/transform/transform.go
@@ -733,18 +733,18 @@ func (o *Options) resolveAndValidateStages(
 				continue
 			}
 
-			if err := validateStageNameToken(requested); err == nil {
-				stageName, err := o.createCustomStageWithAutoPriority(requested, nextPriority, orchestrator, transformDir, log)
-				if err != nil {
-					return nil, err
-				}
-				resolved = append(resolved, stageName)
-				seen[stageName] = true
-				nextPriority += 10
-				continue
+			if validationErr := validateStageNameToken(requested); validationErr != nil {
+				return nil, fmt.Errorf("invalid custom stage name %q: %w", requested, validationErr)
 			}
 
-			return nil, fmt.Errorf("invalid custom stage name %q: %v", requested, err)
+			stageName, err := o.createCustomStageWithAutoPriority(requested, nextPriority, orchestrator, transformDir, log)
+			if err != nil {
+				return nil, err
+			}
+			resolved = append(resolved, stageName)
+			seen[stageName] = true
+			nextPriority += 10
+			continue
 		}
 
 		// Plugin name - lazy-load and create stage

--- a/cmd/transform/transform_test.go
+++ b/cmd/transform/transform_test.go
@@ -562,6 +562,12 @@ func TestResolveAndValidateStages_CustomStageCreation(t *testing.T) {
 			shouldCreate:   true,
 			expectError:    false,
 		},
+		{
+            name:           "invalid custom stage name returns wrapped error",
+            requestedStage: "invalid stage name!", 
+            shouldCreate:   false,
+            expectError:    true,
+        },
 	}
 
 	for _, tt := range tests {

--- a/cmd/transform/transform_test.go
+++ b/cmd/transform/transform_test.go
@@ -609,15 +609,24 @@ func TestResolveAndValidateStages_CustomStageCreation(t *testing.T) {
 			)
 
 			if tt.expectError {
-				if err == nil {
-					t.Errorf("expected error but got none")
-				}
-				return
-			}
+                if err == nil {
+                    t.Fatalf("expected error but got none")
+                }
+                if !strings.Contains(err.Error(), "invalid custom stage name") || strings.Contains(err.Error(), "<nil>") {
+                    t.Errorf("expected error to contain validation context, but got: %v", err)
+                }
 
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+                stageDir := filepath.Join(subTransformDir, tt.requestedStage)
+                if _, statErr := os.Stat(stageDir); statErr == nil {
+                    t.Errorf("expected directory %s NOT to be created for invalid stage name", stageDir)
+                }
+
+                return
+            } else {
+                if err != nil {
+                    t.Fatalf("unexpected error: %v", err)
+                }
+            }
 
 			if len(resolved) != 1 {
 				t.Fatalf("expected 1 resolved stage, got %d", len(resolved))


### PR DESCRIPTION
[#479](https://github.com/migtools/crane/issues/479)

### Description
Fixes a bug where providing an invalid custom stage name to the `crane transform` command returned a `<nil>` error instead of a helpful error message.

### What was wrong?
In the original implementation, the variable `err` was scoped inside the `if` block checking for successful validation (`if err := validateStageNameToken(requested); err == nil`). When the validation actually failed, the code skipped the `if` block and returned `fmt.Errorf("...", err)`. However, at that point, the outer function's `err` variable was shadowed and evaluated to `<nil>`.

### What was fixed?
Refactored the validation check using a clean guard clause (`if validationErr != nil`) to properly capture and bubble up the actual inner validation error.

### Testing & Verification
Verified locally by running:
`crane transform "my stage" -e ./test-export -t ./test-transform`

- Before: `Error: invalid custom stage name "my stage": <nil>`
- After: `Error: invalid custom stage name "my stage": contains unsafe characters (only A-Z, a-z, 0-9, -, _ allowed)`
## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to error handling and validation logic for custom stage creation. No user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for custom stage names so invalid names fail cleanly and prevent unintended stage directory creation.
* **Tests**
  * Added coverage for invalid custom stage name inputs and strengthened assertions around returned error behavior.
* **Chores**
  * Updated ignore rules to exclude additional local artifacts and temporary project directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->