### PR TITLE
fix: resolve duplicate suggestion text in validate output reason column

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,13 @@ vendor/
 
 crane
 .DS_Store
+
+
+# My Personal Tools and Scripts
+scripts/ship_it.sh
+scripts/mac_refresh.py
+scripts/slack.py
+slack-creds-extractor-main/
+crane-test/
+.claude/
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -17,13 +17,3 @@ vendor/
 
 crane
 .DS_Store
-
-
-# My Personal Tools and Scripts
-scripts/ship_it.sh
-scripts/mac_refresh.py
-scripts/slack.py
-slack-creds-extractor-main/
-crane-test/
-.claude/
-.env

--- a/internal/validate/matcher.go
+++ b/internal/validate/matcher.go
@@ -167,6 +167,5 @@ func addSuggestion(result *ValidationResult, entry ManifestEntry, kindIndex map[
 	sort.Strings(available)
 	suggestion := fmt.Sprintf("available as %s", strings.Join(available, ", "))
 	result.Suggestion = suggestion
-	result.Reason = fmt.Sprintf("%s (%s)", result.Reason, suggestion)
 }
 

--- a/internal/validate/matcher_test.go
+++ b/internal/validate/matcher_test.go
@@ -164,9 +164,6 @@ func TestMatchResults_SuggestionWhenAlternativeExists(t *testing.T) {
 	if !strings.Contains(r.Suggestion, "apps/v1") {
 		t.Fatalf("Suggestion = %q, expected it to mention apps/v1", r.Suggestion)
 	}
-	if !strings.Contains(r.Reason, "available as") {
-		t.Fatalf("Reason = %q, expected it to contain suggestion hint", r.Reason)
-	}
 }
 
 func TestMatchResults_NoSuggestionWhenKindNotOnTarget(t *testing.T) {


### PR DESCRIPTION
[#382](https://github.com/migtools/crane/issues/382)

## 📝 Summary

This PR fixes an issue where the output of `crane validate` duplicated the suggestion text inside the `REASON` column, causing jumbled and overly wide tables on smaller screens. 

### 🕵️‍♂️ Root Cause
In `internal/validate/matcher.go`, the `addSuggestion` function was responsible for both setting `result.Suggestion` and appending the same text to `result.Reason`. This second operation was completely redundant since the suggestion already had its own dedicated field and column in the output table.

### 🛠️ Fix Applied
- Removed the line that appended the suggestion to `result.Reason` in `internal/validate/matcher.go`.
- The `REASON` column now correctly contains only the reason for incompatibility, while the `SUGGESTION` column shows the alternatives.

### 🧪 Test Changes
- Updated `TestMatchResults_SuggestionWhenAlternativeExists` in `internal/validate/matcher_test.go` to remove the assertion that checked if `Reason` contains "available as", as this was validating the old incorrect behavior.