### PR TITLE
fix: support multi-file KUBECONFIG in crane export and validate

### DIFF
--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd/api"
+
 )
 
 // ExportOptions holds CLI flags and runtime state for a single export run.
@@ -52,6 +53,14 @@ type ExportOptions struct {
 // Complete loads kubeconfig context, namespace, and parses --as-extras into o.extras.
 func (o *ExportOptions) Complete(c *cobra.Command, args []string) error {
 	var err error
+
+	if c != nil {
+		kubeconfigFlag := c.Flags().Lookup("kubeconfig")
+		if kubeconfigFlag == nil || !kubeconfigFlag.Changed {
+			emptyStr := ""
+			o.configFlags.KubeConfig = &emptyStr
+		}
+	}
 
 	o.rawConfig, err = o.configFlags.ToRawKubeConfigLoader().RawConfig()
 	if err != nil {

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -35,6 +35,12 @@ type ValidateOptions struct {
 // detected later in Run() when discovery is queried.
 // Skipped in offline mode (--api-resources).
 func (o *ValidateOptions) Complete(c *cobra.Command, args []string) error {
+	kubeconfigFlag := c.Flags().Lookup("kubeconfig")
+	if kubeconfigFlag == nil || !kubeconfigFlag.Changed {
+		emptyStr := ""
+		o.configFlags.KubeConfig = &emptyStr
+	}
+
 	if o.apiResourcesFile != "" {
 		return nil
 	}
@@ -126,7 +132,7 @@ func (o *ValidateOptions) Run() error {
 		discoveryClient, err := o.configFlags.ToDiscoveryClient()
 		if err != nil {
 			return fmt.Errorf("creating discovery client: %w", err)
-		}
+		} 
 		discoveryClient.Invalidate()
 
 		report, err = internalValidate.MatchResults(entries, internalValidate.MatchOptions{DiscoveryClient: discoveryClient}, log)


### PR DESCRIPTION
[#481](https://github.com/migtools/crane/issues/481)
## Problem

  Kubernetes supports specifying multiple kubeconfig files via the
  KUBECONFIG environment variable, separated by colons:

 ```
 export KUBECONFIG=~/.kube/config-cluster1:~/.kube/config-cluster2
 ```
This works with kubectl and with crane's transform/apply commands,
but crane export and crane validate failed with:
 ```
Error: stat /home/user/.kube/config-cluster1:/home/user/.kube/config-cluster2: no such file or directory
```

  ## Root Cause

  crane uses viper with `AutomaticEnv() `enabled globally. When
  `viper.BindPFlags() `registers the `--kubeconfig` flag, viper automatically
  reads the KUBECONFIG environment variable and maps its raw value
  (the full colon-separated string) into configFlags.KubeConfig.

  When `configFlags.ToRawKubeConfigLoader()` is later called, it sets
  `loadingRules.ExplicitPath` to that raw colon-separated string.
  `os.Stat()`is then called on the full string as a single path,
  which does not exist.

  transform and apply are not affected because their Complete()
  functions do not connect to the cluster at all.

  ## Fix

  At the start of Complete() in both export and validate, reset
  configFlags.KubeConfig to an empty string if the user did not
  explicitly pass --kubeconfig on the command line.

  This prevents viper from injecting the raw KUBECONFIG env var
  into the loading rules, allowing NewDefaultClientConfigLoadingRules()
  to correctly split KUBECONFIG by colon and load each file separately —
  the same behavior as kubectl.

  ## Files Changed

  - cmd/export/export.go
  - cmd/validate/validate.go

  ## Testing

  Verified manually with two kubeconfig files:

      export KUBECONFIG=~/.kube/config:~/.kube/config-copy
      crane export --context minikube -n default   ✅
      crane validate -i export/resources/default --context minikube   ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how command-line operations handle kubeconfig when run programmatically, making behavior more predictable.
  * Validation and export commands now consistently treat an unspecified kubeconfig as empty instead of inheriting implicit defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->