### PR TITLE
Deprecate plugin optionals

### DIFF
--- a/cmd/transform/optionals/optionals.go
+++ b/cmd/transform/optionals/optionals.go
@@ -47,8 +47,9 @@ func NewOptionalsCommand(f *flags.GlobalFlags) *cobra.Command {
 		cobraGlobalFlags: f,
 	}
 	cmd := &cobra.Command{
-		Use:   "optionals",
-		Short: "Return a list of optional fields accepted by configured plugins",
+		Use:        "optionals",
+		Short:      "Return a list of optional fields accepted by configured plugins",
+		Deprecated: "use custom stages with kustomization patches instead. Optional flags apply globally to all stages and will be removed in a future version.",
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := o.Complete(c, args); err != nil {
 				return err

--- a/cmd/transform/optionals_test.go
+++ b/cmd/transform/optionals_test.go
@@ -1,7 +1,6 @@
 package transform
 
 import (
-	"encoding/json"
 	"testing"
 
 	jsonpatch "github.com/evanphx/json-patch"
@@ -10,17 +9,14 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-// mockPluginWithOptionals implements cranelib.Plugin and tracks whether optionals were received
+// mockPluginWithOptionals implements cranelib.Plugin and captures received optionals
 type mockPluginWithOptionals struct {
 	name              string
 	receivedOptionals map[string]string
 }
 
 func (m *mockPluginWithOptionals) Run(request cranelib.PluginRequest) (cranelib.PluginResponse, error) {
-	// Capture the optionals that were passed to the plugin
 	m.receivedOptionals = request.Extras
-
-	// Return a simple response with no transformations (empty patch)
 	return cranelib.PluginResponse{
 		Version:    string(cranelib.V1),
 		Patches:    jsonpatch.Patch{},
@@ -37,22 +33,9 @@ func (m *mockPluginWithOptionals) Metadata() cranelib.PluginMetadata {
 	}
 }
 
-// TestOptionalFlags_PassedToPlugin verifies that optional flags are passed to plugins via Runner
-func TestOptionalFlags_PassedToPlugin(t *testing.T) {
-	// Setup test optionals
-	testOptionals := map[string]string{
-		"registry-replacement": "docker.io=quay.io",
-		"add-annotations":      "migration=crane,team=platform",
-	}
-
-	// Create mock plugin
-	mockPlugin := &mockPluginWithOptionals{
-		name:              "TestPlugin",
-		receivedOptionals: make(map[string]string),
-	}
-
-	// Create a simple test resource
-	testResource := unstructured.Unstructured{
+// testConfigMap creates a simple ConfigMap for testing
+func testConfigMap() unstructured.Unstructured {
+	return unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "v1",
 			"kind":       "ConfigMap",
@@ -65,40 +48,61 @@ func TestOptionalFlags_PassedToPlugin(t *testing.T) {
 			},
 		},
 	}
+}
+
+// assertMapEquals verifies two string maps are equal
+func assertMapEquals(t *testing.T, expected, actual map[string]string) {
+	t.Helper()
+
+	if len(actual) != len(expected) {
+		t.Errorf("expected %d keys, got %d", len(expected), len(actual))
+	}
+
+	for key, expectedValue := range expected {
+		actualValue, ok := actual[key]
+		if !ok {
+			t.Errorf("expected key %q to be present", key)
+			continue
+		}
+		if actualValue != expectedValue {
+			t.Errorf("key %q: expected value %q, got %q", key, expectedValue, actualValue)
+		}
+	}
+}
+
+// TestOptionalFlags_PassedToPlugin verifies that optional flags are passed to plugins via Runner
+func TestOptionalFlags_PassedToPlugin(t *testing.T) {
+	testOptionals := map[string]string{
+		"registry-replacement": "docker.io=quay.io",
+		"add-annotations":      "migration=crane,team=platform",
+	}
+
+	mockPlugin := &mockPluginWithOptionals{
+		name:              "TestPlugin",
+		receivedOptionals: make(map[string]string),
+	}
 
 	log := logrus.New()
-	log.SetLevel(logrus.FatalLevel) // Suppress log output during tests
+	log.SetLevel(logrus.FatalLevel)
 
-	// Create runner with optionals - this is what orchestrator uses
 	runner := cranelib.Runner{
 		Log:           log,
 		OptionalFlags: testOptionals,
 	}
 
-	// Run the plugin - this should pass optionals
-	_, err := runner.Run(testResource, []cranelib.Plugin{mockPlugin})
+	_, err := runner.Run(testConfigMap(), []cranelib.Plugin{mockPlugin})
 	if err != nil {
 		t.Fatalf("failed to run plugin: %v", err)
 	}
 
-	// Verify that optionals were passed to the plugin
 	if len(mockPlugin.receivedOptionals) == 0 {
 		t.Fatal("expected plugin to receive optionals, but got none")
 	}
 
-	for key, expectedValue := range testOptionals {
-		receivedValue, ok := mockPlugin.receivedOptionals[key]
-		if !ok {
-			t.Errorf("expected plugin to receive optional key %q, but it was missing", key)
-			continue
-		}
-		if receivedValue != expectedValue {
-			t.Errorf("optional key %q: expected value %q, got %q", key, expectedValue, receivedValue)
-		}
-	}
+	assertMapEquals(t, testOptionals, mockPlugin.receivedOptionals)
 }
 
-// TestOptionalFlagsToLower verifies that optional flags keys are lowercased
+// TestOptionalFlagsToLower verifies that optional flags keys are normalized to lowercase
 func TestOptionalFlagsToLower(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -130,98 +134,23 @@ func TestOptionalFlagsToLower(t *testing.T) {
 			input:    map[string]string{},
 			expected: map[string]string{},
 		},
+		{
+			name: "uppercase keys",
+			input: map[string]string{
+				"FOO": "bar",
+				"BAZ": "qux",
+			},
+			expected: map[string]string{
+				"foo": "bar",
+				"baz": "qux",
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := optionalFlagsToLower(tt.input)
-
-			if len(result) != len(tt.expected) {
-				t.Errorf("expected %d keys, got %d", len(tt.expected), len(result))
-			}
-
-			for key, expectedValue := range tt.expected {
-				resultValue, ok := result[key]
-				if !ok {
-					t.Errorf("expected key %q to be present in result", key)
-					continue
-				}
-				if resultValue != expectedValue {
-					t.Errorf("key %q: expected value %q, got %q", key, expectedValue, resultValue)
-				}
-			}
-		})
-	}
-}
-
-// TestOptionalFlags_JSONParsing verifies that optional flags JSON string is parsed correctly
-func TestOptionalFlags_JSONParsing(t *testing.T) {
-	tests := []struct {
-		name        string
-		jsonString  string
-		expected    map[string]string
-		expectError bool
-	}{
-		{
-			name:       "valid JSON",
-			jsonString: `{"registry-replacement": "docker.io=quay.io", "add-annotations": "migration=crane"}`,
-			expected: map[string]string{
-				"registry-replacement": "docker.io=quay.io",
-				"add-annotations":      "migration=crane",
-			},
-			expectError: false,
-		},
-		{
-			name:       "empty JSON object",
-			jsonString: `{}`,
-			expected:   map[string]string{},
-			expectError: false,
-		},
-		{
-			name:        "invalid JSON",
-			jsonString:  `{invalid json}`,
-			expectError: true,
-		},
-		{
-			name:       "JSON with special characters",
-			jsonString: `{"pvc-rename-map": "old-pvc-1:new-pvc-1,old-pvc-2:new-pvc-2"}`,
-			expected: map[string]string{
-				"pvc-rename-map": "old-pvc-1:new-pvc-1,old-pvc-2:new-pvc-2",
-			},
-			expectError: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var result map[string]string
-			err := json.Unmarshal([]byte(tt.jsonString), &result)
-
-			if tt.expectError {
-				if err == nil {
-					t.Error("expected error parsing JSON, but got none")
-				}
-				return
-			}
-
-			if err != nil {
-				t.Fatalf("unexpected error parsing JSON: %v", err)
-			}
-
-			if len(result) != len(tt.expected) {
-				t.Errorf("expected %d keys, got %d", len(tt.expected), len(result))
-			}
-
-			for key, expectedValue := range tt.expected {
-				resultValue, ok := result[key]
-				if !ok {
-					t.Errorf("expected key %q to be present in result", key)
-					continue
-				}
-				if resultValue != expectedValue {
-					t.Errorf("key %q: expected value %q, got %q", key, expectedValue, resultValue)
-				}
-			}
+			assertMapEquals(t, tt.expected, result)
 		})
 	}
 }

--- a/cmd/transform/optionals_test.go
+++ b/cmd/transform/optionals_test.go
@@ -1,0 +1,227 @@
+package transform
+
+import (
+	"encoding/json"
+	"testing"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	cranelib "github.com/konveyor/crane-lib/transform"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// mockPluginWithOptionals implements cranelib.Plugin and tracks whether optionals were received
+type mockPluginWithOptionals struct {
+	name              string
+	receivedOptionals map[string]string
+}
+
+func (m *mockPluginWithOptionals) Run(request cranelib.PluginRequest) (cranelib.PluginResponse, error) {
+	// Capture the optionals that were passed to the plugin
+	m.receivedOptionals = request.Extras
+
+	// Return a simple response with no transformations (empty patch)
+	return cranelib.PluginResponse{
+		Version:    string(cranelib.V1),
+		Patches:    jsonpatch.Patch{},
+		IsWhiteOut: false,
+	}, nil
+}
+
+func (m *mockPluginWithOptionals) Metadata() cranelib.PluginMetadata {
+	return cranelib.PluginMetadata{
+		Name:            m.name,
+		Version:         "test",
+		RequestVersion:  []cranelib.Version{cranelib.V1},
+		ResponseVersion: []cranelib.Version{cranelib.V1},
+	}
+}
+
+// TestOptionalFlags_PassedToPlugin verifies that optional flags are passed to plugins via Runner
+func TestOptionalFlags_PassedToPlugin(t *testing.T) {
+	// Setup test optionals
+	testOptionals := map[string]string{
+		"registry-replacement": "docker.io=quay.io",
+		"add-annotations":      "migration=crane,team=platform",
+	}
+
+	// Create mock plugin
+	mockPlugin := &mockPluginWithOptionals{
+		name:              "TestPlugin",
+		receivedOptionals: make(map[string]string),
+	}
+
+	// Create a simple test resource
+	testResource := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name":      "test-configmap",
+				"namespace": "default",
+			},
+			"data": map[string]interface{}{
+				"key": "value",
+			},
+		},
+	}
+
+	log := logrus.New()
+	log.SetLevel(logrus.FatalLevel) // Suppress log output during tests
+
+	// Create runner with optionals - this is what orchestrator uses
+	runner := cranelib.Runner{
+		Log:           log,
+		OptionalFlags: testOptionals,
+	}
+
+	// Run the plugin - this should pass optionals
+	_, err := runner.Run(testResource, []cranelib.Plugin{mockPlugin})
+	if err != nil {
+		t.Fatalf("failed to run plugin: %v", err)
+	}
+
+	// Verify that optionals were passed to the plugin
+	if len(mockPlugin.receivedOptionals) == 0 {
+		t.Fatal("expected plugin to receive optionals, but got none")
+	}
+
+	for key, expectedValue := range testOptionals {
+		receivedValue, ok := mockPlugin.receivedOptionals[key]
+		if !ok {
+			t.Errorf("expected plugin to receive optional key %q, but it was missing", key)
+			continue
+		}
+		if receivedValue != expectedValue {
+			t.Errorf("optional key %q: expected value %q, got %q", key, expectedValue, receivedValue)
+		}
+	}
+}
+
+// TestOptionalFlagsToLower verifies that optional flags keys are lowercased
+func TestOptionalFlagsToLower(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]string
+		expected map[string]string
+	}{
+		{
+			name: "mixed case keys",
+			input: map[string]string{
+				"Registry-Replacement": "docker.io=quay.io",
+				"Add-Annotations":      "migration=crane",
+			},
+			expected: map[string]string{
+				"registry-replacement": "docker.io=quay.io",
+				"add-annotations":      "migration=crane",
+			},
+		},
+		{
+			name: "already lowercase",
+			input: map[string]string{
+				"registry-replacement": "docker.io=quay.io",
+			},
+			expected: map[string]string{
+				"registry-replacement": "docker.io=quay.io",
+			},
+		},
+		{
+			name:     "empty map",
+			input:    map[string]string{},
+			expected: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := optionalFlagsToLower(tt.input)
+
+			if len(result) != len(tt.expected) {
+				t.Errorf("expected %d keys, got %d", len(tt.expected), len(result))
+			}
+
+			for key, expectedValue := range tt.expected {
+				resultValue, ok := result[key]
+				if !ok {
+					t.Errorf("expected key %q to be present in result", key)
+					continue
+				}
+				if resultValue != expectedValue {
+					t.Errorf("key %q: expected value %q, got %q", key, expectedValue, resultValue)
+				}
+			}
+		})
+	}
+}
+
+// TestOptionalFlags_JSONParsing verifies that optional flags JSON string is parsed correctly
+func TestOptionalFlags_JSONParsing(t *testing.T) {
+	tests := []struct {
+		name        string
+		jsonString  string
+		expected    map[string]string
+		expectError bool
+	}{
+		{
+			name:       "valid JSON",
+			jsonString: `{"registry-replacement": "docker.io=quay.io", "add-annotations": "migration=crane"}`,
+			expected: map[string]string{
+				"registry-replacement": "docker.io=quay.io",
+				"add-annotations":      "migration=crane",
+			},
+			expectError: false,
+		},
+		{
+			name:       "empty JSON object",
+			jsonString: `{}`,
+			expected:   map[string]string{},
+			expectError: false,
+		},
+		{
+			name:        "invalid JSON",
+			jsonString:  `{invalid json}`,
+			expectError: true,
+		},
+		{
+			name:       "JSON with special characters",
+			jsonString: `{"pvc-rename-map": "old-pvc-1:new-pvc-1,old-pvc-2:new-pvc-2"}`,
+			expected: map[string]string{
+				"pvc-rename-map": "old-pvc-1:new-pvc-1,old-pvc-2:new-pvc-2",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result map[string]string
+			err := json.Unmarshal([]byte(tt.jsonString), &result)
+
+			if tt.expectError {
+				if err == nil {
+					t.Error("expected error parsing JSON, but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error parsing JSON: %v", err)
+			}
+
+			if len(result) != len(tt.expected) {
+				t.Errorf("expected %d keys, got %d", len(tt.expected), len(result))
+			}
+
+			for key, expectedValue := range tt.expected {
+				resultValue, ok := result[key]
+				if !ok {
+					t.Errorf("expected key %q to be present in result", key)
+					continue
+				}
+				if resultValue != expectedValue {
+					t.Errorf("key %q: expected value %q, got %q", key, expectedValue, resultValue)
+				}
+			}
+		})
+	}
+}

--- a/cmd/transform/transform.go
+++ b/cmd/transform/transform.go
@@ -157,9 +157,12 @@ func addFlagsForOptions(o *Flags, cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&o.ExportDir, "export-dir", "e", "export", "The path where the kubernetes resources are saved")
 	cmd.Flags().StringVarP(&o.TransformDir, "transform-dir", "t", "transform", "The path where files that contain the transformations are saved")
 	cmd.Flags().StringVar(&o.IgnoredPatchesDir, "ignored-patches-dir", "", "The path where files that contain transformations that were discarded due to conflicts are saved. If left blank, these files will not be saved.")
-	cmd.Flags().StringVar(&o.OptionalFlags, "optional-flags", "", "JSON string holding flag value pairs to be passed to all plugins ran in transform operation. (ie. '{\"foo-flag\": \"foo-a=/data,foo-b=/data\", \"bar-flag\": \"bar-value\"}')")
 	cmd.Flags().StringVar(&o.InstructionsFile, "instructions-file", "", "Path to the transform instructions file")
 	cmd.Flags().BoolVar(&o.Force, "force", false, "Force overwrite of existing stage directories even if they contain user modifications")
+
+	// Deprecated: optional-flags will be removed in a future version
+	cmd.Flags().StringVar(&o.OptionalFlags, "optional-flags", "", "(DEPRECATED) JSON string holding flag value pairs to be passed to all plugins. Use custom stages with kustomization instead. (ie. '{\"foo-flag\": \"foo-a=/data,foo-b=/data\", \"bar-flag\": \"bar-value\"}')")
+	cmd.Flags().MarkDeprecated("optional-flags", "use custom stages with kustomization patches instead. This flag applies globally to all stages and will be removed in a future version.")
 
 	// Kustomize arguments
 	cmd.Flags().StringVar(&o.KustomizeArgs, "kustomize-args", "", "Additional arguments for kustomize (e.g., '--enable-helm --helm-command=helm3')")


### PR DESCRIPTION
The original crane plugin system supports optional flags to be passed to plugins. Continuation of these flags was described in https://github.com/migtools/crane/issues/437 with aim to remove it.

However, to stay on safe side, pending crane plugin system update (partially related to #415) and some gut feeling about possible need for args for each transform stage, I chose the way to mark these flags as deprecated, but keeping them for v0.10 release.

Change
1. Marked related flags and subcommands as deprecated in cobra
2. Added small test to check they work (so, we'll see a failure after removing them)

Fixes: https://github.com/migtools/crane/issues/437