### PR TITLE
:test_tube: Enhanced MTA-831 test to validate crane validate report in YAML format for offline mode

### DIFF
--- a/e2e-tests/tests/tier0/mta_831_validate_compatible_resources_offline_test.go
+++ b/e2e-tests/tests/tier0/mta_831_validate_compatible_resources_offline_test.go
@@ -119,7 +119,7 @@ var _ = Describe("Crane validate: all compatible standard resources in offline m
 	It("[MTA-831][MTA-848] Generate and validate crane validate report in JSON and YAML formats",
 		Label("tier0", "validate"), func() {
 		appName := "multi-resource-app"
-		namespace := "multi-resource-831-offline"
+		namespace := appName
 		scenario := NewMigrationScenario(
 			appName,
 			namespace,

--- a/e2e-tests/tests/tier0/mta_831_validate_compatible_resources_offline_test.go
+++ b/e2e-tests/tests/tier0/mta_831_validate_compatible_resources_offline_test.go
@@ -13,107 +13,7 @@ import (
 	cranevalidate "github.com/konveyor/crane/internal/validate"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"gopkg.in/yaml.v3"
 )
-
-func runValidateAndParseReport(runner CraneRunner, inputDir string, validateDir string,
-	apiSurfaceFile string, outputFormat string) (cranevalidate.ValidationReport, error) {
-	// Ran crane validate command and parse the report
-	stdout, err := runner.Validate(ValidateOptions{
-		InputDir:         inputDir,
-		ValidateDir:      validateDir,
-		APIResourcesFile: apiSurfaceFile,
-		OutputFormat:     outputFormat,
-	})
-	if err != nil {
-		return cranevalidate.ValidationReport{}, err
-	}
-	log.Printf("Validate %s stdout: %s", outputFormat, stdout)
-
-	By("Verify " + outputFormat + " validation report exists")
-	reportExt := "." + outputFormat
-	reportPath := filepath.Join(validateDir, "report"+reportExt)
-	Expect(reportPath).To(BeAnExistingFile(), "expected report%s at %s", reportExt, reportPath)
-
-	By("Parse and verify " + outputFormat + " validation report")
-	reportData, err := os.ReadFile(reportPath)
-	if err != nil {
-		return cranevalidate.ValidationReport{}, err
-	}
-
-	var report cranevalidate.ValidationReport
-	if outputFormat == "yaml" {
-		err = yaml.Unmarshal(reportData, &report)
-	} else {
-		err = json.Unmarshal(reportData, &report)
-	}
-	if err != nil {
-		return cranevalidate.ValidationReport{}, err
-	}
-
-	return report, nil
-}
-
-func verifyValidateResults(report cranevalidate.ValidationReport, namespace string,
-	validateDir string, apiSurfaceFile string, outputFormat string) {
-	// Verify report data and creation of failures directory when required
-	By(outputFormat + " report: Verify report shows offline mode")
-	Expect(report.Mode).To(Equal("offline"), "expected validation mode to be 'offline' in %s report", outputFormat)
-	log.Printf("%s validation mode: %s", outputFormat, report.Mode)
-
-	By(outputFormat + " report: Verify apiResourcesSource is set to the captured API surface file")
-	Expect(report.APIResourcesSource).NotTo(BeEmpty(), "expected apiResourcesSource to be set in offline mode")
-	Expect(report.APIResourcesSource).To(Equal(apiSurfaceFile), "expected apiResourcesSource to match API surface file path")
-	log.Printf("API resources source: %s", report.APIResourcesSource)
-
-	By(outputFormat + " report: Verify resource count")
-	Expect(report.TotalScanned).To(Equal(5), "expected exactly 5 resources scanned in %s report", outputFormat)
-	Expect(report.Compatible).To(Equal(5), "expected all 5 resources to be compatible in %s report", outputFormat)
-	Expect(report.Incompatible).To(Equal(0), "expected no incompatible resources in %s report", outputFormat)
-	log.Printf("%s report - Total: %d, Compatible: %d, Incompatible: %d",
-		outputFormat, report.TotalScanned, report.Compatible, report.Incompatible)
-
-	By(outputFormat + " report: Verify resource API version, namespace, status")
-	expectedResources := map[string]string{
-		"Deployment":  "apps/v1",
-		"Service":     "v1",
-		"ConfigMap":   "v1",
-		"Secret":      "v1",
-		"RoleBinding": "rbac.authorization.k8s.io/v1",
-	}
-
-	foundResources := make(map[string]bool)
-	for _, result := range report.Results {
-		if expectedAPIVersion, expected := expectedResources[result.Kind]; expected {
-			foundResources[result.Kind] = true
-			Expect(result.APIVersion).To(Equal(expectedAPIVersion),
-				"expected %s to have apiVersion %s in %s report", result.Kind, expectedAPIVersion, outputFormat)
-			Expect(result.Status).To(Equal(cranevalidate.StatusOK),
-				"expected %s to have status OK in %s report", result.Kind, outputFormat)
-			Expect(result.Namespace).To(Equal(namespace),
-				"expected %s to be in namespace %s in %s report", result.Kind, namespace, outputFormat)
-		}
-		log.Printf("✓ %s report: Found %s with apiVersion %s in namespace %s with status %s", 
-			outputFormat, result.Kind, result.APIVersion, result.Namespace, result.Status)
-	}
-
-	By(outputFormat + " report: Verify all expected resources were found")
-	var missingResources []string
-	for kind := range expectedResources {
-		if !foundResources[kind] {
-			missingResources = append(missingResources, kind)
-		}
-	}
-	Expect(missingResources).To(BeEmpty(),
-		"expected to find all resources in %s validation results, missing: %v", outputFormat, missingResources)
-
-	By(outputFormat + " output: Verify no failures directory was created")
-	failuresDir := filepath.Join(validateDir, "failures")
-	_, err := os.Stat(failuresDir)
-	Expect(os.IsNotExist(err)).To(BeTrue(),
-		"expected no failures/ directory for all compatible resources")
-	log.Printf("No failures directory created")
-}
 
 var _ = Describe("Crane validate: all compatible standard resources in offline mode in JSON and YAML formats", func() {
 	It("[MTA-831][MTA-848] Generate and validate crane validate report in JSON and YAML formats",
@@ -216,10 +116,44 @@ var _ = Describe("Crane validate: all compatible standard resources in offline m
 		for _, ft := range formats {
 			By("Run crane validate in offline mode with output in " + ft.label + " format")
 			validateDir := filepath.Join(paths.TempDir, ft.dirSuffix)
-			report, err := runValidateAndParseReport(runner, paths.OutputDir, validateDir, apiSurfaceFile, ft.format)
-			Expect(err).NotTo(HaveOccurred(), "validate with %s output should succeed for all compatible resources", ft.label)
 
-			verifyValidateResults(report, namespace, validateDir, apiSurfaceFile, ft.label)
+			// Run crane validate command
+			stdout, err := runner.Validate(ValidateOptions{
+				InputDir:         paths.OutputDir,
+				ValidateDir:      validateDir,
+				APIResourcesFile: apiSurfaceFile,
+				OutputFormat:     ft.format,
+			})
+			Expect(err).NotTo(HaveOccurred(), "crane validate should succeed")
+			log.Printf("Validate %s stdout: %s", ft.format, stdout)
+
+			By("Parse " + ft.label + " validation report")
+			var report cranevalidate.ValidationReport
+			err = utils.ParseValidationReport(validateDir, ft.format, &report)
+			Expect(err).NotTo(HaveOccurred(), "should parse %s report", ft.label)
+
+			// Define expectations for this test
+			expectations := utils.ValidationExpectations{
+				ValidationReport: cranevalidate.ValidationReport{
+					Mode:               "offline",
+					APIResourcesSource: apiSurfaceFile,
+					TotalScanned:       5,
+					Compatible:         5,
+					Incompatible:       0,
+				},
+				ExpectedResources: map[string]string{
+					"Deployment":  "apps/v1",
+					"Service":     "v1",
+					"ConfigMap":   "v1",
+					"Secret":      "v1",
+					"RoleBinding": "rbac.authorization.k8s.io/v1",
+				},
+				ExpectedStatus:    cranevalidate.StatusOK,
+				Namespace:         namespace,
+				ExpectFailuresDir: false,
+			}
+
+			utils.VerifyValidateResults(report, validateDir, ft.label, expectations)
 
 			log.Printf("\n"+
 				"========================================\n"+

--- a/e2e-tests/tests/tier0/mta_831_validate_compatible_resources_offline_test.go
+++ b/e2e-tests/tests/tier0/mta_831_validate_compatible_resources_offline_test.go
@@ -13,10 +13,109 @@ import (
 	cranevalidate "github.com/konveyor/crane/internal/validate"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
 )
 
+// runValidateAndParseReport runs crane validate and parses the report
+func runValidateAndParseReport(runner CraneRunner, inputDir string, validateDir string, apiSurfaceFile string, outputFormat string) (cranevalidate.ValidationReport, error) {
+	By("Run crane validate with " + outputFormat + " output format")
+	stdout, err := runner.Validate(ValidateOptions{
+		InputDir:         inputDir,
+		ValidateDir:      validateDir,
+		APIResourcesFile: apiSurfaceFile,
+		OutputFormat:     outputFormat,
+	})
+	if err != nil {
+		return cranevalidate.ValidationReport{}, err
+	}
+	log.Printf("Validate %s stdout: %s", outputFormat, stdout)
+
+	By("Verify " + outputFormat + " validation report exists")
+	reportExt := "." + outputFormat
+	reportPath := filepath.Join(validateDir, "report"+reportExt)
+	Expect(reportPath).To(BeAnExistingFile(), "expected report%s at %s", reportExt, reportPath)
+
+	By("Parse and verify " + outputFormat + " validation report")
+	reportData, err := os.ReadFile(reportPath)
+	if err != nil {
+		return cranevalidate.ValidationReport{}, err
+	}
+
+	var report cranevalidate.ValidationReport
+	if outputFormat == "yaml" {
+		err = yaml.Unmarshal(reportData, &report)
+	} else {
+		err = json.Unmarshal(reportData, &report)
+	}
+	if err != nil {
+		return cranevalidate.ValidationReport{}, err
+	}
+
+	return report, nil
+}
+
+// verifyCompatibleResources validates that a report contains all expected compatible resources
+func verifyCompatibleResources(report cranevalidate.ValidationReport, namespace string, validateDir string, outputFormat string) {
+	By("Verify report shows offline mode for " + outputFormat + " output")
+	Expect(report.Mode).To(Equal("offline"), "expected validation mode to be 'offline' in %s report", outputFormat)
+	log.Printf("%s validation mode: %s", outputFormat, report.Mode)
+
+	By("Verify all 4 resources were scanned in " + outputFormat + " report")
+	Expect(report.TotalScanned).To(Equal(4), "expected exactly 4 resources scanned in %s report", outputFormat)
+	Expect(report.Compatible).To(Equal(4), "expected all 4 resources to be compatible in %s report", outputFormat)
+	Expect(report.Incompatible).To(Equal(0), "expected no incompatible resources in %s report", outputFormat)
+	log.Printf("%s report - Total: %d, Compatible: %d, Incompatible: %d",
+		outputFormat, report.TotalScanned, report.Compatible, report.Incompatible)
+
+	By("Verify expected resource types are present in " + outputFormat + " results")
+	expectedResources := map[string]string{
+		"Deployment": "apps/v1",
+		"Service":    "v1",
+		"ConfigMap":  "v1",
+		"Secret":     "v1",
+	}
+
+	foundResources := make(map[string]bool)
+	for _, result := range report.Results {
+		log.Printf("%s report resource: %s/%s (namespace: %s, status: %s)",
+			outputFormat, result.APIVersion, result.Kind, result.Namespace, result.Status)
+
+		if expectedAPIVersion, expected := expectedResources[result.Kind]; expected {
+			foundResources[result.Kind] = true
+			Expect(result.APIVersion).To(Equal(expectedAPIVersion),
+				"expected %s to have apiVersion %s in %s report", result.Kind, expectedAPIVersion, outputFormat)
+			Expect(result.Status).To(Equal(cranevalidate.StatusOK),
+				"expected %s to have status OK in %s report", result.Kind, outputFormat)
+			Expect(result.Namespace).To(Equal(namespace),
+				"expected %s to be in namespace %s in %s report", result.Kind, namespace, outputFormat)
+		}
+	}
+
+	By("Verify all 4 resource types were found in " + outputFormat + " report")
+	var missingResources []string
+	for kind := range expectedResources {
+		if !foundResources[kind] {
+			missingResources = append(missingResources, kind)
+		}
+	}
+	Expect(missingResources).To(BeEmpty(),
+		"expected to find all resources in %s validation results, missing: %v", outputFormat, missingResources)
+
+	for kind := range expectedResources {
+		log.Printf("✓ Found %s in %s report with correct apiVersion and status", kind, outputFormat)
+	}
+
+	By("Verify no failures directory was created")
+	failuresDir := filepath.Join(validateDir, "failures")
+	_, err := os.Stat(failuresDir)
+	Expect(os.IsNotExist(err)).To(BeTrue(),
+		"expected no failures/ directory for all compatible resources")
+	log.Printf("No failures directory created")
+}
+
 var _ = Describe("Crane validate: all compatible standard resources in offline mode", func() {
-	It("[MTA-831] Validate final manifests in offline mode using captured API surface as namespace-admin (tier0)", Label("tier0", "validate"), func() {
+	It("[MTA-831] Generate and validate crane validate report in JSON format",
+		Label("tier0", "validate"), func() {
 		appName := "multi-resource-app"
 		namespace := appName
 		scenario := NewMigrationScenario(
@@ -98,104 +197,23 @@ var _ = Describe("Crane validate: all compatible standard resources in offline m
 		Expect(err).NotTo(HaveOccurred(), "API surface file should contain valid JSON")
 		log.Printf("API surface file validated")
 
-		By("Run crane validate in offline mode using captured API surface")
+		// Automate MTA-848: Generate and validate crane validate report in YAML format
+		By("Run crane validate in offline mode with output in JSON format")
 		validateDir := filepath.Join(paths.TempDir, "validate")
-		stdout, err := runner.Validate(ValidateOptions{
-			InputDir:         paths.OutputDir,
-			ValidateDir:      validateDir,
-			APIResourcesFile: apiSurfaceFile,
-		})
-		Expect(err).NotTo(HaveOccurred(), "crane validate should succeed in offline mode with all compatible resources")
-		log.Printf("Crane validate completed in offline mode with exit code 0")
-		log.Printf("Validate stdout: %s", stdout)
-
-		By("Verify validation report exists")
-		reportPath := filepath.Join(validateDir, "report.json")
-		Expect(reportPath).To(BeAnExistingFile(), "expected report.json at %s", reportPath)
-
-		By("Parse and verify validation report")
-		reportData, err := os.ReadFile(reportPath)
-		Expect(err).NotTo(HaveOccurred())
-
-		var report cranevalidate.ValidationReport
-		err = json.Unmarshal(reportData, &report)
-		Expect(err).NotTo(HaveOccurred(), "failed to parse report.json")
+		report, err := runValidateAndParseReport(runner, paths.OutputDir, validateDir, apiSurfaceFile, "json")
+		Expect(err).NotTo(HaveOccurred(), "validate with JSON output should succeed for all compatible resources")
+		log.Printf("Crane validate completed with output in JSON format")
 
 		By("Verify apiResourcesSource is set to the captured API surface file")
 		Expect(report.APIResourcesSource).NotTo(BeEmpty(), "expected apiResourcesSource to be set in offline mode")
 		Expect(report.APIResourcesSource).To(Equal(apiSurfaceFile), "expected apiResourcesSource to match API surface file path")
 		log.Printf("API resources source: %s", report.APIResourcesSource)
 
-		By("Verify all 4 resource types are scanned")
-		Expect(report.TotalScanned).To(BeNumerically(">=", 4), "expected at least 4 resources scanned (Deployment, Service, ConfigMap, Secret)")
-		log.Printf("Total scanned: %d", report.TotalScanned)
-
-		By("Verify all resources are compatible")
-		Expect(report.Compatible).To(Equal(report.TotalScanned), "expected all resources to be compatible")
-		Expect(report.Incompatible).To(Equal(0), "expected 0 incompatible resources")
-		log.Printf("Compatible: %d, Incompatible: %d", report.Compatible, report.Incompatible)
-
-		By("Verify expected resource types are present in results")
-		// Map of expected resource kinds to their API versions
-		// These are the 4 standard Kubernetes resources deployed by multi-resource-app
-		expectedResources := map[string]string{
-			"Deployment": "apps/v1",
-			"Service":    "v1",
-			"ConfigMap":  "v1",
-			"Secret":     "v1",
-		}
-
-		// Track which expected resources were actually found in the report
-		foundResources := make(map[string]bool)
-		for _, result := range report.Results {
-			log.Printf("Found resource: %s/%s (namespace: %s, status: %s, resourcePlural: %s)",
-				result.APIVersion, result.Kind, result.Namespace, result.Status, result.ResourcePlural)
-
-			// Check if this is one of our expected resources
-			if expectedAPIVersion, expected := expectedResources[result.Kind]; expected {
-				foundResources[result.Kind] = true
-
-				// Verify API version matches expected
-				Expect(result.APIVersion).To(Equal(expectedAPIVersion),
-					"expected %s to have apiVersion %s", result.Kind, expectedAPIVersion)
-
-				// Verify status is OK (compatible)
-				Expect(result.Status).To(Equal(cranevalidate.StatusOK),
-					"expected %s to have status OK", result.Kind)
-
-				// Verify namespace is set for namespaced resources
-				Expect(result.Namespace).To(Equal(namespace),
-					"expected %s to be in namespace %s", result.Kind, namespace)
-			}
-		}
-
-		By("Verify all 4 expected resource types were found")
-		var missingResources []string
-		for kind := range expectedResources {
-			if !foundResources[kind] {
-				missingResources = append(missingResources, kind)
-			}
-		}
-		Expect(missingResources).To(BeEmpty(),
-			"expected to find all resources in validation results, missing: %v", missingResources)
-
-		for kind := range expectedResources {
-			log.Printf("Found %s with correct apiVersion and status", kind)
-		}
-
-		By("Verify no failures directory was created")
-		failuresDir := filepath.Join(validateDir, "failures")
-		_, err = os.Stat(failuresDir)
-		Expect(os.IsNotExist(err)).To(BeTrue(),
-			"expected no failures/ directory for all compatible resources")
-		log.Printf("No failures directory created")
-
-		By("Verify offline mode works without cluster connectivity")
-		log.Printf("Offline validation successfully completed without requiring cluster API calls during validation")
+		verifyCompatibleResources(report, namespace, validateDir, "JSON")
 
 		log.Printf("\n"+
 			"========================================\n"+
-			"OFFLINE VALIDATION SUCCESS\n"+
+			"JSON OUTPUT VALIDATION SUCCESS\n"+
 			"========================================\n"+
 			"Mode: %s\n"+
 			"API Resources Source: %s\n"+
@@ -205,5 +223,25 @@ var _ = Describe("Crane validate: all compatible standard resources in offline m
 			"========================================\n",
 			report.Mode, report.APIResourcesSource,
 			report.TotalScanned, report.Compatible, report.Incompatible)
+
+		By("Run crane validate in offline mode with output in YAML format")
+		validateDirYAML := filepath.Join(paths.TempDir, "validate-yaml")
+		reportYAML, err := runValidateAndParseReport(runner, filepath.Join(paths.OutputDir, "resources", namespace), validateDirYAML, apiSurfaceFile, "yaml")
+		Expect(err).NotTo(HaveOccurred(), "validate with YAML output should succeed for all compatible resources")
+		verifyCompatibleResources(reportYAML, namespace, validateDirYAML, "YAML")
+
+		log.Printf("\n"+
+			"========================================\n"+
+			"YAML OUTPUT VALIDATION SUCCESS\n"+
+			"========================================\n"+
+			"Mode: %s\n"+
+			"API Resources Source: %s\n"+
+			"Total Scanned: %d\n"+
+			"Compatible: %d\n"+
+			"Incompatible: %d\n"+
+			"All 4 resource types verified in YAML output!\n"+
+			"========================================\n",
+			reportYAML.Mode, report.APIResourcesSource,
+			reportYAML.TotalScanned, reportYAML.Compatible, reportYAML.Incompatible)
 	})
 })

--- a/e2e-tests/tests/tier0/mta_831_validate_compatible_resources_offline_test.go
+++ b/e2e-tests/tests/tier0/mta_831_validate_compatible_resources_offline_test.go
@@ -60,19 +60,20 @@ func verifyCompatibleResources(report cranevalidate.ValidationReport, namespace 
 	Expect(report.Mode).To(Equal("offline"), "expected validation mode to be 'offline' in %s report", outputFormat)
 	log.Printf("%s validation mode: %s", outputFormat, report.Mode)
 
-	By("Verify all 4 resources were scanned in " + outputFormat + " report")
-	Expect(report.TotalScanned).To(Equal(4), "expected exactly 4 resources scanned in %s report", outputFormat)
-	Expect(report.Compatible).To(Equal(4), "expected all 4 resources to be compatible in %s report", outputFormat)
+	By("Verify all 5 resources were scanned in " + outputFormat + " report")
+	Expect(report.TotalScanned).To(Equal(5), "expected exactly 5 resources scanned in %s report", outputFormat)
+	Expect(report.Compatible).To(Equal(5), "expected all 5 resources to be compatible in %s report", outputFormat)
 	Expect(report.Incompatible).To(Equal(0), "expected no incompatible resources in %s report", outputFormat)
 	log.Printf("%s report - Total: %d, Compatible: %d, Incompatible: %d",
 		outputFormat, report.TotalScanned, report.Compatible, report.Incompatible)
 
 	By("Verify expected resource types are present in " + outputFormat + " results")
 	expectedResources := map[string]string{
-		"Deployment": "apps/v1",
-		"Service":    "v1",
-		"ConfigMap":  "v1",
-		"Secret":     "v1",
+		"Deployment":  "apps/v1",
+		"Service":     "v1",
+		"ConfigMap":   "v1",
+		"Secret":      "v1",
+		"RoleBinding": "rbac.authorization.k8s.io/v1",
 	}
 
 	foundResources := make(map[string]bool)
@@ -91,7 +92,7 @@ func verifyCompatibleResources(report cranevalidate.ValidationReport, namespace 
 		}
 	}
 
-	By("Verify all 4 resource types were found in " + outputFormat + " report")
+	By("Verify all 5 resource types were found in " + outputFormat + " report")
 	var missingResources []string
 	for kind := range expectedResources {
 		if !foundResources[kind] {
@@ -113,7 +114,7 @@ func verifyCompatibleResources(report cranevalidate.ValidationReport, namespace 
 	log.Printf("No failures directory created")
 }
 
-var _ = Describe("Crane validate: all compatible standard resources in offline mode", func() {
+var _ = Describe("Crane validate: all compatible standard resources in offline mode in JSON and YAML formats", func() {
 	It("[MTA-831] Generate and validate crane validate report in JSON format",
 		Label("tier0", "validate"), func() {
 		appName := "multi-resource-app"
@@ -226,7 +227,7 @@ var _ = Describe("Crane validate: all compatible standard resources in offline m
 
 		By("Run crane validate in offline mode with output in YAML format")
 		validateDirYAML := filepath.Join(paths.TempDir, "validate-yaml")
-		reportYAML, err := runValidateAndParseReport(runner, filepath.Join(paths.OutputDir, "resources", namespace), validateDirYAML, apiSurfaceFile, "yaml")
+		reportYAML, err := runValidateAndParseReport(runner, paths.OutputDir, validateDirYAML, apiSurfaceFile, "yaml")
 		Expect(err).NotTo(HaveOccurred(), "validate with YAML output should succeed for all compatible resources")
 		verifyCompatibleResources(reportYAML, namespace, validateDirYAML, "YAML")
 
@@ -239,9 +240,8 @@ var _ = Describe("Crane validate: all compatible standard resources in offline m
 			"Total Scanned: %d\n"+
 			"Compatible: %d\n"+
 			"Incompatible: %d\n"+
-			"All 4 resource types verified in YAML output!\n"+
 			"========================================\n",
-			reportYAML.Mode, report.APIResourcesSource,
+			reportYAML.Mode, reportYAML.APIResourcesSource,
 			reportYAML.TotalScanned, reportYAML.Compatible, reportYAML.Incompatible)
 	})
 })

--- a/e2e-tests/tests/tier0/mta_831_validate_compatible_resources_offline_test.go
+++ b/e2e-tests/tests/tier0/mta_831_validate_compatible_resources_offline_test.go
@@ -16,9 +16,9 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// runValidateAndParseReport runs crane validate and parses the report
 func runValidateAndParseReport(runner CraneRunner, inputDir string, validateDir string,
 	apiSurfaceFile string, outputFormat string) (cranevalidate.ValidationReport, error) {
+	// Ran crane validate command and parse the report
 	stdout, err := runner.Validate(ValidateOptions{
 		InputDir:         inputDir,
 		ValidateDir:      validateDir,
@@ -54,9 +54,9 @@ func runValidateAndParseReport(runner CraneRunner, inputDir string, validateDir 
 	return report, nil
 }
 
-// verifyCompatibleResources validates that a report contains all expected compatible resources
-func verifyCompatibleResources(report cranevalidate.ValidationReport, namespace string,
+func verifyValidateResults(report cranevalidate.ValidationReport, namespace string,
 	validateDir string, apiSurfaceFile string, outputFormat string) {
+	// Verify report data and creation of failures directory when required
 	By(outputFormat + " report: Verify report shows offline mode")
 	Expect(report.Mode).To(Equal("offline"), "expected validation mode to be 'offline' in %s report", outputFormat)
 	log.Printf("%s validation mode: %s", outputFormat, report.Mode)
@@ -116,7 +116,7 @@ func verifyCompatibleResources(report cranevalidate.ValidationReport, namespace 
 }
 
 var _ = Describe("Crane validate: all compatible standard resources in offline mode in JSON and YAML formats", func() {
-	It("[MTA-831] Generate and validate crane validate report in JSON format",
+	It("[MTA-831][MTA-848] Generate and validate crane validate report in JSON and YAML formats",
 		Label("tier0", "validate"), func() {
 		appName := "multi-resource-app"
 		namespace := "multi-resource-831-offline"
@@ -219,7 +219,7 @@ var _ = Describe("Crane validate: all compatible standard resources in offline m
 			report, err := runValidateAndParseReport(runner, paths.OutputDir, validateDir, apiSurfaceFile, ft.format)
 			Expect(err).NotTo(HaveOccurred(), "validate with %s output should succeed for all compatible resources", ft.label)
 
-			verifyCompatibleResources(report, namespace, validateDir, apiSurfaceFile, ft.label)
+			verifyValidateResults(report, namespace, validateDir, apiSurfaceFile, ft.label)
 
 			log.Printf("\n"+
 				"========================================\n"+

--- a/e2e-tests/tests/tier0/mta_831_validate_compatible_resources_offline_test.go
+++ b/e2e-tests/tests/tier0/mta_831_validate_compatible_resources_offline_test.go
@@ -17,8 +17,8 @@ import (
 )
 
 // runValidateAndParseReport runs crane validate and parses the report
-func runValidateAndParseReport(runner CraneRunner, inputDir string, validateDir string, apiSurfaceFile string, outputFormat string) (cranevalidate.ValidationReport, error) {
-	By("Run crane validate with " + outputFormat + " output format")
+func runValidateAndParseReport(runner CraneRunner, inputDir string, validateDir string,
+	apiSurfaceFile string, outputFormat string) (cranevalidate.ValidationReport, error) {
 	stdout, err := runner.Validate(ValidateOptions{
 		InputDir:         inputDir,
 		ValidateDir:      validateDir,
@@ -55,19 +55,25 @@ func runValidateAndParseReport(runner CraneRunner, inputDir string, validateDir 
 }
 
 // verifyCompatibleResources validates that a report contains all expected compatible resources
-func verifyCompatibleResources(report cranevalidate.ValidationReport, namespace string, validateDir string, outputFormat string) {
-	By("Verify report shows offline mode for " + outputFormat + " output")
+func verifyCompatibleResources(report cranevalidate.ValidationReport, namespace string,
+	validateDir string, apiSurfaceFile string, outputFormat string) {
+	By(outputFormat + " report: Verify report shows offline mode")
 	Expect(report.Mode).To(Equal("offline"), "expected validation mode to be 'offline' in %s report", outputFormat)
 	log.Printf("%s validation mode: %s", outputFormat, report.Mode)
 
-	By("Verify all 5 resources were scanned in " + outputFormat + " report")
+	By(outputFormat + " report: Verify apiResourcesSource is set to the captured API surface file")
+	Expect(report.APIResourcesSource).NotTo(BeEmpty(), "expected apiResourcesSource to be set in offline mode")
+	Expect(report.APIResourcesSource).To(Equal(apiSurfaceFile), "expected apiResourcesSource to match API surface file path")
+	log.Printf("API resources source: %s", report.APIResourcesSource)
+
+	By(outputFormat + " report: Verify resource count")
 	Expect(report.TotalScanned).To(Equal(5), "expected exactly 5 resources scanned in %s report", outputFormat)
 	Expect(report.Compatible).To(Equal(5), "expected all 5 resources to be compatible in %s report", outputFormat)
 	Expect(report.Incompatible).To(Equal(0), "expected no incompatible resources in %s report", outputFormat)
 	log.Printf("%s report - Total: %d, Compatible: %d, Incompatible: %d",
 		outputFormat, report.TotalScanned, report.Compatible, report.Incompatible)
 
-	By("Verify expected resource types are present in " + outputFormat + " results")
+	By(outputFormat + " report: Verify resource API version, namespace, status")
 	expectedResources := map[string]string{
 		"Deployment":  "apps/v1",
 		"Service":     "v1",
@@ -78,9 +84,6 @@ func verifyCompatibleResources(report cranevalidate.ValidationReport, namespace 
 
 	foundResources := make(map[string]bool)
 	for _, result := range report.Results {
-		log.Printf("%s report resource: %s/%s (namespace: %s, status: %s)",
-			outputFormat, result.APIVersion, result.Kind, result.Namespace, result.Status)
-
 		if expectedAPIVersion, expected := expectedResources[result.Kind]; expected {
 			foundResources[result.Kind] = true
 			Expect(result.APIVersion).To(Equal(expectedAPIVersion),
@@ -90,9 +93,11 @@ func verifyCompatibleResources(report cranevalidate.ValidationReport, namespace 
 			Expect(result.Namespace).To(Equal(namespace),
 				"expected %s to be in namespace %s in %s report", result.Kind, namespace, outputFormat)
 		}
+		log.Printf("✓ %s report: Found %s with apiVersion %s in namespace %s with status %s", 
+			outputFormat, result.Kind, result.APIVersion, result.Namespace, result.Status)
 	}
 
-	By("Verify all 5 resource types were found in " + outputFormat + " report")
+	By(outputFormat + " report: Verify all expected resources were found")
 	var missingResources []string
 	for kind := range expectedResources {
 		if !foundResources[kind] {
@@ -102,11 +107,7 @@ func verifyCompatibleResources(report cranevalidate.ValidationReport, namespace 
 	Expect(missingResources).To(BeEmpty(),
 		"expected to find all resources in %s validation results, missing: %v", outputFormat, missingResources)
 
-	for kind := range expectedResources {
-		log.Printf("✓ Found %s in %s report with correct apiVersion and status", kind, outputFormat)
-	}
-
-	By("Verify no failures directory was created")
+	By(outputFormat + " output: Verify no failures directory was created")
 	failuresDir := filepath.Join(validateDir, "failures")
 	_, err := os.Stat(failuresDir)
 	Expect(os.IsNotExist(err)).To(BeTrue(),
@@ -118,7 +119,7 @@ var _ = Describe("Crane validate: all compatible standard resources in offline m
 	It("[MTA-831] Generate and validate crane validate report in JSON format",
 		Label("tier0", "validate"), func() {
 		appName := "multi-resource-app"
-		namespace := appName
+		namespace := "multi-resource-831-offline"
 		scenario := NewMigrationScenario(
 			appName,
 			namespace,
@@ -198,50 +199,84 @@ var _ = Describe("Crane validate: all compatible standard resources in offline m
 		Expect(err).NotTo(HaveOccurred(), "API surface file should contain valid JSON")
 		log.Printf("API surface file validated")
 
-		// Automate MTA-848: Generate and validate crane validate report in YAML format
-		By("Run crane validate in offline mode with output in JSON format")
-		validateDir := filepath.Join(paths.TempDir, "validate")
-		report, err := runValidateAndParseReport(runner, paths.OutputDir, validateDir, apiSurfaceFile, "json")
-		Expect(err).NotTo(HaveOccurred(), "validate with JSON output should succeed for all compatible resources")
-		log.Printf("Crane validate completed with output in JSON format")
+		// Table-driven validation for both JSON and YAML formats
+		type formatTest struct {
+			format    string
+			dirSuffix string
+			label     string
+		}
 
-		By("Verify apiResourcesSource is set to the captured API surface file")
-		Expect(report.APIResourcesSource).NotTo(BeEmpty(), "expected apiResourcesSource to be set in offline mode")
-		Expect(report.APIResourcesSource).To(Equal(apiSurfaceFile), "expected apiResourcesSource to match API surface file path")
-		log.Printf("API resources source: %s", report.APIResourcesSource)
+		formats := []formatTest{
+			{format: "json", dirSuffix: "validate", label: "JSON"},
+			{format: "yaml", dirSuffix: "validate-yaml", label: "YAML"},
+		}
 
-		verifyCompatibleResources(report, namespace, validateDir, "JSON")
+		reports := make(map[string]cranevalidate.ValidationReport)
 
-		log.Printf("\n"+
-			"========================================\n"+
-			"JSON OUTPUT VALIDATION SUCCESS\n"+
-			"========================================\n"+
-			"Mode: %s\n"+
-			"API Resources Source: %s\n"+
-			"Total Scanned: %d\n"+
-			"Compatible: %d\n"+
-			"Incompatible: %d\n"+
-			"========================================\n",
-			report.Mode, report.APIResourcesSource,
-			report.TotalScanned, report.Compatible, report.Incompatible)
+		for _, ft := range formats {
+			By("Run crane validate in offline mode with output in " + ft.label + " format")
+			validateDir := filepath.Join(paths.TempDir, ft.dirSuffix)
+			report, err := runValidateAndParseReport(runner, paths.OutputDir, validateDir, apiSurfaceFile, ft.format)
+			Expect(err).NotTo(HaveOccurred(), "validate with %s output should succeed for all compatible resources", ft.label)
 
-		By("Run crane validate in offline mode with output in YAML format")
-		validateDirYAML := filepath.Join(paths.TempDir, "validate-yaml")
-		reportYAML, err := runValidateAndParseReport(runner, paths.OutputDir, validateDirYAML, apiSurfaceFile, "yaml")
-		Expect(err).NotTo(HaveOccurred(), "validate with YAML output should succeed for all compatible resources")
-		verifyCompatibleResources(reportYAML, namespace, validateDirYAML, "YAML")
+			verifyCompatibleResources(report, namespace, validateDir, apiSurfaceFile, ft.label)
 
-		log.Printf("\n"+
-			"========================================\n"+
-			"YAML OUTPUT VALIDATION SUCCESS\n"+
-			"========================================\n"+
-			"Mode: %s\n"+
-			"API Resources Source: %s\n"+
-			"Total Scanned: %d\n"+
-			"Compatible: %d\n"+
-			"Incompatible: %d\n"+
-			"========================================\n",
-			reportYAML.Mode, reportYAML.APIResourcesSource,
-			reportYAML.TotalScanned, reportYAML.Compatible, reportYAML.Incompatible)
+			log.Printf("\n"+
+				"========================================\n"+
+				"%s OUTPUT VALIDATION SUCCESS\n"+
+				"========================================\n"+
+				"Mode: %s\n"+
+				"API Resources Source: %s\n"+
+				"Total Scanned: %d\n"+
+				"Compatible: %d\n"+
+				"Incompatible: %d\n"+
+				"========================================\n",
+				ft.label, report.Mode, report.APIResourcesSource,
+				report.TotalScanned, report.Compatible, report.Incompatible)
+
+			reports[ft.label] = report
+		}
+
+		report := reports["JSON"]
+		reportYAML := reports["YAML"]
+
+		By("Verify JSON and YAML reports contain identical data")
+		Expect(reportYAML.Mode).To(Equal(report.Mode), "JSON and YAML reports should have same mode")
+		Expect(reportYAML.APIResourcesSource).To(Equal(report.APIResourcesSource), "JSON and YAML reports should have same apiResourcesSource")
+		Expect(reportYAML.TotalScanned).To(Equal(report.TotalScanned), "JSON and YAML reports should have same totalScanned")
+		Expect(reportYAML.Compatible).To(Equal(report.Compatible), "JSON and YAML reports should have same compatible count")
+		Expect(reportYAML.Incompatible).To(Equal(report.Incompatible), "JSON and YAML reports should have same incompatible count")
+		Expect(reportYAML.Results).To(HaveLen(len(report.Results)), "JSON and YAML reports should have same number of results")
+
+		By("Verify each resource in JSON and YAML reports match")
+		// Create maps for easier comparison
+		jsonResults := make(map[string]cranevalidate.ValidationResult)
+		for _, r := range report.Results {
+			key := r.Kind + "/" + r.Namespace
+			jsonResults[key] = r
+		}
+
+		yamlResults := make(map[string]cranevalidate.ValidationResult)
+		for _, r := range reportYAML.Results {
+			key := r.Kind + "/" + r.Namespace
+			yamlResults[key] = r
+		}
+
+		// Verify same resources in both formats
+		for key, jsonRes := range jsonResults {
+			yamlRes, found := yamlResults[key]
+			Expect(found).To(BeTrue(), "resource %s found in JSON but missing in YAML", key)
+			Expect(yamlRes.APIVersion).To(Equal(jsonRes.APIVersion), "resource %s has different apiVersion in JSON vs YAML", key)
+			Expect(yamlRes.Status).To(Equal(jsonRes.Status), "resource %s has different status in JSON vs YAML", key)
+			Expect(yamlRes.ResourcePlural).To(Equal(jsonRes.ResourcePlural), "resource %s has different resourcePlural in JSON vs YAML", key)
+		}
+
+		// Verify no extra resources in YAML
+		for key := range yamlResults {
+			_, found := jsonResults[key]
+			Expect(found).To(BeTrue(), "resource %s found in YAML but missing in JSON", key)
+		}
+
+		log.Printf("✅ JSON and YAML reports are identical!")
 	})
 })

--- a/e2e-tests/utils/utils.go
+++ b/e2e-tests/utils/utils.go
@@ -1220,3 +1220,38 @@ func AssertFilesExist(dir string, expectedFiles []string) error {
       }
       return strings.Join(parts, "---\n"), nil
   }
+
+// ParseValidationReport reads and parses a crane validate report file.
+// The report parameter should be a pointer to the structure that will hold the parsed data.
+func ParseValidationReport(validateDir string, outputFormat string, report interface{}) error {
+	if outputFormat != "json" && outputFormat != "yaml" {
+		return fmt.Errorf("unsupported output format: %s (must be 'json' or 'yaml')", outputFormat)
+	}
+
+	reportExt := "." + outputFormat
+	reportPath := filepath.Join(validateDir, "report"+reportExt)
+
+	// Check if report file exists
+	if _, err := os.Stat(reportPath); err != nil {
+		return fmt.Errorf("report file not found at %s: %w", reportPath, err)
+	}
+
+	// Read report file
+	reportData, err := os.ReadFile(reportPath)
+	if err != nil {
+		return fmt.Errorf("failed to read report file: %w", err)
+	}
+
+	// Parse based on format
+	if outputFormat == "yaml" {
+		if err := yaml.Unmarshal(reportData, report); err != nil {
+			return fmt.Errorf("failed to parse YAML report: %w", err)
+		}
+	} else {
+		if err := json.Unmarshal(reportData, report); err != nil {
+			return fmt.Errorf("failed to parse JSON report: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/e2e-tests/utils/utils_validate.go
+++ b/e2e-tests/utils/utils_validate.go
@@ -1,0 +1,134 @@
+// Package utils provides utilities for e2e tests.
+//
+// This file (utils_validate.go) contains Ginkgo/Gomega-specific test helpers
+// for validating crane validate command results. Unlike the framework-agnostic
+// utilities in utils.go (which return errors), these helpers use Ginkgo's Expect()
+// and By() for more convenient test assertions.
+//
+// These helpers are designed to be used across all test tiers (tier0, tier1, tier2+)
+// but are ONLY compatible with Ginkgo/Gomega test suites.
+package utils
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/konveyor/crane/internal/validate"
+	. "github.com/onsi/ginkgo/v2"   //nolint:revive,staticcheck // Ginkgo conventionally uses dot imports
+	. "github.com/onsi/gomega"      //nolint:revive,staticcheck // Gomega conventionally uses dot imports
+)
+
+// ValidationExpectations holds the expected values for validating a crane validate report.
+//
+// It embeds validate.ValidationReport to reuse standard fields (Mode, APIResourcesSource, TotalScanned, etc.)
+// and adds test-specific fields for verification.
+//
+// NOTE: This struct is designed to be used with VerifyValidateResults(), which is a Ginkgo-specific helper.
+type ValidationExpectations struct {
+	validate.ValidationReport                 // Embedded: Mode, APIResourcesSource, TotalScanned, Compatible, Incompatible
+	ExpectedResources         map[string]string            // Map of Kind -> APIVersion for expected resources (simpler than Results)
+	ExpectedStatus            validate.ValidationStatus // Expected status for resources (e.g., StatusOK)
+	Namespace                 string                       // Expected namespace for resources
+	ExpectFailuresDir         bool                         // Whether to expect a failures/ directory
+}
+
+// VerifyValidateResults verifies a crane validate report against expected values using Ginkgo assertions.
+//
+// IMPORTANT: This is a Ginkgo/Gomega-specific test helper. It uses Expect() and By() internally,
+// so it can ONLY be called from within Ginkgo test specs (It, BeforeEach, etc.).
+// For framework-agnostic validation, use ParseValidationReport() instead and write your own assertions.
+//
+// This helper can be used by any validate test in any mode (offline or live mode).
+//
+// Parameters:
+//   - report: The parsed ValidationReport from crane validate
+//   - validateDir: The directory where validate output was written
+//   - outputFormat: The format label (e.g., "JSON", "YAML") for logging
+//   - expectations: ValidationExpectations struct with expected values
+//
+// Example usage:
+//
+//	expectations := utils.ValidationExpectations{
+//		ValidationReport: validate.ValidationReport{
+//			Mode:               "offline",
+//			APIResourcesSource: apiSurfaceFile,
+//			TotalScanned:       5,
+//			Compatible:         5,
+//			Incompatible:       0,
+//		},
+//		ExpectedResources: map[string]string{
+//			"Deployment": "apps/v1",
+//			"Service":    "v1",
+//		},
+//		ExpectedStatus:    validate.StatusOK,
+//		Namespace:         "my-namespace",
+//		ExpectFailuresDir: false,
+//	}
+//	utils.VerifyValidateResults(report, validateDir, "JSON", expectations)
+func VerifyValidateResults(report validate.ValidationReport, validateDir string,
+	outputFormat string, expectations ValidationExpectations) {
+	// Verify report mode
+	By(outputFormat + " report: Verify report shows " + expectations.Mode + " mode")
+	Expect(report.Mode).To(Equal(expectations.Mode), "expected validation mode to be '%s' in %s report", expectations.Mode, outputFormat)
+	log.Printf("%s validation mode: %s", outputFormat, report.Mode)
+
+	// Verify apiResourcesSource (for offline mode)
+	if expectations.Mode == "offline" && expectations.APIResourcesSource != "" {
+		By(outputFormat + " report: Verify apiResourcesSource is set to the captured API surface file")
+		Expect(report.APIResourcesSource).NotTo(BeEmpty(), "expected apiResourcesSource to be set in offline mode")
+		Expect(report.APIResourcesSource).To(Equal(expectations.APIResourcesSource), "expected apiResourcesSource to match API surface file path")
+		log.Printf("API resources source: %s", report.APIResourcesSource)
+	}
+
+	// Verify resource counts
+	By(outputFormat + " report: Verify resource count")
+	Expect(report.TotalScanned).To(Equal(expectations.TotalScanned), "expected %d resources scanned in %s report", expectations.TotalScanned, outputFormat)
+	Expect(report.Compatible).To(Equal(expectations.Compatible), "expected %d compatible resources in %s report", expectations.Compatible, outputFormat)
+	Expect(report.Incompatible).To(Equal(expectations.Incompatible), "expected %d incompatible resources in %s report", expectations.Incompatible, outputFormat)
+	log.Printf("%s report - Total: %d, Compatible: %d, Incompatible: %d",
+		outputFormat, report.TotalScanned, report.Compatible, report.Incompatible)
+
+	// Verify expected resources if provided
+	if len(expectations.ExpectedResources) > 0 {
+		By(outputFormat + " report: Verify resource API version, namespace, status")
+		foundResources := make(map[string]bool)
+		for _, result := range report.Results {
+			if expectedAPIVersion, expected := expectations.ExpectedResources[result.Kind]; expected {
+				foundResources[result.Kind] = true
+				Expect(result.APIVersion).To(Equal(expectedAPIVersion),
+					"expected %s to have apiVersion %s in %s report", result.Kind, expectedAPIVersion, outputFormat)
+				Expect(result.Status).To(Equal(expectations.ExpectedStatus),
+					"expected %s to have status %s in %s report", result.Kind, expectations.ExpectedStatus, outputFormat)
+				if expectations.Namespace != "" {
+					Expect(result.Namespace).To(Equal(expectations.Namespace),
+						"expected %s to be in namespace %s in %s report", result.Kind, expectations.Namespace, outputFormat)
+				}
+			}
+			log.Printf("✓ %s report: Found %s with apiVersion %s in namespace %s with status %s",
+				outputFormat, result.Kind, result.APIVersion, result.Namespace, result.Status)
+		}
+
+		By(outputFormat + " report: Verify all expected resources were found")
+		var missingResources []string
+		for kind := range expectations.ExpectedResources {
+			if !foundResources[kind] {
+				missingResources = append(missingResources, kind)
+			}
+		}
+		Expect(missingResources).To(BeEmpty(),
+			"expected to find all resources in %s validation results, missing: %v", outputFormat, missingResources)
+	}
+
+	// Verify failures directory
+	By(outputFormat + " output: Verify failures directory expectation")
+	failuresDir := filepath.Join(validateDir, "failures")
+	_, err := os.Stat(failuresDir)
+	if expectations.ExpectFailuresDir {
+		Expect(err).NotTo(HaveOccurred(), "expected failures/ directory to exist")
+		log.Printf("Failures directory created as expected")
+	} else {
+		Expect(os.IsNotExist(err)).To(BeTrue(), "expected no failures/ directory")
+		log.Printf("No failures directory created")
+	}
+}

--- a/e2e-tests/utils/utils_validate.go
+++ b/e2e-tests/utils/utils_validate.go
@@ -1,12 +1,9 @@
-// Package utils provides utilities for e2e tests.
-//
 // This file (utils_validate.go) contains Ginkgo/Gomega-specific test helpers
 // for validating crane validate command results. Unlike the framework-agnostic
 // utilities in utils.go (which return errors), these helpers use Ginkgo's Expect()
 // and By() for more convenient test assertions.
 //
-// These helpers are designed to be used across all test tiers (tier0, tier1, tier2+)
-// but are ONLY compatible with Ginkgo/Gomega test suites.
+// These helpers can only be called from within Ginkgo test specs (It, BeforeEach, etc.).
 package utils
 
 import (
@@ -19,12 +16,6 @@ import (
 	. "github.com/onsi/gomega"      //nolint:revive,staticcheck // Gomega conventionally uses dot imports
 )
 
-// ValidationExpectations holds the expected values for validating a crane validate report.
-//
-// It embeds validate.ValidationReport to reuse standard fields (Mode, APIResourcesSource, TotalScanned, etc.)
-// and adds test-specific fields for verification.
-//
-// NOTE: This struct is designed to be used with VerifyValidateResults(), which is a Ginkgo-specific helper.
 type ValidationExpectations struct {
 	validate.ValidationReport                 // Embedded: Mode, APIResourcesSource, TotalScanned, Compatible, Incompatible
 	ExpectedResources         map[string]string            // Map of Kind -> APIVersion for expected resources (simpler than Results)
@@ -34,38 +25,11 @@ type ValidationExpectations struct {
 }
 
 // VerifyValidateResults verifies a crane validate report against expected values using Ginkgo assertions.
-//
-// IMPORTANT: This is a Ginkgo/Gomega-specific test helper. It uses Expect() and By() internally,
-// so it can ONLY be called from within Ginkgo test specs (It, BeforeEach, etc.).
-// For framework-agnostic validation, use ParseValidationReport() instead and write your own assertions.
-//
-// This helper can be used by any validate test in any mode (offline or live mode).
-//
 // Parameters:
 //   - report: The parsed ValidationReport from crane validate
 //   - validateDir: The directory where validate output was written
 //   - outputFormat: The format label (e.g., "JSON", "YAML") for logging
 //   - expectations: ValidationExpectations struct with expected values
-//
-// Example usage:
-//
-//	expectations := utils.ValidationExpectations{
-//		ValidationReport: validate.ValidationReport{
-//			Mode:               "offline",
-//			APIResourcesSource: apiSurfaceFile,
-//			TotalScanned:       5,
-//			Compatible:         5,
-//			Incompatible:       0,
-//		},
-//		ExpectedResources: map[string]string{
-//			"Deployment": "apps/v1",
-//			"Service":    "v1",
-//		},
-//		ExpectedStatus:    validate.StatusOK,
-//		Namespace:         "my-namespace",
-//		ExpectFailuresDir: false,
-//	}
-//	utils.VerifyValidateResults(report, validateDir, "JSON", expectations)
 func VerifyValidateResults(report validate.ValidationReport, validateDir string,
 	outputFormat string, expectations ValidationExpectations) {
 	// Verify report mode

--- a/internal/validate/types.go
+++ b/internal/validate/types.go
@@ -22,24 +22,24 @@ const (
 
 // ValidationResult is one row in the final report.
 type ValidationResult struct {
-	APIVersion     string           `json:"apiVersion"`
-	Kind           string           `json:"kind"`
-	Namespace      string           `json:"namespace,omitempty"`
-	ResourcePlural string           `json:"resourcePlural,omitempty"`
-	Status         ValidationStatus `json:"status"`
-	Reason         string           `json:"reason,omitempty"`
-	Suggestion     string           `json:"suggestion,omitempty"`
+	APIVersion     string           `json:"apiVersion" yaml:"apiVersion"`
+	Kind           string           `json:"kind" yaml:"kind"`
+	Namespace      string           `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	ResourcePlural string           `json:"resourcePlural,omitempty" yaml:"resourcePlural,omitempty"`
+	Status         ValidationStatus `json:"status" yaml:"status"`
+	Reason         string           `json:"reason,omitempty" yaml:"reason,omitempty"`
+	Suggestion     string           `json:"suggestion,omitempty" yaml:"suggestion,omitempty"`
 }
 
 // ValidationReport is the complete output.
 type ValidationReport struct {
-	Mode               string             `json:"mode"`                         // "live" or "offline"
-	APIResourcesSource string             `json:"apiResourcesSource,omitempty"` // file path (offline mode)
-	ClusterContext     string             `json:"clusterContext,omitempty"`     // kubeconfig context (live mode)
-	Results            []ValidationResult `json:"results"`
-	TotalScanned       int                `json:"totalScanned"`
-	Compatible         int                `json:"compatible"`
-	Incompatible       int                `json:"incompatible"`
+	Mode               string             `json:"mode" yaml:"mode"`                                                 // "live" or "offline"
+	APIResourcesSource string             `json:"apiResourcesSource,omitempty" yaml:"apiResourcesSource,omitempty"` // file path (offline mode)
+	ClusterContext     string             `json:"clusterContext,omitempty" yaml:"clusterContext,omitempty"`         // kubeconfig context (live mode)
+	Results            []ValidationResult `json:"results" yaml:"results"`
+	TotalScanned       int                `json:"totalScanned" yaml:"totalScanned"`
+	Compatible         int                `json:"compatible" yaml:"compatible"`
+	Incompatible       int                `json:"incompatible" yaml:"incompatible"`
 }
 
 // HasIncompatible returns true if any resources are incompatible with the target.


### PR DESCRIPTION
Fixes #544 

  * Refactored the  test to validate both JSON and YAML outputs and parse reports with shared helpers; This also automates MTA-848. Hence, the It block has a reference to both tests.
  * Also, verified that the data in both JSON and YAML reports match


