### PR TITLE
Add Resource interface and typed K8s resource helpers for e2e framework

### DIFF
--- a/e2e-tests/framework/resources.go
+++ b/e2e-tests/framework/resources.go
@@ -1,0 +1,198 @@
+package framework
+
+import (
+	"fmt"
+	"log"
+	"strings"
+)
+
+type Resource interface {
+	Delete(k KubectlRunner) error
+	Create(k KubectlRunner) error
+}
+
+func ResourceCleanup(clusters []KubectlRunner, resources []Resource) {
+	for _, k := range clusters {
+		for _, r := range resources {
+			if err := r.Delete(k); err != nil {
+				log.Printf("cleanup: %v", err)
+			}
+		}
+	}
+}
+
+type ClusterRole struct {
+	Name     string
+	Verb     string
+	Resource string
+	Label    string
+}
+
+func (cr ClusterRole) Create(k KubectlRunner) error {
+	_, err := k.Run("create", "clusterrole", cr.Name, "--verb="+cr.Verb, "--resource="+cr.Resource)
+	if err != nil {
+		log.Printf("failed to create ClusterRole %s: %v", cr.Name, err)
+		return err
+	}
+	log.Printf("created ClusterRole %s", cr.Name)
+	if cr.Label != "" {
+		_, err = k.Run("label", "clusterrole", cr.Name, cr.Label)
+		if err != nil {
+			return fmt.Errorf("failed to label ClusterRole %s: %w", cr.Name, err)
+		}
+	}
+	return nil
+}
+
+func (cr ClusterRole) Delete(k KubectlRunner) error {
+	_, err := k.Run("delete", "clusterrole", cr.Name, "--ignore-not-found=true")
+	if err != nil {
+		return fmt.Errorf("failed to delete ClusterRole %s: %w", cr.Name, err)
+	}
+	return nil
+}
+
+type ClusterRoleBinding struct {
+	Name            string
+	ClusterRoleName string
+	Subject         string
+	Label           string
+}
+
+func (crb ClusterRoleBinding) Create(k KubectlRunner) error {
+	_, err := k.Run("create", "clusterrolebinding", crb.Name, "--clusterrole="+crb.ClusterRoleName, crb.Subject)
+	if err != nil {
+		log.Printf("failed to create ClusterRoleBinding %s: %v", crb.Name, err)
+		return err
+	}
+	log.Printf("created ClusterRoleBinding %s -> ClusterRole %s", crb.Name, crb.ClusterRoleName)
+	if crb.Label != "" {
+		_, err = k.Run("label", "clusterrolebinding", crb.Name, crb.Label)
+		if err != nil {
+			return fmt.Errorf("failed to label ClusterRoleBinding %s: %w", crb.Name, err)
+		}
+	}
+	return nil
+}
+
+func (crb ClusterRoleBinding) Delete(k KubectlRunner) error {
+	_, err := k.Run("delete", "clusterrolebinding", crb.Name, "--ignore-not-found=true")
+	if err != nil {
+		return fmt.Errorf("failed to delete ClusterRoleBinding %s: %w", crb.Name, err)
+	}
+	return nil
+}
+
+type ServiceAccount struct {
+	Name      string
+	Namespace string
+	Label     string
+}
+
+func (sa ServiceAccount) Create(k KubectlRunner) error {
+	_, err := k.Run("create", "serviceaccount", sa.Name, "-n", sa.Namespace)
+	if err != nil {
+		log.Printf("failed to create ServiceAccount %s in %s: %v", sa.Name, sa.Namespace, err)
+		return err
+	}
+	log.Printf("created ServiceAccount %s in %s", sa.Name, sa.Namespace)
+	if sa.Label != "" {
+		_, err = k.Run("label", "serviceaccount", sa.Name, "-n", sa.Namespace, sa.Label)
+		if err != nil {
+			return fmt.Errorf("failed to label ServiceAccount %s: %w", sa.Name, err)
+		}
+	}
+	return nil
+}
+
+func (sa ServiceAccount) Delete(k KubectlRunner) error {
+	_, err := k.Run("delete", "serviceaccount", sa.Name, "-n", sa.Namespace, "--ignore-not-found=true")
+	if err != nil {
+		return fmt.Errorf("failed to delete ServiceAccount %s: %w", sa.Name, err)
+	}
+	return nil
+}
+
+type CustomResourceDefinition struct {
+	Name string
+	YAML string
+}
+
+func (crd CustomResourceDefinition) Create(k KubectlRunner) error {
+	_, err := k.RunWithStdin(crd.YAML, "apply", "-f", "-")
+	if err != nil {
+		log.Printf("failed to create CRD %s: %v", crd.Name, err)
+	} else {
+		log.Printf("created CRD %s", crd.Name)
+	}
+	return err
+}
+
+func (crd CustomResourceDefinition) Delete(k KubectlRunner) error {
+	_, err := k.Run("delete", "crd", crd.Name, "--ignore-not-found=true")
+	if err != nil {
+		return fmt.Errorf("failed to delete CRD %s: %w", crd.Name, err)
+	}
+	return nil
+}
+
+func (crd CustomResourceDefinition) WaitForEstablished(k KubectlRunner) error {
+	_, err := k.Run("wait", "--for=condition=Established", "crd/"+crd.Name, "--timeout=30s")
+	if err != nil {
+		return fmt.Errorf("CRD %s not established: %w", crd.Name, err)
+	}
+	log.Printf("CRD %s is Established", crd.Name)
+	return nil
+}
+
+type CustomResource struct {
+	Name      string
+	Namespace string
+	Kind      string
+	YAML      string
+}
+
+func (cr CustomResource) Create(k KubectlRunner) error {
+	_, err := k.RunWithStdin(cr.YAML, "apply", "-f", "-", "-n", cr.Namespace)
+	if err != nil {
+		log.Printf("failed to create %s %s: %v", cr.Kind, cr.Name, err)
+	} else {
+		log.Printf("created %s %s in %s", cr.Kind, cr.Name, cr.Namespace)
+	}
+	return err
+}
+
+func (cr CustomResource) Delete(k KubectlRunner) error {
+	_, err := k.Run("delete", strings.ToLower(cr.Kind), cr.Name, "-n", cr.Namespace, "--ignore-not-found=true")
+	if err != nil {
+		return fmt.Errorf("failed to delete %s %s: %w", cr.Kind, cr.Name, err)
+	}
+	return nil
+}
+
+type Namespace struct {
+	Name  string
+	Label string
+}
+
+func (n Namespace) Create(k KubectlRunner) error {
+	if err := k.CreateNamespace(n.Name); err != nil {
+		return fmt.Errorf("failed to create namespace %s: %w", n.Name, err)
+	}
+	log.Printf("created namespace %s", n.Name)
+	if n.Label != "" {
+		_, err := k.Run("label", "namespace", n.Name, n.Label)
+		if err != nil {
+			return fmt.Errorf("failed to label namespace %s: %w", n.Name, err)
+		}
+	}
+	return nil
+}
+
+func (n Namespace) Delete(k KubectlRunner) error {
+	_, err := k.Run("delete", "namespace", n.Name, "--ignore-not-found=true", "--wait=true")
+	if err != nil {
+		return fmt.Errorf("failed to delete namespace %s: %w", n.Name, err)
+	}
+	return nil
+}

