### PR TITLE
:test_tube: strengthen MTA-828 transform directory structure assertions

### DIFF
--- a/e2e-tests/tests/tier0/mta_828_instructions_file_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_828_instructions_file_migration_test.go
@@ -88,15 +88,24 @@ var _ = Describe("Instructions-file migration", func() {
 		By("Verify transform directory structure")
 		workDirPath := filepath.Join(paths.TransformDir, ".work")
 		_, err = os.Stat(workDirPath)
-		Expect(os.IsNotExist(err)).To(BeTrue(), fmt.Sprintf("did not expect legacy transform work dir at %q", workDirPath))
+		if err == nil {
+			Fail(fmt.Sprintf("did not expect legacy transform work dir at %q, but it exists", workDirPath))
+		}
+		if !os.IsNotExist(err) {
+			Fail(fmt.Sprintf(
+				"unexpected error while checking legacy transform work dir at %q: err=%v type=%T",
+				workDirPath, err, err,
+			))
+		}
 
 		stageSubDirs := []string{"input", "output"}
 		for _, stageDir := range stageDirectories {
 			stagePath := filepath.Join(paths.TransformDir, stageDir)
 			for _, subDir := range stageSubDirs {
 				subDirPath := filepath.Join(stagePath, subDir)
-				_, err = os.Stat(subDirPath)
-				Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("expected stage subdir %q at %q to be present", subDir, subDirPath))
+				subDirInfo, statErr := os.Stat(subDirPath)
+				Expect(statErr).NotTo(HaveOccurred(), fmt.Sprintf("expected stage subdir %q at %q to be present", subDir, subDirPath))
+				Expect(subDirInfo.IsDir()).To(BeTrue(), fmt.Sprintf("expected stage subdir %q at %q to be a directory", subDir, subDirPath))
 
 				yamlFileCount := 0
 				walkErr := filepath.WalkDir(subDirPath, func(path string, d os.DirEntry, walkErr error) error {

--- a/e2e-tests/tests/tier0/mta_828_instructions_file_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_828_instructions_file_migration_test.go
@@ -5,12 +5,14 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/konveyor/crane/e2e-tests/config"
 	. "github.com/konveyor/crane/e2e-tests/framework"
 	"github.com/konveyor/crane/e2e-tests/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"sigs.k8s.io/yaml"
 )
 
 var _ = Describe("Instructions-file migration", func() {
@@ -82,6 +84,60 @@ var _ = Describe("Instructions-file migration", func() {
 			_, err = os.Stat(dirPath)
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("expected stage dir %q at %q to be present", stageDir, dirPath))
 		}
+
+		By("Verify transform directory structure")
+		workDirPath := filepath.Join(paths.TransformDir, ".work")
+		_, err = os.Stat(workDirPath)
+		Expect(os.IsNotExist(err)).To(BeTrue(), fmt.Sprintf("did not expect legacy transform work dir at %q", workDirPath))
+
+		stageSubDirs := []string{"input", "output"}
+		for _, stageDir := range stageDirectories {
+			stagePath := filepath.Join(paths.TransformDir, stageDir)
+			for _, subDir := range stageSubDirs {
+				subDirPath := filepath.Join(stagePath, subDir)
+				_, err = os.Stat(subDirPath)
+				Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("expected stage subdir %q at %q to be present", subDir, subDirPath))
+
+				yamlFileCount := 0
+				walkErr := filepath.WalkDir(subDirPath, func(path string, d os.DirEntry, walkErr error) error {
+					if walkErr != nil {
+						return walkErr
+					}
+					if d.IsDir() {
+						return nil
+					}
+					if strings.HasSuffix(d.Name(), ".yaml") {
+						yamlFileCount++
+					}
+					return nil
+				})
+				Expect(walkErr).NotTo(HaveOccurred(), fmt.Sprintf("failed to walk yaml files in %q", subDirPath))
+				Expect(yamlFileCount).To(BeNumerically(">", 0), fmt.Sprintf("expected yaml files in %q", subDirPath))
+			}
+
+			kustomizationPath := filepath.Join(stagePath, "kustomization.yaml")
+			kustomizationBytes, readErr := os.ReadFile(kustomizationPath)
+			Expect(readErr).NotTo(HaveOccurred(), fmt.Sprintf("expected kustomization file at %q", kustomizationPath))
+
+			kustomization := map[string]any{}
+			unmarshalErr := yaml.Unmarshal(kustomizationBytes, &kustomization)
+			Expect(unmarshalErr).NotTo(HaveOccurred(), fmt.Sprintf("failed to parse kustomization yaml at %q", kustomizationPath))
+
+			resourcesRaw, exists := kustomization["resources"]
+			Expect(exists).To(BeTrue(), fmt.Sprintf("expected resources field in kustomization %q", kustomizationPath))
+
+			resources, ok := resourcesRaw.([]any)
+			Expect(ok).To(BeTrue(), fmt.Sprintf("expected resources in %q to be []any but got %T", kustomizationPath, resourcesRaw))
+			Expect(resources).NotTo(BeEmpty(), fmt.Sprintf("expected resources list in %q to be non-empty", kustomizationPath))
+
+			for i, resourceRaw := range resources {
+				resourcePath, pathOK := resourceRaw.(string)
+				Expect(pathOK).To(BeTrue(), fmt.Sprintf("expected resources[%d] in %q to be string but got %T", i, kustomizationPath, resourceRaw))
+				Expect(resourcePath).To(HavePrefix("input/"), fmt.Sprintf("expected resources[%d]=%q in %q to reference input/ path", i, resourcePath, kustomizationPath))
+				Expect(resourcePath).NotTo(ContainSubstring("resources/"), fmt.Sprintf("did not expect legacy resources/ path in resources[%d]=%q in %q", i, resourcePath, kustomizationPath))
+			}
+		}
+
 		log.Printf("Running crane apply for namespace %s\n", srcApp.Namespace)
 		Expect(runner.Apply(paths.ExportDir, paths.TransformDir, paths.OutputDir)).NotTo(HaveOccurred())
 		log.Printf("Crane pipeline completed for namespace %s\n", srcApp.Namespace)


### PR DESCRIPTION
## Summary
- Strengthens `MTA-828` e2e coverage for transform stage directory layout introduced by #555.
- Adds explicit assertions that legacy `transform/.work` is not created.
- Validates both instructions-file stages (`10_KubernetesPlugin`, `20_CustomStage`) for:
  - presence of `input/` and `output/` directories
  - recursive presence of YAML manifests in both directories
- Parses each stage `kustomization.yaml` as YAML and verifies:
  - `resources` field exists and is non-empty
  - each resource entry is a string path under `input/`
  - no legacy `resources/` path references remain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive validation tests for the instructions-file migration feature to verify proper output directory structure, presence of input/output subdirectories, YAML file organization, and kustomization configuration integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->