### PR TITLE
Fixed bug 419: same group validation in both include & exclude flags

### DIFF
--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -113,6 +113,17 @@ func (o *ExportOptions) Validate() error {
 			return fmt.Errorf("invalid --label-selector: %w", err)
 		}
 	}
+	if len(o.crdSkipGroups) > 0 && len(o.crdIncludeGroups) > 0 {
+		includeSet := make(map[string]bool, len(o.crdIncludeGroups))
+		for _, g := range o.crdIncludeGroups {
+			includeSet[g] = true
+		}
+		for _, g := range o.crdSkipGroups {
+			if includeSet[g] {
+				return fmt.Errorf("CRD group %q appears in both --crd-skip-group and --crd-include-group", g)
+			}
+		}
+	}
 	return nil
 }
 

--- a/cmd/export/export_test.go
+++ b/cmd/export/export_test.go
@@ -292,6 +292,68 @@ func TestValidate_ContextConflicts(t *testing.T) {
 	}
 }
 
+func TestValidate_CRDGroupConflict(t *testing.T) {
+	tests := []struct {
+		name             string
+		crdSkipGroups    []string
+		crdIncludeGroups []string
+		wantErr          bool
+		wantSubstr       string
+	}{
+		{
+			name:             "no overlap - ok",
+			crdSkipGroups:    []string{"foo.io"},
+			crdIncludeGroups: []string{"bar.io"},
+		},
+		{
+			name:             "overlap - error",
+			crdSkipGroups:    []string{"example.com"},
+			crdIncludeGroups: []string{"example.com"},
+			wantErr:          true,
+			wantSubstr:       "example.com",
+		},
+		{
+			name:             "partial overlap - error on first match",
+			crdSkipGroups:    []string{"foo.io", "bar.io"},
+			crdIncludeGroups: []string{"bar.io", "baz.io"},
+			wantErr:          true,
+			wantSubstr:       "bar.io",
+		},
+		{
+			name:          "skip only - ok",
+			crdSkipGroups: []string{"foo.io"},
+		},
+		{
+			name:             "include only - ok",
+			crdIncludeGroups: []string{"foo.io"},
+		},
+		{
+			name: "both empty - ok",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := &ExportOptions{
+				configFlags:      genericclioptions.NewConfigFlags(true),
+				crdSkipGroups:    tt.crdSkipGroups,
+				crdIncludeGroups: tt.crdIncludeGroups,
+			}
+
+			err := o.Validate()
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantErr && err != nil && !strings.Contains(err.Error(), tt.wantSubstr) {
+				t.Fatalf("error = %q, want substring %q", err.Error(), tt.wantSubstr)
+			}
+		})
+	}
+}
+
 func TestNewExportCommand(t *testing.T) {
 	streams := genericclioptions.NewTestIOStreamsDiscard()
 	cmd := NewExportCommand(streams, nil)


### PR DESCRIPTION
 ## Summary

  - Add validation in `ExportOptions.Validate()` to reject conflicting CRD group flags when the same API group appears in both `--crd-skip-group` and `--crd-include-group`
  - Previously, the command silently accepted the contradiction and `--crd-include-group` took precedence without any warning
  - Add 6 unit test cases covering: no overlap, exact overlap, partial overlap, skip-only, include-only, and both empty

  Fixes #419

  ## Test plan

  - [x] Unit tests pass (`go test ./cmd/export/ -run TestValidate_CRDGroupConflict`)
  - [x] All 6 scenarios covered:
    - No overlap between skip and include groups — succeeds
    - Same group in both flags — errors with `CRD group "example.com" appears in both --crd-skip-group and --crd-include-group`
    - Partial overlap across multiple groups — errors on first conflicting group
    - Skip-only, include-only, both empty — all succeed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Export command now validates CRD configuration to prevent conflicting settings where the same API group appears in both skip and include parameters.

* **Tests**
  * Added test coverage for CRD group conflict validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->