### PR TITLE
feat(e2e): add --run-as flag to run all tests as cluster-admin

### DIFF
--- a/.github/workflows/test-compliance.yml
+++ b/.github/workflows/test-compliance.yml
@@ -1,0 +1,58 @@
+name: Test Compliance
+
+on:
+  pull_request:
+    paths:
+      - 'e2e-tests/tests/**'
+
+permissions:
+  contents: read
+
+jobs:
+  run-as-admin-compliance:
+    name: run-as-admin compliance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for non-compliant test patterns
+        run: |
+          set +e
+          FAILED=0
+
+          # Check all test files in the repo
+          CHANGED=$(find e2e-tests/tests -name '*_test.go')
+
+          echo "Checking files:"
+          echo "$CHANGED"
+          echo ""
+
+          for FILE in $CHANGED; do
+            [ -f "$FILE" ] || continue
+
+            # Skip admin tests — only non-admin tests call SetupActiveKubectlRunners
+            if ! grep -q "SetupActiveKubectlRunners\|SetupNamespaceAdminUsersForScenario" "$FILE"; then
+              echo "SKIP $FILE: admin test, skipping compliance check"
+              continue
+            fi
+
+            echo "CHECK $FILE: non-admin test, checking compliance..."
+
+            # 1. Must not call SetupNamespaceAdminUsersForScenario — use SetupActiveKubectlRunners instead
+            if grep -n "SetupNamespaceAdminUsersForScenario" "$FILE"; then
+              echo "FAIL $FILE: use SetupActiveKubectlRunners instead of SetupNamespaceAdminUsersForScenario"
+              FAILED=1
+            fi
+
+            # 2. Must not guard on empty non-admin context (Skip guards prevent RUN_AS_ADMIN override from working)
+            if grep -n 'NonAdmin\.Context == ""' "$FILE"; then
+              echo "FAIL $FILE: remove empty-context Skip guards — they block the RUN_AS_ADMIN override in Jenkins"
+              FAILED=1
+            fi
+          done
+
+          if [ "$FAILED" -eq 0 ]; then
+            echo "PASS: all test files are compliant."
+          fi
+
+          exit $FAILED

--- a/.github/workflows/test-compliance.yml
+++ b/.github/workflows/test-compliance.yml
@@ -23,8 +23,8 @@ jobs:
           for FILE in $(find e2e-tests/tests -name '*_test.go'); do
             [ -f "$FILE" ] || continue
 
-            # Skip admin tests — only non-admin tests call SetupActiveKubectlRunners
-            if ! grep -q "SetupActiveKubectlRunners\|SetupNamespaceAdminUsersForScenario" "$FILE"; then
+            # Skip admin tests — non-admin tests either call SetupActiveKubectlRunners or use NonAdmin fields directly
+            if ! grep -q "SetupActiveKubectlRunners\|SetupNamespaceAdminUsersForScenario\|CraneNonAdmin\|KubectlSrcNonAdmin\|KubectlTgtNonAdmin\|SrcAppNonAdmin\|TgtAppNonAdmin" "$FILE"; then
               continue
             fi
 

--- a/.github/workflows/test-compliance.yml
+++ b/.github/workflows/test-compliance.yml
@@ -18,41 +18,45 @@ jobs:
       - name: Check for non-compliant test patterns
         run: |
           set +e
-          FAILED=0
+          VIOLATIONS=()
 
-          # Check all test files in the repo
-          CHANGED=$(find e2e-tests/tests -name '*_test.go')
-
-          echo "Checking files:"
-          echo "$CHANGED"
-          echo ""
-
-          for FILE in $CHANGED; do
+          for FILE in $(find e2e-tests/tests -name '*_test.go'); do
             [ -f "$FILE" ] || continue
 
             # Skip admin tests — only non-admin tests call SetupActiveKubectlRunners
             if ! grep -q "SetupActiveKubectlRunners\|SetupNamespaceAdminUsersForScenario" "$FILE"; then
-              echo "SKIP $FILE: admin test, skipping compliance check"
               continue
             fi
 
-            echo "CHECK $FILE: non-admin test, checking compliance..."
+            ISSUES=""
 
-            # 1. Must not call SetupNamespaceAdminUsersForScenario — use SetupActiveKubectlRunners instead
-            if grep -n "SetupNamespaceAdminUsersForScenario" "$FILE"; then
-              echo "FAIL $FILE: use SetupActiveKubectlRunners instead of SetupNamespaceAdminUsersForScenario"
-              FAILED=1
+            if grep -q "SetupNamespaceAdminUsersForScenario" "$FILE"; then
+              ISSUES="${ISSUES}\n    - use SetupActiveKubectlRunners instead of SetupNamespaceAdminUsersForScenario"
             fi
 
-            # 2. Must not guard on empty non-admin context (Skip guards prevent RUN_AS_ADMIN override from working)
-            if grep -n 'NonAdmin\.Context == ""' "$FILE"; then
-              echo "FAIL $FILE: remove empty-context Skip guards — they block the RUN_AS_ADMIN override in Jenkins"
-              FAILED=1
+            if grep -q 'NonAdmin\.Context == ""' "$FILE"; then
+              ISSUES="${ISSUES}\n    - remove empty-context Skip guards (they block RUN_AS_ADMIN override)"
+            fi
+
+            if [ -n "$ISSUES" ]; then
+              VIOLATIONS+=("$FILE:$ISSUES")
             fi
           done
 
