### PR TITLE
fix: silence command usage on runtime errors for core commands

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -87,6 +87,7 @@ If no stages specified, all discovered stages are applied.`,
 			if err := o.Validate(); err != nil {
 				return err
 			}
+			c.SilenceUsage = true
 			if err := o.Run(); err != nil {
 				return err
 			}

--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -304,6 +304,7 @@ func NewExportCommand(streams genericclioptions.IOStreams, f *flags.GlobalFlags)
 			if err := o.Validate(); err != nil {
 				return err
 			}
+			c.SilenceUsage = true
 			if err := o.Run(); err != nil {
 				return err
 			}

--- a/cmd/transform/transform.go
+++ b/cmd/transform/transform.go
@@ -131,6 +131,7 @@ If no stages specified, all discovered stages are run.`,
 			if err := o.Validate(); err != nil {
 				return err
 			}
+			c.SilenceUsage = true
 			if err := o.Run(); err != nil {
 				return err
 			}

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -259,7 +259,6 @@ the validate-dir for auditability.
 Exit code 0 means all checks pass; exit code 1 means one or more checks
 failed (or another error occurred).`,
 		Args:         cobra.NoArgs,
-		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := o.Complete(c, args); err != nil {
 				return err
@@ -267,6 +266,7 @@ failed (or another error occurred).`,
 			if err := o.Validate(c); err != nil {
 				return err
 			}
+			c.SilenceUsage = true
 			if err := o.Run(); err != nil {
 				return err
 			}


### PR DESCRIPTION
[#472](https://github.com/migtools/crane/issues/472)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command error output for apply, export, transform, and validate by suppressing automatic usage text when execution fails. This results in cleaner, more focused error messages without extra guidance being printed alongside failures, making it easier to understand what went wrong and take corrective action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->