### PR TITLE
crane validate --api-resources fails when KUBECONFIG is set

### DIFF
--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -46,7 +46,7 @@ func (o *ValidateOptions) Complete(c *cobra.Command, args []string) error {
 }
 
 // Validate checks that flags have valid values.
-func (o *ValidateOptions) Validate() error {
+func (o *ValidateOptions) Validate(cmd *cobra.Command) error {
 	info, err := os.Stat(o.inputDir)
 	if err != nil {
 		return fmt.Errorf("input-dir %q: %w", o.inputDir, err)
@@ -61,22 +61,25 @@ func (o *ValidateOptions) Validate() error {
 	}
 
 	if o.apiResourcesFile != "" {
-		if o.configFlags.Context != nil && *o.configFlags.Context != "" {
+		// Only enforce mutual exclusivity if kubeconfig flags were EXPLICITLY set by user.
+		// Ignore default kubeconfig loaded from KUBECONFIG env var or ~/.kube/config.
+		// This allows offline validation to work in CI/CD environments where KUBECONFIG is set.
+		if cmd.Flags().Changed("context") {
 			return fmt.Errorf("--api-resources and --context are mutually exclusive; use --api-resources for offline validation or --context for live validation")
 		}
-		if o.configFlags.KubeConfig != nil && *o.configFlags.KubeConfig != "" {
+		if cmd.Flags().Changed("kubeconfig") {
 			return fmt.Errorf("--api-resources and --kubeconfig are mutually exclusive; use --api-resources for offline validation or --kubeconfig for live validation")
 		}
-		if o.configFlags.APIServer != nil && *o.configFlags.APIServer != "" {
+		if cmd.Flags().Changed("server") {
 			return fmt.Errorf("--api-resources and --server are mutually exclusive; use --api-resources for offline validation or --server for live validation")
 		}
-		if o.configFlags.BearerToken != nil && *o.configFlags.BearerToken != "" {
+		if cmd.Flags().Changed("token") {
 			return fmt.Errorf("--api-resources and --token are mutually exclusive; use --api-resources for offline validation or --token for live validation")
 		}
-		if o.configFlags.ClusterName != nil && *o.configFlags.ClusterName != "" {
+		if cmd.Flags().Changed("cluster") {
 			return fmt.Errorf("--api-resources and --cluster are mutually exclusive; use --api-resources for offline validation or --cluster for live validation")
 		}
-		if o.configFlags.AuthInfoName != nil && *o.configFlags.AuthInfoName != "" {
+		if cmd.Flags().Changed("user") {
 			return fmt.Errorf("--api-resources and --user are mutually exclusive; use --api-resources for offline validation or --user for live validation")
 		}
 		if _, err := os.Stat(o.apiResourcesFile); err != nil {
@@ -223,7 +226,7 @@ failed (or another error occurred).`,
 			if err := o.Complete(c, args); err != nil {
 				return err
 			}
-			if err := o.Validate(); err != nil {
+			if err := o.Validate(c); err != nil {
 				return err
 			}
 			if err := o.Run(); err != nil {

--- a/cmd/validate/validate_test.go
+++ b/cmd/validate/validate_test.go
@@ -42,10 +42,11 @@ func TestNewValidateCommand(t *testing.T) {
 
 func TestValidate_Flags(t *testing.T) {
 	tests := []struct {
-		name     string
-		setup    func(t *testing.T) *ValidateOptions
-		wantErr  bool
-		errMatch string
+		name                     string
+		setup                    func(t *testing.T) *ValidateOptions
+		wantErr                  bool
+		errMatch                 string
+		setMutualExclusionFlags  bool // If true, explicitly mark kubeconfig-related flags as changed
 	}{
 		{
 			name: "missing input-dir",
@@ -167,8 +168,9 @@ func TestValidate_Flags(t *testing.T) {
 					apiResourcesFile: f,
 				}
 			},
-			wantErr:  true,
-			errMatch: "--api-resources and --context are mutually exclusive",
+			wantErr:                 true,
+			errMatch:                "--api-resources and --context are mutually exclusive",
+			setMutualExclusionFlags: true,
 		},
 		{
 			name: "api-resources with --kubeconfig is mutually exclusive",
@@ -188,8 +190,9 @@ func TestValidate_Flags(t *testing.T) {
 					apiResourcesFile: f,
 				}
 			},
-			wantErr:  true,
-			errMatch: "--api-resources and --kubeconfig are mutually exclusive",
+			wantErr:                 true,
+			errMatch:                "--api-resources and --kubeconfig are mutually exclusive",
+			setMutualExclusionFlags: true,
 		},
 		{
 			name: "api-resources with --server is mutually exclusive",
@@ -209,8 +212,9 @@ func TestValidate_Flags(t *testing.T) {
 					apiResourcesFile: f,
 				}
 			},
-			wantErr:  true,
-			errMatch: "--api-resources and --server are mutually exclusive",
+			wantErr:                 true,
+			errMatch:                "--api-resources and --server are mutually exclusive",
+			setMutualExclusionFlags: true,
 		},
 		{
 			name: "api-resources with --token is mutually exclusive",
@@ -230,8 +234,9 @@ func TestValidate_Flags(t *testing.T) {
 					apiResourcesFile: f,
 				}
 			},
-			wantErr:  true,
-			errMatch: "--api-resources and --token are mutually exclusive",
+			wantErr:                 true,
+			errMatch:                "--api-resources and --token are mutually exclusive",
+			setMutualExclusionFlags: true,
 		},
 		{
 			name: "api-resources with --cluster is mutually exclusive",
@@ -251,8 +256,9 @@ func TestValidate_Flags(t *testing.T) {
 					apiResourcesFile: f,
 				}
 			},
-			wantErr:  true,
-			errMatch: "--api-resources and --cluster are mutually exclusive",
+			wantErr:                 true,
+			errMatch:                "--api-resources and --cluster are mutually exclusive",
+			setMutualExclusionFlags: true,
 		},
 		{
 			name: "api-resources with --user is mutually exclusive",
@@ -272,8 +278,9 @@ func TestValidate_Flags(t *testing.T) {
 					apiResourcesFile: f,
 				}
 			},
-			wantErr:  true,
-			errMatch: "--api-resources and --user are mutually exclusive",
+			wantErr:                 true,
+			errMatch:                "--api-resources and --user are mutually exclusive",
+			setMutualExclusionFlags: true,
 		},
 		{
 			name: "api-resources valid file accepted",
@@ -306,25 +313,38 @@ func TestValidate_Flags(t *testing.T) {
 			}
 			o.configFlags.AddFlags(cmd.Flags())
 
-			// For mutual exclusivity tests, simulate flag parsing by marking flags as changed
-			if strings.Contains(tt.name, "mutually exclusive") {
+			// For mutual exclusivity tests, explicitly mark kubeconfig-related flags as changed
+			// to simulate user-provided flags (vs environment/default values)
+			if tt.setMutualExclusionFlags {
 				if o.configFlags.Context != nil && *o.configFlags.Context != "" {
-					cmd.Flags().Set("context", *o.configFlags.Context)
+					if err := cmd.Flags().Set("context", *o.configFlags.Context); err != nil {
+						t.Fatalf("failed to set context flag: %v", err)
+					}
 				}
 				if o.configFlags.KubeConfig != nil && *o.configFlags.KubeConfig != "" {
-					cmd.Flags().Set("kubeconfig", *o.configFlags.KubeConfig)
+					if err := cmd.Flags().Set("kubeconfig", *o.configFlags.KubeConfig); err != nil {
+						t.Fatalf("failed to set kubeconfig flag: %v", err)
+					}
 				}
 				if o.configFlags.APIServer != nil && *o.configFlags.APIServer != "" {
-					cmd.Flags().Set("server", *o.configFlags.APIServer)
+					if err := cmd.Flags().Set("server", *o.configFlags.APIServer); err != nil {
+						t.Fatalf("failed to set server flag: %v", err)
+					}
 				}
 				if o.configFlags.BearerToken != nil && *o.configFlags.BearerToken != "" {
-					cmd.Flags().Set("token", *o.configFlags.BearerToken)
+					if err := cmd.Flags().Set("token", *o.configFlags.BearerToken); err != nil {
+						t.Fatalf("failed to set token flag: %v", err)
+					}
 				}
 				if o.configFlags.ClusterName != nil && *o.configFlags.ClusterName != "" {
-					cmd.Flags().Set("cluster", *o.configFlags.ClusterName)
+					if err := cmd.Flags().Set("cluster", *o.configFlags.ClusterName); err != nil {
+						t.Fatalf("failed to set cluster flag: %v", err)
+					}
 				}
 				if o.configFlags.AuthInfoName != nil && *o.configFlags.AuthInfoName != "" {
-					cmd.Flags().Set("user", *o.configFlags.AuthInfoName)
+					if err := cmd.Flags().Set("user", *o.configFlags.AuthInfoName); err != nil {
+						t.Fatalf("failed to set user flag: %v", err)
+					}
 				}
 			}
 

--- a/cmd/validate/validate_test.go
+++ b/cmd/validate/validate_test.go
@@ -297,7 +297,38 @@ func TestValidate_Flags(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			o := tt.setup(t)
-			err := o.Validate()
+			// Create a minimal cobra command for testing
+			cmd := &cobra.Command{}
+
+			// Ensure configFlags is initialized (some tests don't set it)
+			if o.configFlags == nil {
+				o.configFlags = genericclioptions.NewConfigFlags(true)
+			}
+			o.configFlags.AddFlags(cmd.Flags())
+
+			// For mutual exclusivity tests, simulate flag parsing by marking flags as changed
+			if strings.Contains(tt.name, "mutually exclusive") {
+				if o.configFlags.Context != nil && *o.configFlags.Context != "" {
+					cmd.Flags().Set("context", *o.configFlags.Context)
+				}
+				if o.configFlags.KubeConfig != nil && *o.configFlags.KubeConfig != "" {
+					cmd.Flags().Set("kubeconfig", *o.configFlags.KubeConfig)
+				}
+				if o.configFlags.APIServer != nil && *o.configFlags.APIServer != "" {
+					cmd.Flags().Set("server", *o.configFlags.APIServer)
+				}
+				if o.configFlags.BearerToken != nil && *o.configFlags.BearerToken != "" {
+					cmd.Flags().Set("token", *o.configFlags.BearerToken)
+				}
+				if o.configFlags.ClusterName != nil && *o.configFlags.ClusterName != "" {
+					cmd.Flags().Set("cluster", *o.configFlags.ClusterName)
+				}
+				if o.configFlags.AuthInfoName != nil && *o.configFlags.AuthInfoName != "" {
+					cmd.Flags().Set("user", *o.configFlags.AuthInfoName)
+				}
+			}
+
+			err := o.Validate(cmd)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")


### PR DESCRIPTION
Fixes #570 

Note: The unit tests are failing. I'm working on fixing the unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command validation so offline validation (`--api-resources`) works reliably even when default kubeconfig sources (environment variables or standard kube config paths) are present.
  * Updated mutual-exclusivity handling to only report conflicts when users explicitly set the related kubeconfig/context/client flags.

* **Tests**
  * Updated validation tests to cover the new explicit-flag behavior and ensure correct conflict detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->