-          if [ "$FAILED" -eq 0 ]; then
-            echo "PASS: all test files are compliant."
+          echo ""
+          if [ ${#VIOLATIONS[@]} -eq 0 ]; then
+            echo "PASS: all non-admin test files are compliant."
+            exit 0
           fi
 
-          exit $FAILED
+          echo "FAIL: the following non-admin test files are not compliant with RUN_AS_ADMIN:"
+          echo ""
+          for V in "${VIOLATIONS[@]}"; do
+            FILE="${V%%:*}"
+            ISSUES="${V#*:}"
+            echo "  $FILE"
+            echo -e "$ISSUES"
+            echo ""
+          done
+
+          exit 1

--- a/e2e-tests/config/config.go
+++ b/e2e-tests/config/config.go
@@ -9,4 +9,5 @@ var (
 	SourceNonAdminContext string
 	TargetNonAdminContext string
 	InsecureSkipTLSVerify bool
+	RunAs                 string
 )

--- a/e2e-tests/framework/rbac.go
+++ b/e2e-tests/framework/rbac.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/konveyor/crane/e2e-tests/config"
 	"github.com/konveyor/crane/e2e-tests/utils"
 )
 
@@ -106,6 +107,46 @@ func SetupNamespaceAdminUser(adminKubectl KubectlRunner, nonAdminContext, namesp
 	}
 
 	return userKubectl, cleanup, nil
+}
+
+// SetupActiveNamespaceAdmin sets up namespace-scoped access on a single cluster.
+// When config.RunAs == "admin", it creates the namespace with the admin runner and returns
+// a no-op cleanup. Otherwise it delegates to SetupNamespaceAdminUser.
+func SetupActiveNamespaceAdmin(adminKubectl KubectlRunner, nonAdminContext, namespace string) (KubectlRunner, func(), error) {
+	if config.RunAs == "admin" {
+		if err := adminKubectl.CreateNamespace(namespace); err != nil {
+			return KubectlRunner{}, nil, fmt.Errorf("failed to create namespace %q: %w", namespace, err)
+		}
+		return adminKubectl, func() {}, nil
+	}
+	return SetupNamespaceAdminUser(adminKubectl, nonAdminContext, namespace)
+}
+
+// SetupActiveKubectlRunners returns kubectl runners appropriate for the current RunAs mode.
+// When config.RunAs == "admin", it creates the namespace with admin credentials and returns
+// admin runners directly (bypassing RBAC setup). Otherwise it delegates to
+// SetupNamespaceAdminUsersForScenario to grant namespace-scoped permissions to the non-admin user.
+func SetupActiveKubectlRunners(scenario MigrationScenario, namespace string) (KubectlRunner, KubectlRunner, func(), error) {
+	if config.RunAs == "admin" {
+		if srcUser, err := ResolveUsernameForContext(scenario.KubectlSrc.Context); err != nil {
+			log.Printf("[run-as=admin] source context=%q: could not resolve username: %v", scenario.KubectlSrc.Context, err)
+		} else {
+			log.Printf("[run-as=admin] source context=%q running as user=%q", scenario.KubectlSrc.Context, srcUser)
+		}
+		if tgtUser, err := ResolveUsernameForContext(scenario.KubectlTgt.Context); err != nil {
+			log.Printf("[run-as=admin] target context=%q: could not resolve username: %v", scenario.KubectlTgt.Context, err)
+		} else {
+			log.Printf("[run-as=admin] target context=%q running as user=%q", scenario.KubectlTgt.Context, tgtUser)
+		}
+		if err := scenario.KubectlSrc.CreateNamespace(namespace); err != nil {
+			return KubectlRunner{}, KubectlRunner{}, nil, fmt.Errorf("failed to create namespace %q on source: %w", namespace, err)
+		}
+		if err := scenario.KubectlTgt.CreateNamespace(namespace); err != nil {
+			return KubectlRunner{}, KubectlRunner{}, nil, fmt.Errorf("failed to create namespace %q on target: %w", namespace, err)
+		}
+		return scenario.KubectlSrc, scenario.KubectlTgt, func() {}, nil
+	}
+	return SetupNamespaceAdminUsersForScenario(scenario, namespace)
 }
 
 // SetupNamespaceAdminUsersForScenario grants namespace-scoped admin permissions

--- a/e2e-tests/framework/scenario.go
+++ b/e2e-tests/framework/scenario.go
@@ -26,7 +26,16 @@ type MigrationScenario struct {
 }
 
 // NewMigrationScenario builds shared runners and app objects for a migration test.
+// When config.RunAs == "admin", the NonAdmin fields are populated with admin contexts
+// so all test code using those fields automatically runs with cluster-admin credentials.
 func NewMigrationScenario(appName, namespace, k8sDeployBin, craneBin, srcCtx, tgtCtx string) MigrationScenario {
+	srcNonAdminCtx := config.SourceNonAdminContext
+	tgtNonAdminCtx := config.TargetNonAdminContext
+	if config.RunAs == "admin" {
+		srcNonAdminCtx = srcCtx
+		tgtNonAdminCtx = tgtCtx
+	}
+
 	return MigrationScenario{
 		AppName:   appName,
 		Namespace: namespace,
@@ -48,27 +57,27 @@ func NewMigrationScenario(appName, namespace, k8sDeployBin, craneBin, srcCtx, tg
 			Name:            appName,
 			Namespace:       namespace,
 			Bin:             k8sDeployBin,
-			Context:         config.SourceNonAdminContext,
+			Context:         srcNonAdminCtx,
 			InsecureSkipTLS: config.InsecureSkipTLSVerify,
 		},
 		TgtAppNonAdmin: K8sDeployApp{
 			Name:            appName,
 			Namespace:       namespace,
 			Bin:             k8sDeployBin,
-			Context:         config.TargetNonAdminContext,
+			Context:         tgtNonAdminCtx,
 			InsecureSkipTLS: config.InsecureSkipTLSVerify,
 		},
 		KubectlSrc:         KubectlRunner{Bin: "kubectl", Context: srcCtx},
 		KubectlTgt:         KubectlRunner{Bin: "kubectl", Context: tgtCtx},
-		KubectlSrcNonAdmin: KubectlRunner{Bin: "kubectl", Context: config.SourceNonAdminContext},
-		KubectlTgtNonAdmin: KubectlRunner{Bin: "kubectl", Context: config.TargetNonAdminContext},
+		KubectlSrcNonAdmin: KubectlRunner{Bin: "kubectl", Context: srcNonAdminCtx},
+		KubectlTgtNonAdmin: KubectlRunner{Bin: "kubectl", Context: tgtNonAdminCtx},
 		Crane: CraneRunner{
 			Bin:           craneBin,
 			SourceContext: srcCtx,
 		},
 		CraneNonAdmin: CraneRunner{
 			Bin:           craneBin,
-			SourceContext: config.SourceNonAdminContext,
+			SourceContext: srcNonAdminCtx,
 		},
 	}
 }

