### PR TITLE
feat: add manual PR-ready Slack notification workflow

### DIFF
--- a/.github/workflows/pr-ready-for-review-slack.yml
+++ b/.github/workflows/pr-ready-for-review-slack.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
   issues: write
 
 concurrency:

--- a/.github/workflows/pr-ready-for-review-slack.yml
+++ b/.github/workflows/pr-ready-for-review-slack.yml
@@ -123,7 +123,6 @@ jobs:
         with:
           text: |
             :pr-open-1: PR Ready for Review
-            @mta-app-migration
             PR Title: ${{ steps.guard.outputs.pr_title }}
             PR: ${{ steps.guard.outputs.pr_url }}
             Author: @${{ steps.guard.outputs.pr_author }}

--- a/.github/workflows/pr-ready-for-review-slack.yml
+++ b/.github/workflows/pr-ready-for-review-slack.yml
@@ -1,0 +1,98 @@
+name: PR Ready For Review Slack Notification
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+concurrency:
+  group: ready-for-review-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  notify:
+    # issue_comment runs for both issues and PRs; continue only for PR comments.
+    if: ${{ github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate command and PR state
+        id: guard
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          comment_body="$(jq -r '.comment.body // ""' "$GITHUB_EVENT_PATH")"
+          if [[ "$comment_body" != "/ready-for-review" ]]; then
+            echo "should_notify=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          pr_number="$(jq -r '.issue.number' "$GITHUB_EVENT_PATH")"
+          pr_author="$(jq -r '.issue.user.login' "$GITHUB_EVENT_PATH")"
+          commenter="$(jq -r '.comment.user.login' "$GITHUB_EVENT_PATH")"
+          issue_state="$(jq -r '.issue.state' "$GITHUB_EVENT_PATH")"
+
+          if [[ "$issue_state" != "open" ]]; then
+            echo "::notice::Ignoring command because PR #${pr_number} is not open."
+            echo "should_notify=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$commenter" != "$pr_author" ]]; then
+            echo "::notice::Ignoring command from @${commenter}; only PR author @${pr_author} can trigger."
+            echo "should_notify=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if jq -e '.issue.labels[]? | select(.name == "ready-for-review-notified")' "$GITHUB_EVENT_PATH" >/dev/null; then
+            echo "::notice::PR #${pr_number} already has ready-for-review-notified label; skipping duplicate notification."
+            echo "should_notify=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          pr_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}")"
+          is_draft="$(printf '%s' "$pr_json" | jq -r '.draft')"
+          pr_title="$(printf '%s' "$pr_json" | jq -r '.title')"
+          pr_url="$(printf '%s' "$pr_json" | jq -r '.html_url')"
+
+          if [[ "$is_draft" == "true" ]]; then
+            echo "::notice::PR #${pr_number} is still draft; skipping Slack notification."
+            echo "should_notify=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "should_notify=true" >> "$GITHUB_OUTPUT"
+          echo "pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
+          echo "pr_title=${pr_title}" >> "$GITHUB_OUTPUT"
+          echo "pr_url=${pr_url}" >> "$GITHUB_OUTPUT"
+          echo "pr_author=${pr_author}" >> "$GITHUB_OUTPUT"
+          echo "commenter=${commenter}" >> "$GITHUB_OUTPUT"
+
+      - name: Notify Slack for ready-for-review
+        if: steps.guard.outputs.should_notify == 'true'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        uses: ./.github/actions/slack-incoming-webhook
+        with:
+          text: |
+            :eyes: PR Ready for Review
+            *${{ steps.guard.outputs.pr_title }}*
+            PR: ${{ steps.guard.outputs.pr_url }}
+            Author: @${{ steps.guard.outputs.pr_author }}
+            Triggered by: @${{ steps.guard.outputs.commenter }}
+
+      - name: Mark PR as notified
+        if: steps.guard.outputs.should_notify == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}/issues/${{ steps.guard.outputs.pr_number }}/labels" \
+            -X POST \
+            -f labels[]="ready-for-review-notified"

--- a/.github/workflows/pr-ready-for-review-slack.yml
+++ b/.github/workflows/pr-ready-for-review-slack.yml
@@ -16,10 +16,13 @@ concurrency:
 
 jobs:
   notify:
-    # issue_comment runs for both issues and PRs; continue only for PR comments.
+    # issue_comment runs for both issues and PRs; continue only for PR comments. 
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Evaluate command and PR state
         id: guard
         env:
@@ -28,7 +31,7 @@ jobs:
           set -euo pipefail
 
           comment_body="$(jq -r '.comment.body // ""' "$GITHUB_EVENT_PATH")"
-          if [[ "$comment_body" != "/ready-for-review" ]]; then
+          if [[ "$comment_body" != "/ready-for-review" && "$comment_body" != "/ready-for-review-reset" ]]; then
             echo "should_notify=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -46,6 +49,22 @@ jobs:
 
           if [[ "$commenter" != "$pr_author" ]]; then
             echo "::notice::Ignoring command from @${commenter}; only PR author @${pr_author} can trigger."
