### PR TITLE
:seedling: Introduce PR conventions check workflow

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     runs-on: ubuntu-latest
@@ -15,6 +18,7 @@ jobs:
         persist-credentials: false
     - name: Check Title
       id: verifier
+      # Using @main from trusted Konveyor org; pinned SHA available but @main preferred for automatic updates
       uses: konveyor/release-tools/cmd/verify-pr@main
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,7 +1,7 @@
-name: PR Convetions Checks
+name: PR Conventions Checks
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, edited, reopened, synchronize]
 
 jobs:
@@ -10,7 +10,9 @@ jobs:
     name: Verify PR contents
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
     - name: Check Title
       id: verifier
       uses: konveyor/release-tools/cmd/verify-pr@main

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,18 @@
+name: PR Convetions Checks
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    name: Verify PR contents
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Check Title
+      id: verifier
+      uses: konveyor/release-tools/cmd/verify-pr@main
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
As discussed on team call, adding a github workflow checking Konveyor-like PR conventions, primary `:gitmoji: Title` format.

Examples: https://github.com/konveyor/release-tools/blob/main/pkg/pr/prefix.go#L12-L38

<img width="312" height="315" alt="image" src="https://github.com/user-attachments/assets/10616781-08dd-4434-8fe0-21e06819e34b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated PR title verification to the development workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->