--- a/e2e-tests/tests/tier0/e2e_suite_test.go
+++ b/e2e-tests/tests/tier0/e2e_suite_test.go
@@ -21,6 +21,7 @@ func init() {
 	flag.StringVar(&config.SourceNonAdminContext, "source-nonadmin-context", "", "Source cluster non-admin context for RBAC scenarios")
 	flag.StringVar(&config.TargetNonAdminContext, "target-nonadmin-context", "", "Target cluster non-admin context for RBAC scenarios")
 	flag.BoolVar(&config.InsecureSkipTLSVerify, "insecure-skip-tls-verify", false, "Skip TLS certificate verification for k8sdeploy connections (use for OCP clusters with self-signed certs)")
+	flag.StringVar(&config.RunAs, "run-as", "", "Override user context: set to 'admin' to run all tests with cluster-admin credentials")
 }
 
 // TestE2E configures Ginkgo and executes the e2e test suite.

--- a/e2e-tests/tests/tier0/mta_804_empty_pvc_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_804_empty_pvc_migration_test.go
@@ -23,12 +23,6 @@ var _ = Describe("Empty PVC migration", func() {
 			config.SourceContext,
 			config.TargetContext,
 		)
-		if scenario.KubectlSrcNonAdmin.Context == "" {
-			Skip("source-nonadmin-context is required for non-admin test")
-		}
-		if scenario.KubectlTgtNonAdmin.Context == "" {
-			Skip("target-nonadmin-context is required for non-admin test")
-		}
 		srcApp := scenario.SrcAppNonAdmin
 		tgtApp := scenario.TgtAppNonAdmin
 
@@ -42,7 +36,7 @@ var _ = Describe("Empty PVC migration", func() {
 		}
 
 		By("Grant ns admin permissions to nonadmin user on source and target")
-		kubectlSrcNonAdmin, kubectlTgtNonAdmin, cleanup, err := SetupNamespaceAdminUsersForScenario(scenario, namespace)
+		kubectlSrcNonAdmin, kubectlTgtNonAdmin, cleanup, err := SetupActiveKubectlRunners(scenario, namespace)
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(cleanup)
 

--- a/e2e-tests/tests/tier0/mta_805_sets_test.go
+++ b/e2e-tests/tests/tier0/mta_805_sets_test.go
@@ -25,12 +25,6 @@ var _ = Describe("Sets resources migration", func() {
 			config.SourceContext,
 			config.TargetContext,
 		)
-		if scenario.KubectlSrcNonAdmin.Context == "" {
-			Skip("source-nonadmin-context is required for non-admin stateless migration test")
-		}
-		if scenario.KubectlTgtNonAdmin.Context == "" {
-			Skip("target-nonadmin-context is required for non-admin stateless migration test")
-		}
 		srcApp := scenario.SrcAppNonAdmin
 		tgtApp := scenario.TgtAppNonAdmin
 		runner := scenario.CraneNonAdmin
@@ -53,7 +47,7 @@ var _ = Describe("Sets resources migration", func() {
 		tgtApp.ExtraVars = srcApp.ExtraVars
 
 		By("Grant ns admin permissions to nonadmin user on source and target")
-		kubectlSrcNonAdmin, kubectlTgtNonAdmin, cleanup, err := SetupNamespaceAdminUsersForScenario(scenario, namespace)
+		kubectlSrcNonAdmin, kubectlTgtNonAdmin, cleanup, err := SetupActiveKubectlRunners(scenario, namespace)
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() {
 			By("Delete test namespace on source and target (best effort)")

--- a/e2e-tests/tests/tier0/mta_806_pvc_data_integrity_test.go
+++ b/e2e-tests/tests/tier0/mta_806_pvc_data_integrity_test.go
@@ -25,12 +25,6 @@ var _ = Describe("PVC data integrity migration", func() {
 			config.SourceContext,
 			config.TargetContext,
 		)
-		if scenario.KubectlSrcNonAdmin.Context == "" {
-			Skip("source-nonadmin-context is required for non-admin test")
-		}
-		if scenario.KubectlTgtNonAdmin.Context == "" {
-			Skip("target-nonadmin-context is required for non-admin test")
-		}
 		srcApp := scenario.SrcAppNonAdmin
 		tgtApp := scenario.TgtAppNonAdmin
 
@@ -48,7 +42,7 @@ var _ = Describe("PVC data integrity migration", func() {
 		}
 
 		By("Grant ns admin permissions to nonadmin user on source and target")
-		kubectlSrcNonAdmin, kubectlTgtNonAdmin, cleanup, err := SetupNamespaceAdminUsersForScenario(scenario, namespace)
+		kubectlSrcNonAdmin, kubectlTgtNonAdmin, cleanup, err := SetupActiveKubectlRunners(scenario, namespace)
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(cleanup)
 

--- a/e2e-tests/tests/tier0/mta_807_data_validation_test.go
+++ b/e2e-tests/tests/tier0/mta_807_data_validation_test.go
@@ -129,12 +129,6 @@ var _ = Describe("Data validation with indirect migration of MySQL DB", func() {
 			config.SourceContext,
 			config.TargetContext,
 		)
-		if scenario.KubectlSrcNonAdmin.Context == "" {
-			Skip("source-nonadmin-context is required for non-admin stateful migration test")
-		}
-		if scenario.KubectlTgtNonAdmin.Context == "" {
-			Skip("target-nonadmin-context is required for non-admin stateful migration test")
-		}
 		srcApp := scenario.SrcAppNonAdmin
 		tgtApp := scenario.TgtAppNonAdmin
 		runner := scenario.CraneNonAdmin
@@ -150,7 +144,7 @@ var _ = Describe("Data validation with indirect migration of MySQL DB", func() {
 		}
 
 		By("Grant namespace admin permissions to nonadmin user on source and target")
-		kubectlSrcNonAdmin, kubectlTgtNonAdmin, cleanup, err := SetupNamespaceAdminUsersForScenario(scenario, namespace)
+		kubectlSrcNonAdmin, kubectlTgtNonAdmin, cleanup, err := SetupActiveKubectlRunners(scenario, namespace)
 		Expect(err).NotTo(HaveOccurred())
 
 		DeferCleanup(func() {

--- a/e2e-tests/tests/tier0/mta_809_initcontainer_test.go
+++ b/e2e-tests/tests/tier0/mta_809_initcontainer_test.go
@@ -23,12 +23,6 @@ var _ = Describe("InitContainer Migration", func() {
 			config.SourceContext,
 			config.TargetContext,
 		)
-		if scenario.KubectlSrcNonAdmin.Context == "" {
-			Skip("source-nonadmin-context is required for non-admin stateless migration test")
-		}
-		if scenario.KubectlTgtNonAdmin.Context == "" {
-			Skip("target-nonadmin-context is required for non-admin stateless migration test")
-		}
 		srcApp := scenario.SrcAppNonAdmin
 		tgtApp := scenario.TgtAppNonAdmin
 		runner := scenario.CraneNonAdmin
@@ -43,7 +37,7 @@ var _ = Describe("InitContainer Migration", func() {
 		}
 
 		By("Grant ns admin permissions to nonadmin user on source and target")
-		kubectlSrcNonAdmin, kubectlTgtNonAdmin, cleanup, err := SetupNamespaceAdminUsersForScenario(scenario, namespace)
+		kubectlSrcNonAdmin, kubectlTgtNonAdmin, cleanup, err := SetupActiveKubectlRunners(scenario, namespace)
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() {
 			By("Delete test namespace on source and target (wait for completion)")

--- a/e2e-tests/tests/tier0/mta_810_configmap_test.go
+++ b/e2e-tests/tests/tier0/mta_810_configmap_test.go
@@ -25,12 +25,6 @@ var _ = Describe("ConfigMap Migration", func() {
 			config.TargetContext,
 		)
 
-		if scenario.KubectlSrcNonAdmin.Context == "" {
-			Skip("source-nonadmin-context is required for non-admin stateless migration test")
-		}
-		if scenario.KubectlTgtNonAdmin.Context == "" {
-			Skip("target-nonadmin-context is required for non-admin stateless migration test")
-		}
 		srcApp := scenario.SrcAppNonAdmin
 		tgtApp := scenario.TgtAppNonAdmin
 		runner := scenario.CraneNonAdmin
@@ -43,7 +37,7 @@ var _ = Describe("ConfigMap Migration", func() {
 		}
 
 		By("Grant ns admin permissions to nonadmin user on source and target")
-		kubectlSrcNonAdmin, kubectlTgtNonAdmin, cleanup, err := SetupNamespaceAdminUsersForScenario(scenario, namespace)
+		kubectlSrcNonAdmin, kubectlTgtNonAdmin, cleanup, err := SetupActiveKubectlRunners(scenario, namespace)
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() {
 			By("Delete test namespace on source and target (wait for completion)")

--- a/e2e-tests/tests/tier0/mta_811_mongodb_non_admin_test.go
+++ b/e2e-tests/tests/tier0/mta_811_mongodb_non_admin_test.go
@@ -108,12 +108,6 @@ var _ = Describe("MongoDB Migration", func() {
 			config.TargetContext,
 		)
 
-		if scenario.KubectlSrcNonAdmin.Context == "" {
-			Skip("source-nonadmin-context is required for non-admin stateful migration test")
-		}
-		if scenario.KubectlTgtNonAdmin.Context == "" {
-			Skip("target-nonadmin-context is required for non-admin stateful migration test")
-		}
 		srcApp := scenario.SrcAppNonAdmin
 		tgtApp := scenario.TgtAppNonAdmin
 		runner := scenario.CraneNonAdmin
@@ -126,7 +120,7 @@ var _ = Describe("MongoDB Migration", func() {
 		}
 
 		By("Grant namespace admin permissions to nonadmin user on source and target")
-		kubectlSrcNonAdmin, kubectlTgtNonAdmin, cleanup, err := SetupNamespaceAdminUsersForScenario(scenario, namespace)
+		kubectlSrcNonAdmin, kubectlTgtNonAdmin, cleanup, err := SetupActiveKubectlRunners(scenario, namespace)
 		Expect(err).NotTo(HaveOccurred())
 
 		DeferCleanup(func() {

--- a/e2e-tests/tests/tier0/mta_812_role_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_812_role_migration_test.go
@@ -24,12 +24,6 @@ var _ = Describe("Role and RoleBinding migration", func() {
 			config.TargetContext,
 		)
 
-		if scenario.KubectlSrcNonAdmin.Context == "" {
-			Skip("source-nonadmin-context is required for non-admin role migration test")
-		}
-		if scenario.KubectlTgtNonAdmin.Context == "" {
-			Skip("target-nonadmin-context is required for non-admin role migration test")
-		}
 
 		srcApp := scenario.SrcAppNonAdmin
 		tgtApp := scenario.TgtAppNonAdmin
@@ -43,7 +37,7 @@ var _ = Describe("Role and RoleBinding migration", func() {
 		}
 
 		By("Grant ns admin permissions to nonadmin user on source and target")
-		kubectlSrcNonAdmin, kubectlTgtNonAdmin, cleanup, err := SetupNamespaceAdminUsersForScenario(scenario, namespace)
+		kubectlSrcNonAdmin, kubectlTgtNonAdmin, cleanup, err := SetupActiveKubectlRunners(scenario, namespace)
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() {
 			By("Delete test namespace on source and target (wait for completion)")

--- a/e2e-tests/tests/tier0/mta_813_cronJob_PVC_test.go
+++ b/e2e-tests/tests/tier0/mta_813_cronJob_PVC_test.go
@@ -26,12 +26,6 @@ var _ = Describe("CronJob with attached PVC migration as non-admin user", func()
 			config.TargetContext,
 		)
 
-		if scenario.KubectlSrcNonAdmin.Context == "" {
-			Skip("source-nonadmin-context is required for this test")
-		}
-		if scenario.KubectlTgtNonAdmin.Context == "" {
-			Skip("target-nonadmin-context is required for this test")
-		}
 
 		srcApp := scenario.SrcAppNonAdmin
 		tgtApp := scenario.TgtAppNonAdmin
@@ -51,7 +45,7 @@ var _ = Describe("CronJob with attached PVC migration as non-admin user", func()
 		}
 
 		By("Grant namespace-admin permissions to non-admin user on source and target")
-		kubectlSrcNonAdmin, _, cleanup, err := SetupNamespaceAdminUsersForScenario(scenario, namespace)
+		kubectlSrcNonAdmin, _, cleanup, err := SetupActiveKubectlRunners(scenario, namespace)
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() {
 			By("Delete test namespace on source and target (wait for completion)")

--- a/e2e-tests/tests/tier0/mta_827_custom_transformation_stage_test.go
+++ b/e2e-tests/tests/tier0/mta_827_custom_transformation_stage_test.go
@@ -28,12 +28,6 @@ var _ = Describe("Custom transformation stage", func() {
 			config.SourceContext,
 			config.TargetContext,
 		)
-		if scenario.KubectlSrcNonAdmin.Context == "" {
-			Skip("source-nonadmin-context is required for non-admin custom transformation stage test")
-		}
-		if scenario.KubectlTgtNonAdmin.Context == "" {
-			Skip("target-nonadmin-context is required for non-admin custom transformation stage test")
-		}
 
 		srcApp := scenario.SrcAppNonAdmin
 		tgtApp := scenario.TgtAppNonAdmin
@@ -48,10 +42,10 @@ var _ = Describe("Custom transformation stage", func() {
 		}
 
 		By("Grant namespace admin permissions to nonadmin user on source and target")
-		kubectlSrcNonAdmin, kubectlTgtNonAdmin, scenarioCleanup, err := SetupNamespaceAdminUsersForScenario(scenario, namespace)
+		kubectlSrcNonAdmin, kubectlTgtNonAdmin, scenarioCleanup, err := SetupActiveKubectlRunners(scenario, namespace)
 		Expect(err).NotTo(HaveOccurred())
 		By("Grant namespace admin permissions to nonadmin user on migrated target namespace")
-		_, migratedNamespaceCleanup, err := SetupNamespaceAdminUser(
+		_, migratedNamespaceCleanup, err := SetupActiveNamespaceAdmin(
 			scenario.KubectlTgt,
 			scenario.KubectlTgtNonAdmin.Context,
 			targetNamespace,

--- a/e2e-tests/tests/tier0/mta_828_instructions_file_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_828_instructions_file_migration_test.go
@@ -28,12 +28,6 @@ var _ = Describe("Instructions-file migration", func() {
 			config.TargetContext,
 		)
 
-		if scenario.KubectlSrcNonAdmin.Context == "" {
-			Skip("source-nonadmin-context is required for non-admin instructions file migration test")
-		}
-		if scenario.KubectlTgtNonAdmin.Context == "" {
-			Skip("target-nonadmin-context is required for non-admin instructions file migration test")
-		}
 
 		srcApp := scenario.SrcAppNonAdmin
 		tgtApp := scenario.TgtAppNonAdmin
@@ -44,7 +38,7 @@ var _ = Describe("Instructions-file migration", func() {
 		tgtApp.ExtraVars = srcApp.ExtraVars
 
 		By("Grant ns admin permissions to nonadmin user on source and target")
-		kubectlSrcNonAdmin, _, cleanup, err := SetupNamespaceAdminUsersForScenario(scenario, namespace)
+		kubectlSrcNonAdmin, _, cleanup, err := SetupActiveKubectlRunners(scenario, namespace)
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() {
 			By("Delete test namespace on source and target (wait for completion)")

--- a/e2e-tests/tests/tier0/mta_831_validate_compatible_resources_offline_test.go
+++ b/e2e-tests/tests/tier0/mta_831_validate_compatible_resources_offline_test.go
@@ -28,12 +28,6 @@ var _ = Describe("Crane validate: all compatible standard resources in offline m
 			config.TargetContext,
 		)
 
-		if scenario.SrcAppNonAdmin.Context == "" {
-			Skip("source-nonadmin-context is required for non-admin offline validation test")
-		}
-		if scenario.TgtAppNonAdmin.Context == "" {
-			Skip("target-nonadmin-context is required for non-admin offline validation test")
-		}
 		srcApp := scenario.SrcAppNonAdmin
 		tgtApp := scenario.TgtAppNonAdmin
 		runner := scenario.CraneNonAdmin
@@ -43,7 +37,7 @@ var _ = Describe("Crane validate: all compatible standard resources in offline m
 		tgtApp.ExtraVars = srcApp.ExtraVars
 
 		By("Grant ns admin permissions to nonadmin user on source and target")
-		kubectlSrcNonAdmin, _, cleanup, err := SetupNamespaceAdminUsersForScenario(scenario, namespace)
+		kubectlSrcNonAdmin, _, cleanup, err := SetupActiveKubectlRunners(scenario, namespace)
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() {
 			By("Delete test namespace on source and target (wait for completion)")

--- a/e2e-tests/tests/tier0/mta_833_compatible_resources_live_test.go
+++ b/e2e-tests/tests/tier0/mta_833_compatible_resources_live_test.go
@@ -25,12 +25,6 @@ var _ = Describe("Crane validate: all compatible standard resources in live mode
 			config.SourceContext,
 			config.TargetContext,
 		)
-		if scenario.SrcAppNonAdmin.Context == "" {
-			Skip("source-nonadmin-context is required for non-admin offline validation test")
-		}
-		if scenario.TgtAppNonAdmin.Context == "" {
-			Skip("target-nonadmin-context is required for non-admin offline validation test")
-		}
 		srcApp := scenario.SrcAppNonAdmin
 		tgtApp := scenario.TgtAppNonAdmin
 		runner := scenario.CraneNonAdmin
@@ -40,7 +34,7 @@ var _ = Describe("Crane validate: all compatible standard resources in live mode
 		tgtApp.ExtraVars = srcApp.ExtraVars
 
 		By("Grant ns admin permissions to nonadmin user on source and target")
-		kubectlSrcNonAdmin, _, cleanup, err := SetupNamespaceAdminUsersForScenario(scenario, namespace)
+		kubectlSrcNonAdmin, _, cleanup, err := SetupActiveKubectlRunners(scenario, namespace)
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() {
 			By("Delete test namespace on source and target (wait for completion)")

--- a/e2e-tests/tests/tier0/mta_844_validate_mixed_resources_live_test.go
+++ b/e2e-tests/tests/tier0/mta_844_validate_mixed_resources_live_test.go
@@ -28,12 +28,6 @@ var _ = Describe("Crane validate: mixed compatible and incompatible resources in
 			config.TargetContext,
 		)
 
-		if scenario.SrcAppNonAdmin.Context == "" {
-			Skip("source-nonadmin-context is required for non-admin validation test")
-		}
-		if scenario.TgtAppNonAdmin.Context == "" {
-			Skip("target-nonadmin-context is required for non-admin validation test")
-		}
 		srcApp := scenario.SrcAppNonAdmin
 		tgtApp := scenario.TgtAppNonAdmin
 		runner := scenario.CraneNonAdmin
@@ -43,7 +37,7 @@ var _ = Describe("Crane validate: mixed compatible and incompatible resources in
 		tgtApp.ExtraVars = srcApp.ExtraVars
 
 		By("Grant ns admin permissions to nonadmin user on source and target")
-		kubectlSrcNonAdmin, _, cleanup, err := SetupNamespaceAdminUsersForScenario(scenario, namespace)
+		kubectlSrcNonAdmin, _, cleanup, err := SetupActiveKubectlRunners(scenario, namespace)
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() {
 			By("Delete test namespace on source and target (wait for completion)")

--- a/e2e-tests/tests/tier0/mta_845_validate_mixed_resources_offline_test.go
+++ b/e2e-tests/tests/tier0/mta_845_validate_mixed_resources_offline_test.go
@@ -30,12 +30,6 @@ var _ = Describe("Crane validate: mixed compatible and incompatible resources in
 			config.TargetContext,
 		)
 
-		if scenario.SrcAppNonAdmin.Context == "" {
-			Skip("source-nonadmin-context is required for non-admin validation test")
-		}
-		if scenario.TgtAppNonAdmin.Context == "" {
-			Skip("target-nonadmin-context is required for non-admin validation test")
-		}
 		srcApp := scenario.SrcAppNonAdmin
 		tgtApp := scenario.TgtAppNonAdmin
 		runner := scenario.CraneNonAdmin
@@ -45,7 +39,7 @@ var _ = Describe("Crane validate: mixed compatible and incompatible resources in
 		tgtApp.ExtraVars = srcApp.ExtraVars
 
 		By("Grant ns admin permissions to nonadmin user on source and target")
-		kubectlSrcNonAdmin, _, cleanup, err := SetupNamespaceAdminUsersForScenario(scenario, namespace)
+		kubectlSrcNonAdmin, _, cleanup, err := SetupActiveKubectlRunners(scenario, namespace)
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() {
 			By("Delete test namespace on source and target (wait for completion)")

--- a/e2e-tests/tests/tier0/mta_846_validate_single_incompatible_route_live_test.go
+++ b/e2e-tests/tests/tier0/mta_846_validate_single_incompatible_route_live_test.go
@@ -28,9 +28,6 @@ var _ = Describe("Validate single incompatible Route [Live Mode]", func() {
 			Skip("Route is supported on OpenShift targets; this minikube-only incompatibility check is not applicable")
 		}
 
-		if scenario.KubectlTgtNonAdmin.Context == "" {
-			Skip("target-nonadmin-context is required")
-		}
 
 		runner := scenario.CraneNonAdmin
 		paths, err := NewScenarioPaths("crane-validate-single-route-live-*")

--- a/e2e-tests/tests/tier0/mta_846_validate_single_incompatible_route_live_test.go
+++ b/e2e-tests/tests/tier0/mta_846_validate_single_incompatible_route_live_test.go
@@ -29,6 +29,8 @@ var _ = Describe("Validate single incompatible Route [Live Mode]", func() {
 		}
 
 
+		Expect(scenario.KubectlTgtNonAdmin.Context).NotTo(BeEmpty(), "target-nonadmin-context is required for this test")
+
 		runner := scenario.CraneNonAdmin
 		paths, err := NewScenarioPaths("crane-validate-single-route-live-*")
 		Expect(err).NotTo(HaveOccurred())

--- a/e2e-tests/tests/tier0/mta_853_split_apply_test.go
+++ b/e2e-tests/tests/tier0/mta_853_split_apply_test.go
@@ -27,12 +27,6 @@ var _ = Describe("Namespace-admin cluster-level migration", func() {
 		clusterRoleBindingName := "crane-e2e-pod-reader-binding"
 		clusterRoleName := "crane-e2e-pod-reader"
 		deniedResources := []string{"clusterroles.yaml", "clusterrolebindings.yaml"}
-		if scenario.KubectlSrcNonAdmin.Context == "" {
-			Skip("source-nonadmin-context is required for non-admin role migration test")
-		}
-		if scenario.KubectlTgtNonAdmin.Context == "" {
-			Skip("target-nonadmin-context is required for non-admin role migration test")
-		}
 		srcAppNonAdmin := scenario.SrcAppNonAdmin
 		tgtAppNonAdmin := scenario.TgtAppNonAdmin
 
@@ -58,7 +52,7 @@ var _ = Describe("Namespace-admin cluster-level migration", func() {
 		cr := ClusterRole{Name: clusterRoleName, Verb: "get,list,watch", Resource: "pods"}
 
 		By("Granting namespace-admin permissions to non-admin user on source and target")
-		kubectlSrcNonAdmin, kubectlTgtNonAdmin, rbacCleanup, err := SetupNamespaceAdminUsersForScenario(scenario, namespace)
+		kubectlSrcNonAdmin, kubectlTgtNonAdmin, rbacCleanup, err := SetupActiveKubectlRunners(scenario, namespace)
 		Expect(err).NotTo(HaveOccurred())
 
 		DeferCleanup(rbacCleanup)

--- a/e2e-tests/tests/tier1/e2e_suite_test.go
+++ b/e2e-tests/tests/tier1/e2e_suite_test.go
@@ -21,6 +21,7 @@ func init() {
 	flag.StringVar(&config.SourceNonAdminContext, "source-nonadmin-context", "", "Source cluster non-admin context for RBAC scenarios")
 	flag.StringVar(&config.TargetNonAdminContext, "target-nonadmin-context", "", "Target cluster non-admin context for RBAC scenarios")
 	flag.BoolVar(&config.InsecureSkipTLSVerify, "insecure-skip-tls-verify", false, "Skip TLS certificate verification for k8sdeploy connections (use for OCP clusters with self-signed certs)")
+	flag.StringVar(&config.RunAs, "run-as", "", "Override user context: set to 'admin' to run all tests with cluster-admin credentials")
 }
 
 // TestE2E configures Ginkgo and executes the e2e test suite.

--- a/e2e-tests/tests/tier1/mta_829_validate_alternative_gv_suggestion_test.go
+++ b/e2e-tests/tests/tier1/mta_829_validate_alternative_gv_suggestion_test.go
@@ -26,12 +26,6 @@ var _ = Describe("Validate alternative GV suggestion [Live Mode]", func() {
 			config.TargetContext,
 		)
 
-		if scenario.SrcAppNonAdmin.Context == "" {
-			Skip("source-nonadmin-context is required for non-admin stateless migration test")
-		}
-		if scenario.TgtAppNonAdmin.Context == "" {
-			Skip("target-nonadmin-context is required for non-admin stateless migration test")
-		}
 		srcApp := scenario.SrcAppNonAdmin
 		tgtApp := scenario.TgtAppNonAdmin
 		runner := scenario.CraneNonAdmin
@@ -40,7 +34,7 @@ var _ = Describe("Validate alternative GV suggestion [Live Mode]", func() {
 		}
 		tgtApp.ExtraVars = srcApp.ExtraVars
 		By("Grant ns admin permissions to nonadmin user on source and target")
-		kubectlSrcNonAdmin, _, cleanup, err := SetupNamespaceAdminUsersForScenario(scenario, namespace)
+		kubectlSrcNonAdmin, _, cleanup, err := SetupActiveKubectlRunners(scenario, namespace)
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() {
 			By("Delete test namespace on source and target (wait for completion)")

--- a/e2e-tests/tests/tier1/mta_830_instructions_file_force_reconcile_test.go
+++ b/e2e-tests/tests/tier1/mta_830_instructions_file_force_reconcile_test.go
@@ -27,12 +27,6 @@ var _ = Describe("Instructions-file force reconcile migration", func() {
 			config.TargetContext,
 		)
 
-		if scenario.KubectlSrcNonAdmin.Context == "" {
-			Skip("source-nonadmin-context is required for non-admin instructions file migration test")
-		}
-		if scenario.KubectlTgtNonAdmin.Context == "" {
-			Skip("target-nonadmin-context is required for non-admin instructions file migration test")
-		}
 
 		srcApp := scenario.SrcAppNonAdmin
 		tgtApp := scenario.TgtAppNonAdmin
@@ -43,7 +37,7 @@ var _ = Describe("Instructions-file force reconcile migration", func() {
 		tgtApp.ExtraVars = srcApp.ExtraVars
 
 		By("Grant ns admin permissions to nonadmin user on source and target")
-		kubectlSrcNonAdmin, kubectlTgtNonAdmin, cleanup, err := SetupNamespaceAdminUsersForScenario(scenario, namespace)
+		kubectlSrcNonAdmin, kubectlTgtNonAdmin, cleanup, err := SetupActiveKubectlRunners(scenario, namespace)
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() {
 			By("Delete test namespace on source and target (wait for completion)")

--- a/e2e-tests/tests/tier1/mta_832_validate_alternative_gv_suggestion_offline_test.go
+++ b/e2e-tests/tests/tier1/mta_832_validate_alternative_gv_suggestion_offline_test.go
@@ -29,12 +29,6 @@ var _ = Describe("Validate alternative GV suggestion [Offline Mode]", func() {
 			config.TargetContext,
 		)
 
-		if scenario.SrcAppNonAdmin.Context == "" {
-			Skip("source-nonadmin-context is required for non-admin stateless migration test")
-		}
-		if scenario.TgtAppNonAdmin.Context == "" {
-			Skip("target-nonadmin-context is required for non-admin stateless migration test")
-		}
 		srcApp := scenario.SrcAppNonAdmin
 		tgtApp := scenario.TgtAppNonAdmin
 		runner := scenario.CraneNonAdmin
@@ -43,7 +37,7 @@ var _ = Describe("Validate alternative GV suggestion [Offline Mode]", func() {
 		}
 		tgtApp.ExtraVars = srcApp.ExtraVars
 		By("Grant ns admin permissions to nonadmin user on source and target")
-		kubectlSrcNonAdmin, _, cleanup, err := SetupNamespaceAdminUsersForScenario(scenario, namespace)
+		kubectlSrcNonAdmin, _, cleanup, err := SetupActiveKubectlRunners(scenario, namespace)
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() {
 			By("Delete test namespace on source and target (wait for completion)")

--- a/e2e-tests/tests/tier1/mta_836_validate_core_group_omitted_offline_test.go
+++ b/e2e-tests/tests/tier1/mta_836_validate_core_group_omitted_offline_test.go
@@ -28,12 +28,6 @@ var _ = Describe("Validate core group omission [Offline Mode]", func() {
 			config.TargetContext,
 		)
 
-		if scenario.SrcAppNonAdmin.Context == "" {
-			Skip("source-nonadmin-context is required for non-admin offline validation test")
-		}
-		if scenario.TgtAppNonAdmin.Context == "" {
-			Skip("target-nonadmin-context is required for non-admin offline validation test")
-		}
 
 		srcApp := scenario.SrcAppNonAdmin
 		tgtApp := scenario.TgtAppNonAdmin
@@ -45,7 +39,7 @@ var _ = Describe("Validate core group omission [Offline Mode]", func() {
 		tgtApp.ExtraVars = srcApp.ExtraVars
 
 		By("Grant ns admin permissions to nonadmin user on source and target")
-		kubectlSrcNonAdmin, _, cleanup, err := SetupNamespaceAdminUsersForScenario(scenario, namespace)
+		kubectlSrcNonAdmin, _, cleanup, err := SetupActiveKubectlRunners(scenario, namespace)
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() {
 			By("Delete test namespace on source and target (wait for completion)")

--- a/e2e-tests/tests/tier1/mta_850_validate_duplicate_gvk_test.go
+++ b/e2e-tests/tests/tier1/mta_850_validate_duplicate_gvk_test.go
@@ -64,6 +64,8 @@ var _ = Describe("Crane validate with duplicate GVK resources in live mode", fun
 		)
 
 
+		Expect(scenario.KubectlTgtNonAdmin.Context).NotTo(BeEmpty(), "target-nonadmin-context is required for this test")
+
 		runner := scenario.CraneNonAdmin
 		runner.WorkDir = tempDir
 

--- a/e2e-tests/tests/tier1/mta_850_validate_duplicate_gvk_test.go
+++ b/e2e-tests/tests/tier1/mta_850_validate_duplicate_gvk_test.go
@@ -63,9 +63,6 @@ var _ = Describe("Crane validate with duplicate GVK resources in live mode", fun
 			config.TargetContext,
 		)
 
-		if scenario.KubectlTgtNonAdmin.Context == "" {
-			Skip("target-nonadmin-context is required for live validation test")
-		}
 
 		runner := scenario.CraneNonAdmin
 		runner.WorkDir = tempDir


### PR DESCRIPTION
Add a --run-as=admin flag that overrides all test contexts to use
cluster-admin credentials without modifying individual test files.

Changes:
- config: add RunAs field
- suite: register --run-as flag in tier0 and tier1 suite files
- scenario: populate NonAdmin fields with admin contexts when RunAs=admin
- rbac: add SetupActiveKubectlRunners and SetupActiveNamespaceAdmin
  helpers that bypass RBAC setup in admin mode and log the resolved
  username as proof of identity
- tests: remove empty-context Skip guards from all 21 non-admin tests
  and replace SetupNamespaceAdminUsersForScenario with
  SetupActiveKubectlRunners

When --run-as is omitted, behavior is unchanged.

**[Jenkins Run](https://jenkins-csb-migrationqe-main.dno.corp.redhat.com/job/mta/job/crane-ocp-tests-runner/213/testReport/)**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a `--run-as` flag to run end-to-end tests with admin credentials.
* **Bug Fixes**
  * Removed multiple premature skips so non-admin E2E migrations and validations run even when non-admin contexts are not provided.
  * Updated non-admin kubectl/permission initialization to consistently follow the correct admin vs non-admin execution path across tiers and scenarios.
* **Tests**
  * Added a compliance workflow to enforce non-admin test conventions around setup and skip guards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->