+            echo "should_notify=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$comment_body" == "/ready-for-review-reset" ]]; then
+            set +e
+            gh api "repos/${GITHUB_REPOSITORY}/issues/${pr_number}/labels/ready-for-review-notified" -X DELETE
+            rc=$?
+            set -e
+
+            if [[ "$rc" -eq 0 ]]; then
+              echo "::notice::Removed ready-for-review-notified label from PR #${pr_number}."
+            else
+              echo "::notice::Label ready-for-review-notified was not present on PR #${pr_number}."
+            fi
+
             echo "should_notify=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/.github/workflows/pr-ready-for-review-slack.yml
+++ b/.github/workflows/pr-ready-for-review-slack.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
   issues: write
 
 concurrency:
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   notify:
-    # issue_comment runs for both issues and PRs; continue only for PR comments. 
+    # issue_comment runs for both issues and PRs; continue only for PR comments 
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     steps:
@@ -100,8 +100,8 @@ jobs:
         uses: ./.github/actions/slack-incoming-webhook
         with:
           text: |
-            :eyes: PR Ready for Review
-            *${{ steps.guard.outputs.pr_title }}*
+            :pr-open-1: PR Ready for Review
+            PR Title: ${{ steps.guard.outputs.pr_title }}
             PR: ${{ steps.guard.outputs.pr_url }}
             Author: @${{ steps.guard.outputs.pr_author }}
             Triggered by: @${{ steps.guard.outputs.commenter }}

--- a/.github/workflows/pr-ready-for-review-slack.yml
+++ b/.github/workflows/pr-ready-for-review-slack.yml
@@ -30,7 +30,9 @@ jobs:
         run: |
           set -euo pipefail
 
+          echo "should_react=false" >> "$GITHUB_OUTPUT"
           comment_body="$(jq -r '.comment.body // ""' "$GITHUB_EVENT_PATH")"
+          comment_body="$(printf '%s' "$comment_body" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//;s/\r$//')"
           if [[ "$comment_body" != "/ready-for-review" && "$comment_body" != "/ready-for-review-reset" ]]; then
             echo "should_notify=false" >> "$GITHUB_OUTPUT"
             exit 0
@@ -52,6 +54,10 @@ jobs:
             echo "should_notify=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+
+          comment_id="$(jq -r '.comment.id' "$GITHUB_EVENT_PATH")"
+          echo "should_react=true" >> "$GITHUB_OUTPUT"
+          echo "comment_id=${comment_id}" >> "$GITHUB_OUTPUT"
 
           if [[ "$comment_body" == "/ready-for-review-reset" ]]; then
             set +e
@@ -91,7 +97,23 @@ jobs:
           echo "pr_title=${pr_title}" >> "$GITHUB_OUTPUT"
           echo "pr_url=${pr_url}" >> "$GITHUB_OUTPUT"
           echo "pr_author=${pr_author}" >> "$GITHUB_OUTPUT"
-          echo "commenter=${commenter}" >> "$GITHUB_OUTPUT"
+
+      - name: React to command comment
+        if: steps.guard.outputs.should_react == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          set +e
+          gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${{ steps.guard.outputs.comment_id }}/reactions" \
+            -X POST \
+            -f content="+1"
+          rc=$?
+          set -e
+
+          if [[ "$rc" -ne 0 ]]; then
+            echo "::warning::Failed to add +1 reaction to the command comment."
+          fi
 
       - name: Notify Slack for ready-for-review
         if: steps.guard.outputs.should_notify == 'true'
@@ -101,10 +123,10 @@ jobs:
         with:
           text: |
             :pr-open-1: PR Ready for Review
+            @mta-app-migration
             PR Title: ${{ steps.guard.outputs.pr_title }}
             PR: ${{ steps.guard.outputs.pr_url }}
             Author: @${{ steps.guard.outputs.pr_author }}
-            Triggered by: @${{ steps.guard.outputs.commenter }}
 
       - name: Mark PR as notified
         if: steps.guard.outputs.should_notify == 'true'
@@ -112,6 +134,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          set +e
           gh api "repos/${GITHUB_REPOSITORY}/issues/${{ steps.guard.outputs.pr_number }}/labels" \
             -X POST \
             -f labels[]="ready-for-review-notified"
+          rc=$?
+          set -e
+
+          if [[ "$rc" -ne 0 ]]; then
+            echo "::warning::Slack message sent, but failed to add ready-for-review-notified label."
+          fi

--- a/.github/workflows/pr-ready-for-review-slack.yml
+++ b/.github/workflows/pr-ready-for-review-slack.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Evaluate command and PR state
         id: guard
@@ -33,7 +35,7 @@ jobs:
           echo "should_react=false" >> "$GITHUB_OUTPUT"
           comment_body="$(jq -r '.comment.body // ""' "$GITHUB_EVENT_PATH")"
           comment_body="$(printf '%s' "$comment_body" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//;s/\r$//')"
