### PR TITLE
Upgrade crane-lib for Job resource cleanup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/gnostic-models v0.7.0
 	github.com/google/go-cmp v0.7.0
 	github.com/jarcoal/httpmock v1.2.0
-	github.com/konveyor/crane-lib v0.1.6-0.20260414113823-a9f07d55042b
+	github.com/konveyor/crane-lib v0.1.6-0.20260618130404-9791be7b44bd
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.0
@@ -19,6 +19,7 @@ require (
 	github.com/openshift/library-go v0.0.0-20260318142011-72bf34f474bc
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.10.0
+	github.com/spf13/pflag v1.0.9
 	github.com/spf13/viper v1.12.0
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/mod v0.32.0
@@ -79,7 +80,6 @@ require (
 	github.com/spf13/afero v1.9.2 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/subosito/gotenv v1.3.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -339,8 +339,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/konveyor/crane-lib v0.1.6-0.20260414113823-a9f07d55042b h1:0zzw6KX9EodCBsMswlOUfdWqFddoxJ+0qWDnj6TWa5w=
-github.com/konveyor/crane-lib v0.1.6-0.20260414113823-a9f07d55042b/go.mod h1:oYw915/11lZhW5k+nVxZtWdpl5AGc0lL52Z1YcKjU7Y=
+github.com/konveyor/crane-lib v0.1.6-0.20260618130404-9791be7b44bd h1:40YRFVxxE2zq1jxtpZ7tCvQgEmEQz9GaZLqDdn5liz4=
+github.com/konveyor/crane-lib v0.1.6-0.20260618130404-9791be7b44bd/go.mod h1:oYw915/11lZhW5k+nVxZtWdpl5AGc0lL52Z1YcKjU7Y=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
There was a recent change in KubernetesPlugin regarding to Job resource cleanup in https://github.com/migtools/crane-lib/pull/138

Updating crane-lib dependency to get this update into crane.

Related to https://github.com/migtools/crane-lib/pull/138

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `crane-lib` dependency to latest version
  * Promoted `pflag` from indirect to direct dependency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->