--- a/e2e-tests/framework/resources.go
+++ b/e2e-tests/framework/resources.go
@@ -3,7 +3,6 @@ package framework
 import (
 	"fmt"
 	"log"
-	"strings"
 )
 
 type Resource interface {
@@ -31,8 +30,7 @@ type ClusterRole struct {
 func (cr ClusterRole) Create(k KubectlRunner) error {
 	_, err := k.Run("create", "clusterrole", cr.Name, "--verb="+cr.Verb, "--resource="+cr.Resource)
 	if err != nil {
-		log.Printf("failed to create ClusterRole %s: %v", cr.Name, err)
-		return err
+		return fmt.Errorf("failed to create ClusterRole %s: %w", cr.Name, err)
 	}
 	log.Printf("created ClusterRole %s", cr.Name)
 	if cr.Label != "" {
@@ -62,8 +60,7 @@ type ClusterRoleBinding struct {
 func (crb ClusterRoleBinding) Create(k KubectlRunner) error {
 	_, err := k.Run("create", "clusterrolebinding", crb.Name, "--clusterrole="+crb.ClusterRoleName, crb.Subject)
 	if err != nil {
-		log.Printf("failed to create ClusterRoleBinding %s: %v", crb.Name, err)
-		return err
+		return fmt.Errorf("failed to create ClusterRoleBinding %s: %w", crb.Name, err)
 	}
 	log.Printf("created ClusterRoleBinding %s -> ClusterRole %s", crb.Name, crb.ClusterRoleName)
 	if crb.Label != "" {
@@ -92,8 +89,7 @@ type ServiceAccount struct {
 func (sa ServiceAccount) Create(k KubectlRunner) error {
 	_, err := k.Run("create", "serviceaccount", sa.Name, "-n", sa.Namespace)
 	if err != nil {
-		log.Printf("failed to create ServiceAccount %s in %s: %v", sa.Name, sa.Namespace, err)
-		return err
+		return fmt.Errorf("failed to create ServiceAccount %s in %s: %w", sa.Name, sa.Namespace, err)
 	}
 	log.Printf("created ServiceAccount %s in %s", sa.Name, sa.Namespace)
 	if sa.Label != "" {
@@ -121,11 +117,10 @@ type CustomResourceDefinition struct {
 func (crd CustomResourceDefinition) Create(k KubectlRunner) error {
 	_, err := k.RunWithStdin(crd.YAML, "apply", "-f", "-")
 	if err != nil {
-		log.Printf("failed to create CRD %s: %v", crd.Name, err)
-	} else {
-		log.Printf("created CRD %s", crd.Name)
+		return fmt.Errorf("failed to create CRD %s: %w", crd.Name, err)
 	}
-	return err
+	log.Printf("created CRD %s", crd.Name)
+	return nil
 }
 
 func (crd CustomResourceDefinition) Delete(k KubectlRunner) error {
@@ -149,23 +144,26 @@ type CustomResource struct {
 	Name      string
 	Namespace string
 	Kind      string
+	Resource  string
 	YAML      string
 }
 
 func (cr CustomResource) Create(k KubectlRunner) error {
 	_, err := k.RunWithStdin(cr.YAML, "apply", "-f", "-", "-n", cr.Namespace)
 	if err != nil {
-		log.Printf("failed to create %s %s: %v", cr.Kind, cr.Name, err)
-	} else {
-		log.Printf("created %s %s in %s", cr.Kind, cr.Name, cr.Namespace)
+		return fmt.Errorf("failed to create %s %s: %w", cr.Kind, cr.Name, err)
 	}
-	return err
+	log.Printf("created %s %s in %s", cr.Kind, cr.Name, cr.Namespace)
+	return nil
 }
 
 func (cr CustomResource) Delete(k KubectlRunner) error {
-	_, err := k.Run("delete", strings.ToLower(cr.Kind), cr.Name, "-n", cr.Namespace, "--ignore-not-found=true")
+	if cr.Resource == "" {
+		return fmt.Errorf("failed to delete %s %s: missing API resource name for kind %s", cr.Kind, cr.Name, cr.Kind)
+	}
+	_, err := k.Run("delete", cr.Resource, cr.Name, "-n", cr.Namespace, "--ignore-not-found=true")
 	if err != nil {
-		return fmt.Errorf("failed to delete %s %s: %w", cr.Kind, cr.Name, err)
+		return fmt.Errorf("failed to delete %s %s (api resource %s): %w", cr.Kind, cr.Name, cr.Resource, err)
 	}
 	return nil
 }
@@ -190,7 +188,7 @@ func (n Namespace) Create(k KubectlRunner) error {
 }
 
 func (n Namespace) Delete(k KubectlRunner) error {
-	_, err := k.Run("delete", "namespace", n.Name, "--ignore-not-found=true", "--wait=true")
+	_, err := k.Run("delete", "namespace", n.Name, "--ignore-not-found=true", "--wait=true", "--timeout=60s")
 	if err != nil {
 		return fmt.Errorf("failed to delete namespace %s: %w", n.Name, err)
 	}


### PR DESCRIPTION
## Summary

Introduces a `Resource` interface and typed structs for managing Kubernetes resources in e2e tests.

Each K8s resource type (ClusterRole, ClusterRoleBinding, ServiceAccount, CRD, CustomResource, Namespace) is represented as a struct with `Create` and `Delete` methods. As tests grow in complexity, new operations can be added to any resource type — waiting for conditions, patching, field assertions, etc. — and every test using that type picks them up automatically.

This replaces the current pattern of inline `k.Run(...)` calls, where resource logic is duplicated across tests. With typed structs, resource behavior lives in one place: if an operation needs to change (e.g. to work on OpenShift, not just minikube), it's a single method fix rather than a change in every test. New resource types can be added to `resources.go` as needed.

A `ResourceCleanup` helper handles teardown for any combination of resources across clusters in one call.

## Why this matters

- **Extensible**: Adding new operations to a resource type (e.g. `WaitForEstablished`, `Patch`, `AssertField`) is one method on one struct — all tests benefit without changes.
- **Single point of change**: Platform-specific or environment-specific differences are handled in one place, not scattered across test files.
- **Scales with test complexity**: Upcoming tests manage cluster-scoped resources (ClusterRoles, CRDs, custom resources) — typed structs keep that manageable as the resource count per test grows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end testing framework with enhanced Kubernetes resource management capabilities and automated cleanup of test resources across clusters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->