-          if [[ "$comment_body" != "/ready-for-review" && "$comment_body" != "/ready-for-review-reset" ]]; then
+          if [[ "$comment_body" != "/ready-for-review" && "$comment_body" != "/rfr" && "$comment_body" != "/ready-for-review-reset" && "$comment_body" != "/rfr-reset" ]]; then
             echo "should_notify=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -59,7 +61,7 @@ jobs:
           echo "should_react=true" >> "$GITHUB_OUTPUT"
           echo "comment_id=${comment_id}" >> "$GITHUB_OUTPUT"
 
-          if [[ "$comment_body" == "/ready-for-review-reset" ]]; then
+          if [[ "$comment_body" == "/ready-for-review-reset" || "$comment_body" == "/rfr-reset" ]]; then
             set +e
             gh api "repos/${GITHUB_REPOSITORY}/issues/${pr_number}/labels/ready-for-review-notified" -X DELETE
             rc=$?
@@ -94,7 +96,11 @@ jobs:
 
           echo "should_notify=true" >> "$GITHUB_OUTPUT"
           echo "pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
-          echo "pr_title=${pr_title}" >> "$GITHUB_OUTPUT"
+          {
+            echo "pr_title<<__EOF__"
+            printf '%s\n' "$pr_title"
+            echo "__EOF__"
+          } >> "$GITHUB_OUTPUT"
           echo "pr_url=${pr_url}" >> "$GITHUB_OUTPUT"
           echo "pr_author=${pr_author}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/pr-ready-for-review-slack.yml
+++ b/.github/workflows/pr-ready-for-review-slack.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
+  pull-requests: read
   issues: write
 
 concurrency:
@@ -77,7 +77,7 @@ jobs:
             exit 0
           fi
 
-          if jq -e '.issue.labels[]? | select(.name == "ready-for-review-notified")' "$GITHUB_EVENT_PATH" >/dev/null; then
+          if gh api "repos/${GITHUB_REPOSITORY}/issues/${pr_number}/labels" | jq -e '.[] | select(.name == "ready-for-review-notified")' >/dev/null; then
             echo "::notice::PR #${pr_number} already has ready-for-review-notified label; skipping duplicate notification."
             echo "should_notify=false" >> "$GITHUB_OUTPUT"
             exit 0
@@ -96,10 +96,11 @@ jobs:
 
           echo "should_notify=true" >> "$GITHUB_OUTPUT"
           echo "pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
+          output_delimiter="__CRANE_PR_TITLE_${pr_number}_EOF__"
           {
-            echo "pr_title<<__EOF__"
+            echo "pr_title<<${output_delimiter}"
             printf '%s\n' "$pr_title"
-            echo "__EOF__"
+            echo "${output_delimiter}"
           } >> "$GITHUB_OUTPUT"
           echo "pr_url=${pr_url}" >> "$GITHUB_OUTPUT"
           echo "pr_author=${pr_author}" >> "$GITHUB_OUTPUT"
@@ -139,13 +140,20 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          set +e
-          gh api "repos/${GITHUB_REPOSITORY}/issues/${{ steps.guard.outputs.pr_number }}/labels" \
-            -X POST \
-            -f labels[]="ready-for-review-notified"
-          rc=$?
-          set -e
+          max_attempts=3
+          for attempt in $(seq 1 "${max_attempts}"); do
+            if gh api "repos/${GITHUB_REPOSITORY}/issues/${{ steps.guard.outputs.pr_number }}/labels" \
+              -X POST \
+              -f labels[]="ready-for-review-notified"; then
+              echo "::notice::Added ready-for-review-notified label to PR #${{ steps.guard.outputs.pr_number }}."
+              exit 0
+            fi
 
-          if [[ "$rc" -ne 0 ]]; then
-            echo "::warning::Slack message sent, but failed to add ready-for-review-notified label."
-          fi
+            if [[ "${attempt}" -lt "${max_attempts}" ]]; then
+              echo "::warning::Failed to add ready-for-review-notified label (attempt ${attempt}/${max_attempts}); retrying."
+              sleep $((attempt * 2))
+            fi
+          done
+
+          echo "::error::Slack message sent, but failed to add ready-for-review-notified label after ${max_attempts} attempts."
+          exit 1


### PR DESCRIPTION
## Summary
- add a new `issue_comment` workflow that sends a Slack notification when PR authors comment `/ready-for-review` (also supports `/rfr`)
- add reset command support (`/ready-for-review-reset`, `/rfr-reset`) to clear the dedupe label and re-enable notifications
- include guardrails for open non-draft PRs, author-only trigger, dedupe label handling, and best-effort comment reaction + non-fatal label updates

## Test plan
- [x] Create/update workflow on fork `main`
- [x] Comment `/ready-for-review` on a test PR and verify Slack message
- [x] Comment `/ready-for-review-reset` and verify label reset behavior
- [x] Re-comment `/ready-for-review` and verify notification can be re-sent
- [ ] Validate behavior in `migtools/crane` repository



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an automated “ready-for-review” command for pull requests, including reset support.
  * When triggered, the PR author’s command receives a “+1” reaction and can send a Slack notification with PR details.

* **Bug Fixes**
  * Prevents duplicate notifications for the same pull request by tracking notification state.
  * Reset now clears that state, allowing notifications to be sent again on the next command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->