### PR TITLE
fixed test mta 807 to be compatible with both k8s and ocp

### DIFF
--- a/e2e-tests/framework/kubectl.go
+++ b/e2e-tests/framework/kubectl.go
@@ -51,6 +51,14 @@ func (k KubectlRunner) executeWithStdin(stdin string, args ...string) (string, e
 	return strings.TrimSpace(string(out)), nil
 }
 
+// IsOpenShift reports whether the cluster is an OpenShift cluster by checking
+// for the route.openshift.io API group. This is used to conditionally adjust
+// test app manifests for OCP's SCC requirements.
+func (k KubectlRunner) IsOpenShift() bool {
+	_, err := k.Run("api-resources", "--api-group=route.openshift.io", "--no-headers")
+	return err == nil
+}
+
 // OLMAPIAvailable reports whether the Subscription CRD is registered on the cluster.
 func (k KubectlRunner) OLMAPIAvailable() (bool, error) {
 	_, err := k.Run("get", "crd", "subscriptions.operators.coreos.com")

--- a/e2e-tests/tests/tier0/mta_807_data_validation_test.go
+++ b/e2e-tests/tests/tier0/mta_807_data_validation_test.go
@@ -75,7 +75,7 @@ func mysqlAuthorsCount(k KubectlRunner, namespace, podName string) (int, error) 
 	out, err := k.Run(
 		"exec", podName, "-n", namespace, "--",
 		"sh", "-c",
-		`MYSQL_PWD="$MYSQL_PASSWORD" mysql -N -B -u"$MYSQL_USER" "$MYSQL_DATABASE" -e "SELECT COUNT(*) FROM authors;"`,
+		`MYSQL_PWD="$MYSQL_PASSWORD" mysql -N -B -h 127.0.0.1 -u"$MYSQL_USER" "$MYSQL_DATABASE" -e "SELECT COUNT(*) FROM authors;"`,
 	)
 	if err != nil {
 		return 0, err
@@ -138,11 +138,15 @@ var _ = Describe("Data validation with indirect migration of MySQL DB", func() {
 		srcApp := scenario.SrcAppNonAdmin
 		tgtApp := scenario.TgtAppNonAdmin
 		runner := scenario.CraneNonAdmin
+
+		isOCP := scenario.KubectlSrc.IsOpenShift()
 		srcApp.ExtraVars = map[string]any{
 			"non_admin_user": "true",
+			"has_scc":        isOCP,
 		}
 		tgtApp.ExtraVars = map[string]any{
 			"non_admin_user": "true",
+			"has_scc":        isOCP,
 		}
 
 		By("Grant namespace admin permissions to nonadmin user on source and target")


### PR DESCRIPTION
Fixed MTA 807 to work with both k8s and ocp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test coverage for non-admin data validation scenarios on OpenShift clusters.
  * Added automatic OpenShift detection so validation flows can apply the right cluster-specific settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->