### PR TITLE
Add typed K8s resource helpers and cluster-level export e2e tests (MTA-851–855)

### DIFF
--- a/e2e-tests/framework/resources.go
+++ b/e2e-tests/framework/resources.go
@@ -1,0 +1,222 @@
+package framework
+
+import (
+	"fmt"
+	"log"
+	"strings"
+)
+
+type Resource interface {
+	Delete(k KubectlRunner) error
+	Create(k KubectlRunner) error
+}
+
+func ResourceCleanup(clusters []KubectlRunner, resources []Resource) {
+	for _, k := range clusters {
+		for _, r := range resources {
+			if err := r.Delete(k); err != nil {
+				log.Printf("cleanup: %v", err)
+			}
+		}
+	}
+}
+
+type ClusterRole struct {
+	Name     string
+	Verb     string
+	Resource string
+	Label    string
+}
+
+func (cr ClusterRole) Create(k KubectlRunner) error {
+	_, err := k.Run("create", "clusterrole", cr.Name, "--verb="+cr.Verb, "--resource="+cr.Resource)
+	if err != nil {
+		return fmt.Errorf("failed to create ClusterRole %s: %w", cr.Name, err)
+	}
+	log.Printf("created ClusterRole %s", cr.Name)
+	if cr.Label != "" {
+		_, err = k.Run("label", "clusterrole", cr.Name, cr.Label)
+		if err != nil {
+			return fmt.Errorf("failed to label ClusterRole %s: %w", cr.Name, err)
+		}
+	}
+	return nil
+}
+
+func (cr ClusterRole) Delete(k KubectlRunner) error {
+	_, err := k.Run("delete", "clusterrole", cr.Name, "--ignore-not-found=true")
+	if err != nil {
+		return fmt.Errorf("failed to delete ClusterRole %s: %w", cr.Name, err)
+	}
+	return nil
+}
+
+func (cr CustomResource) AssertField(k KubectlRunner, jsonpath, expected string) error {
+	val, err := k.Run("get", strings.ToLower(cr.Kind), cr.Name, "-n", cr.Namespace, "-o", "jsonpath="+jsonpath)
+	if err != nil {
+		return fmt.Errorf("failed to get %s %s field %s: %w", cr.Kind, cr.Name, jsonpath, err)
+	}
+	if val != expected {
+		return fmt.Errorf("%s %s field %s: expected %q, got %q", cr.Kind, cr.Name, jsonpath, expected, val)
+	}
+	return nil
+}
+
+type ClusterRoleBinding struct {
+	Name            string
+	ClusterRoleName string
+	Label           string
+}
+
+func (crb ClusterRoleBinding) Create(k KubectlRunner) error {
+	_, err := k.Run("create", "clusterrolebinding", crb.Name, "--clusterrole="+crb.ClusterRoleName)
+	if err != nil {
+		return fmt.Errorf("failed to create ClusterRoleBinding %s: %w", crb.Name, err)
+	}
+	log.Printf("created ClusterRoleBinding %s -> ClusterRole %s", crb.Name, crb.ClusterRoleName)
+	if crb.Label != "" {
+		_, err = k.Run("label", "clusterrolebinding", crb.Name, crb.Label)
+		if err != nil {
+			return fmt.Errorf("failed to label ClusterRoleBinding %s: %w", crb.Name, err)
+		}
+	}
+	return nil
+}
+
+func (crb ClusterRoleBinding) Delete(k KubectlRunner) error {
+	_, err := k.Run("delete", "clusterrolebinding", crb.Name, "--ignore-not-found=true")
+	if err != nil {
+		return fmt.Errorf("failed to delete ClusterRoleBinding %s: %w", crb.Name, err)
+	}
+	return nil
+}
+
+func (crb ClusterRoleBinding) AddSubject(k KubectlRunner, sa ServiceAccount) error {
+	subject := fmt.Sprintf(`{"kind":"ServiceAccount","name":"%s","namespace":"%s"}`, sa.Name, sa.Namespace)
+
+	out, err := k.Run("get", "clusterrolebinding", crb.Name, "-o", "jsonpath={.subjects}")
+	if err != nil {
+		return fmt.Errorf("failed to check subjects on CRB %s: %w", crb.Name, err)
+	}
+
+	var patch string
+	if out == "" {
+		patch = fmt.Sprintf(`[{"op":"add","path":"/subjects","value":[%s]}]`, subject)
+	} else {
+		patch = fmt.Sprintf(`[{"op":"add","path":"/subjects/-","value":%s}]`, subject)
+	}
+
+	_, err = k.Run("patch", "clusterrolebinding", crb.Name, "--type=json", "-p", patch)
+	if err != nil {
+		return fmt.Errorf("failed to add subject to CRB %s: %w", crb.Name, err)
+	}
+	return nil
+}
+
+type ServiceAccount struct {
+	Name      string
+	Namespace string
+}
+
+func (sa ServiceAccount) Create(k KubectlRunner) error {
+	_, err := k.Run("create", "serviceaccount", sa.Name, "-n", sa.Namespace)
+	if err != nil {
+		return fmt.Errorf("failed to create ServiceAccount %s in %s: %w", sa.Name, sa.Namespace, err)
+	}
+	log.Printf("created ServiceAccount %s in %s", sa.Name, sa.Namespace)
+	return nil
+}
+
+func (sa ServiceAccount) Delete(k KubectlRunner) error {
+	_, err := k.Run("delete", "serviceaccount", sa.Name, "-n", sa.Namespace, "--ignore-not-found=true")
+	if err != nil {
+		return fmt.Errorf("failed to delete ServiceAccount %s: %w", sa.Name, err)
+	}
+	return nil
+}
+
+type CustomResourceDefinition struct {
+	Name string
+	YAML string
+}
+
+func (crd CustomResourceDefinition) Create(k KubectlRunner) error {
+	_, err := k.RunWithStdin(crd.YAML, "apply", "-f", "-")
+	if err != nil {
+		return fmt.Errorf("failed to create CRD %s: %w", crd.Name, err)
+	}
+	log.Printf("created CRD %s", crd.Name)
+	return nil
+}
+
+func (crd CustomResourceDefinition) Delete(k KubectlRunner) error {
+	_, err := k.Run("delete", "crd", crd.Name, "--ignore-not-found=true")
+	if err != nil {
+		return fmt.Errorf("failed to delete CRD %s: %w", crd.Name, err)
+	}
+	return nil
+}
+
+func (crd CustomResourceDefinition) WaitForEstablished(k KubectlRunner) error {
+	_, err := k.Run("wait", "--for=condition=Established", "crd/"+crd.Name, "--timeout=30s")
+	if err != nil {
+		return fmt.Errorf("CRD %s not established: %w", crd.Name, err)
+	}
+	log.Printf("CRD %s is Established", crd.Name)
+	return nil
+}
+
+type CustomResource struct {
+	Name      string
+	Namespace string
+	Kind      string
+	Resource  string
+	YAML      string
+}
+
+func (cr CustomResource) Create(k KubectlRunner) error {
+	_, err := k.RunWithStdin(cr.YAML, "apply", "-f", "-", "-n", cr.Namespace)
+	if err != nil {
+		return fmt.Errorf("failed to create %s %s: %w", cr.Kind, cr.Name, err)
+	}
+	log.Printf("created %s %s in %s", cr.Kind, cr.Name, cr.Namespace)
+	return nil
+}
+
+func (cr CustomResource) Delete(k KubectlRunner) error {
+	if cr.Resource == "" {
+		return fmt.Errorf("failed to delete %s %s: missing API resource name for kind %s", cr.Kind, cr.Name, cr.Kind)
+	}
+	_, err := k.Run("delete", cr.Resource, cr.Name, "-n", cr.Namespace, "--ignore-not-found=true")
+	if err != nil {
+		return fmt.Errorf("failed to delete %s %s (api resource %s): %w", cr.Kind, cr.Name, cr.Resource, err)
+	}
+	return nil
+}
+
+type Namespace struct {
+	Name  string
+	Label string
+}
+
+func (n Namespace) Create(k KubectlRunner) error {
+	if err := k.CreateNamespace(n.Name); err != nil {
+		return fmt.Errorf("failed to create namespace %s: %w", n.Name, err)
+	}
+	log.Printf("created namespace %s", n.Name)
+	if n.Label != "" {
+		_, err := k.Run("label", "namespace", n.Name, n.Label)
+		if err != nil {
+			return fmt.Errorf("failed to label namespace %s: %w", n.Name, err)
+		}
+	}
+	return nil
+}
+
+func (n Namespace) Delete(k KubectlRunner) error {
+	_, err := k.Run("delete", "namespace", n.Name, "--ignore-not-found=true", "--wait=true", "--timeout=60s")
+	if err != nil {
+		return fmt.Errorf("failed to delete namespace %s: %w", n.Name, err)
+	}
+	return nil
+}

--- a/e2e-tests/framework/resources.go
+++ b/e2e-tests/framework/resources.go
@@ -1,6 +1,7 @@
 package framework
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -11,14 +12,16 @@ type Resource interface {
 	Create(k KubectlRunner) error
 }
 
-func ResourceCleanup(clusters []KubectlRunner, resources []Resource) {
+func ResourceCleanup(clusters []KubectlRunner, resources []Resource) error {
+	var errs []error
 	for _, k := range clusters {
 		for _, r := range resources {
 			if err := r.Delete(k); err != nil {
-				log.Printf("cleanup: %v", err)
+				errs = append(errs, err)
 			}
 		}
 	}
+	return errors.Join(errs...)
 }
 
 type ClusterRole struct {

--- a/e2e-tests/framework/test_helpers.go
+++ b/e2e-tests/framework/test_helpers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/onsi/ginkgo/v2"
@@ -71,12 +72,14 @@ func ValidateClusterRBAC(kubectl KubectlRunner, bindings []ExpectedClusterRoleBi
 			return fmt.Errorf("CRB %s references %s, expected %s", b.ClusterRoleBindingName, roleRef, b.ClusterRoleName)
 		}
 
-		subject, err := kubectl.Run("get", "clusterrolebinding", b.ClusterRoleBindingName, "-o", "jsonpath={.subjects[*].name}")
+		subjectOutput, err := kubectl.Run("get", "clusterrolebinding", b.ClusterRoleBindingName, "-o", "jsonpath={.subjects[*].name}")
 		if err != nil {
 			return fmt.Errorf("failed to get subject for CRB %s: %w", b.ClusterRoleBindingName, err)
 		}
-		if subject != b.SubjectName {
-			return fmt.Errorf("CRB %s subject is %s, expected %s", b.ClusterRoleBindingName, subject, b.SubjectName)
+		subjects := strings.Fields(subjectOutput)
+
+		if !slices.Contains(subjects, b.SubjectName) {
+			return fmt.Errorf("CRB %s subject is %s, expected %s", b.ClusterRoleBindingName, subjectOutput, b.SubjectName)
 		}
 		log.Printf("CRB %s -> CR %s (subject: %s) verified", b.ClusterRoleBindingName, b.ClusterRoleName, b.SubjectName)
 	}

--- a/e2e-tests/framework/test_helpers.go
+++ b/e2e-tests/framework/test_helpers.go
@@ -2,6 +2,7 @@ package framework
 
 import (
 	"fmt"
+	"log"
 	"regexp"
 	"strings"
 
@@ -37,4 +38,47 @@ func RegisterMTAResultReporter() {
 			fmt.Printf("\n[CRANE-RESULT] SKIPPED %s\n", id)
 		}
 	})
+}
+
+type ExpectedClusterRoleBinding struct {
+	ClusterRoleBindingName string
+	ClusterRoleName        string
+	SubjectName            string
+}
+
+func ValidateClusterRBAC(kubectl KubectlRunner, bindings []ExpectedClusterRoleBinding) error {
+	clusterRoles := map[string]bool{}
+	for _, b := range bindings {
+		clusterRoles[b.ClusterRoleName] = true
+	}
+	for cr := range clusterRoles {
+		if _, err := kubectl.Run("get", "clusterrole", cr); err != nil {
+			return fmt.Errorf("ClusterRole %s not found: %w", cr, err)
+		}
+		log.Printf("ClusterRole %s exists", cr)
+	}
+
+	for _, b := range bindings {
+		if _, err := kubectl.Run("get", "clusterrolebinding", b.ClusterRoleBindingName); err != nil {
+			return fmt.Errorf("ClusterRoleBinding %s not found: %w", b.ClusterRoleBindingName, err)
+		}
+
+		roleRef, err := kubectl.Run("get", "clusterrolebinding", b.ClusterRoleBindingName, "-o", "jsonpath={.roleRef.name}")
+		if err != nil {
+			return fmt.Errorf("failed to get roleRef for CRB %s: %w", b.ClusterRoleBindingName, err)
+		}
+		if roleRef != b.ClusterRoleName {
+			return fmt.Errorf("CRB %s references %s, expected %s", b.ClusterRoleBindingName, roleRef, b.ClusterRoleName)
+		}
+
+		subject, err := kubectl.Run("get", "clusterrolebinding", b.ClusterRoleBindingName, "-o", "jsonpath={.subjects[*].name}")
+		if err != nil {
+			return fmt.Errorf("failed to get subject for CRB %s: %w", b.ClusterRoleBindingName, err)
+		}
+		if subject != b.SubjectName {
+			return fmt.Errorf("CRB %s subject is %s, expected %s", b.ClusterRoleBindingName, subject, b.SubjectName)
+		}
+		log.Printf("CRB %s -> CR %s (subject: %s) verified", b.ClusterRoleBindingName, b.ClusterRoleName, b.SubjectName)
+	}
+	return nil
 }

--- a/e2e-tests/testdata/widget_cr.yaml
+++ b/e2e-tests/testdata/widget_cr.yaml
@@ -1,0 +1,7 @@
+apiVersion: crane-e2e.example.com/v1
+kind: Widget
+metadata:
+  name: test-widget
+spec:
+  color: blue
+  size: 5

--- a/e2e-tests/testdata/widget_crd.yaml
+++ b/e2e-tests/testdata/widget_crd.yaml
@@ -1,0 +1,27 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.crane-e2e.example.com
+spec:
+  group: crane-e2e.example.com
+  names:
+    kind: Widget
+    listKind: WidgetList
+    plural: widgets
+    singular: widget
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                color:
+                  type: string
+                size:
+                  type: integer

--- a/e2e-tests/tests/tier0/mta_851_no_cluster_resources_test.go
+++ b/e2e-tests/tests/tier0/mta_851_no_cluster_resources_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"log"
 	"os"
 	"path/filepath"
 
@@ -35,7 +36,9 @@ var _ = Describe("Cluster-level export control", func() {
 			OutputDir: paths.OutputDir}
 
 		DeferCleanup(func() {
-			CleanupScenario(paths.TempDir, srcApp, tgtApp)
+			if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
+				log.Printf("cleanup: %v", err)
+			}
 		})
 
 		By("Deploying namespace-only app on source cluster")

--- a/e2e-tests/tests/tier0/mta_851_no_cluster_resources_test.go
+++ b/e2e-tests/tests/tier0/mta_851_no_cluster_resources_test.go
@@ -1,0 +1,57 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Cluster-level export control", func() {
+	It("[MTA-851] Should produce no _cluster output for namespace-only workload", Label("tier0"), func() {
+		appName := "simple-nginx-nopv"
+		namespace := "simple-nginx-nopv"
+		serviceName := "my-" + appName
+		scenario := NewMigrationScenario(
+			appName,
+			namespace,
+			config.K8sDeployBin,
+			config.CraneBin,
+			config.SourceContext,
+			config.TargetContext,
+		)
+		srcApp := scenario.SrcApp
+		tgtApp := scenario.TgtApp
+		kubectlSrc := scenario.KubectlSrc
+		paths, err := NewScenarioPaths("crane-ca5-*")
+		Expect(err).NotTo(HaveOccurred())
+		runner := scenario.Crane
+		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
+
+		DeferCleanup(func() {
+			CleanupScenario(paths.TempDir, srcApp, tgtApp)
+		})
+
+		By("Deploying namespace-only app on source cluster")
+		Expect(PrepareSourceApp(srcApp, kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Waiting for source pods and endpoints to drain")
+		WaitForSourceQuiesce(kubectlSrc, namespace, "app="+appName, serviceName)
+
+		By("Running crane export, transform, apply")
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
+
+		By("Verifying no _cluster directory to be created")
+		_, err = os.Stat(filepath.Join(paths.ExportDir, "resources", namespace, "_cluster"))
+		// _cluster directory is being created only when cluster Resources are present
+		Expect(err).To(HaveOccurred())
+
+	})
+
+})

--- a/e2e-tests/tests/tier0/mta_852_minimal_rbac_test.go
+++ b/e2e-tests/tests/tier0/mta_852_minimal_rbac_test.go
@@ -43,8 +43,13 @@ var _ = Describe("Cluster-level RBAC export", func() {
 		cr := ClusterRole{Name: clusterRoleName, Verb: "get,list,watch", Resource: "pods"}
 		sa := ServiceAccount{Name: "nginx-sa", Namespace: namespace}
 		DeferCleanup(func() {
-			ResourceCleanup([]KubectlRunner{kubectlSrc, kubectlTgt}, []Resource{cr, crb, sa})
-			CleanupScenario(paths.TempDir, srcApp, tgtApp)
+			if err := ResourceCleanup([]KubectlRunner{kubectlSrc, kubectlTgt}, []Resource{cr, crb, sa}); err != nil {
+				log.Printf("Resources cleanup: %v", err)
+			}
+
+			if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
+				log.Printf("Scenario cleanup: %v", err)
+			}
 		})
 
 		By("Prepare source app")

--- a/e2e-tests/tests/tier0/mta_852_minimal_rbac_test.go
+++ b/e2e-tests/tests/tier0/mta_852_minimal_rbac_test.go
@@ -1,0 +1,95 @@
+package e2e
+
+import (
+	"log"
+	"path/filepath"
+
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	"github.com/konveyor/crane/e2e-tests/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Cluster-level RBAC export", func() {
+	It("[MTA-852] Should export ClusterRole and ClusterRoleBinding for linked ServiceAccount", Label("cluster-admin"), func() {
+		appName := "simple-nginx-nopv"
+		namespace := "simple-nginx-nopv"
+		serviceName := "my-" + appName
+		clusterRoleBindingName := "crane-e2e-pod-reader-binding"
+		clusterRoleName := "crane-e2e-pod-reader"
+		scenario := NewMigrationScenario(
+			appName,
+			namespace,
+			config.K8sDeployBin,
+			config.CraneBin,
+			config.SourceContext,
+			config.TargetContext,
+		)
+		srcApp := scenario.SrcApp
+		tgtApp := scenario.TgtApp
+		kubectlSrc := scenario.KubectlSrc
+		kubectlTgt := scenario.KubectlTgt
+		runner := scenario.Crane
+
+		paths, err := NewScenarioPaths("crane-ca1-*")
+		Expect(err).NotTo(HaveOccurred())
+		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
+
+		crb := ClusterRoleBinding{Name: clusterRoleBindingName, ClusterRoleName: clusterRoleName}
+		cr := ClusterRole{Name: clusterRoleName, Verb: "get,list,watch", Resource: "pods"}
+		sa := ServiceAccount{Name: "nginx-sa", Namespace: namespace}
+		DeferCleanup(func() {
+			ResourceCleanup([]KubectlRunner{kubectlSrc, kubectlTgt}, []Resource{cr, crb, sa})
+			CleanupScenario(paths.TempDir, srcApp, tgtApp)
+		})
+
+		By("Prepare source app")
+		log.Printf("Preparing source app %s in namespace %s\n", srcApp.Name, srcApp.Namespace)
+		Expect(PrepareSourceApp(srcApp, kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Creating Service-Account on namespace")
+		Expect(sa.Create(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Creating ClusterRole")
+		Expect(cr.Create(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Creating ClusterRoleBinding that references the app's ServiceAccount")
+		Expect(crb.Create(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Bind Relevent Service-Account to cluster role")
+		Expect(crb.AddSubject(kubectlSrc, sa)).NotTo(HaveOccurred())
+
+		By("Waiting for source pods and endpoints to drain")
+		WaitForSourceQuiesce(kubectlSrc, namespace, "app="+appName, serviceName)
+
+		By("Running crane export, transform, apply")
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
+
+		By("Verifying no resources failed to export")
+		failuresDir := filepath.Join(paths.ExportDir, "failures", namespace)
+		hasFiles, _, err := utils.HasFilesRecursively(failuresDir)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(hasFiles).To(BeFalse())
+
+		By("Dry-run applying output manifests on target")
+		Expect(kubectlTgt.CreateNamespace(namespace)).NotTo(HaveOccurred())
+		Expect(kubectlTgt.ValidateApplyDir(paths.OutputDir)).NotTo(HaveOccurred())
+
+		By("Applying migrated manifests to target cluster")
+		Expect(ApplyOutputToTarget(kubectlTgt, namespace, paths.OutputDir)).NotTo(HaveOccurred())
+
+		By("Scaling target deployment and validating app")
+		Expect(kubectlTgt.ScaleDeployment(namespace, appName, 1)).NotTo(HaveOccurred())
+		Eventually(tgtApp.Validate, "2m", "10s").Should(Succeed())
+
+		By("Verifying ClusterRoleBinding on target references correct ClusterRole and ServiceAccount")
+		Expect(ValidateClusterRBAC(kubectlTgt, []ExpectedClusterRoleBinding{
+			{ClusterRoleBindingName: clusterRoleBindingName, ClusterRoleName: clusterRoleName, SubjectName: sa.Name},
+		})).NotTo(HaveOccurred())
+	})
+
+})

--- a/e2e-tests/tests/tier0/mta_852_minimal_rbac_test.go
+++ b/e2e-tests/tests/tier0/mta_852_minimal_rbac_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 var _ = Describe("Cluster-level RBAC export", func() {
-	It("[MTA-852] Should export ClusterRole and ClusterRoleBinding for linked ServiceAccount", Label("cluster-admin"), func() {
+	It("[MTA-852] Should export ClusterRole and ClusterRoleBinding for linked ServiceAccount", Label("tier0"), func() {
 		appName := "simple-nginx-nopv"
 		namespace := "simple-nginx-nopv"
 		serviceName := "my-" + appName

--- a/e2e-tests/tests/tier0/mta_853_split_apply_test.go
+++ b/e2e-tests/tests/tier0/mta_853_split_apply_test.go
@@ -1,0 +1,102 @@
+package e2e
+
+import (
+	"path/filepath"
+
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	"github.com/konveyor/crane/e2e-tests/utils"
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Namespace-admin cluster-level migration", func() {
+	It("[MTA-853] Should migrate workload with split apply: namespace-admin + cluster-admin", Label("namespace-admin"), func() {
+		appName := "simple-nginx-nopv"
+		namespace := "simple-nginx-nopv"
+		serviceName := "my-" + appName
+		scenario := NewMigrationScenario(
+			appName,
+			namespace,
+			config.K8sDeployBin,
+			config.CraneBin,
+			config.SourceContext,
+			config.TargetContext,
+		)
+		clusterRoleBindingName := "crane-e2e-pod-reader-binding"
+		clusterRoleName := "crane-e2e-pod-reader"
+		deniedResources := []string{"clusterroles.yaml", "clusterrolebindings.yaml"}
+		if scenario.KubectlSrcNonAdmin.Context == "" {
+			Skip("source-nonadmin-context is required for non-admin role migration test")
+		}
+		if scenario.KubectlTgtNonAdmin.Context == "" {
+			Skip("target-nonadmin-context is required for non-admin role migration test")
+		}
+		srcAppNonAdmin := scenario.SrcAppNonAdmin
+		tgtAppNonAdmin := scenario.TgtAppNonAdmin
+
+		srcAppNonAdmin.ExtraVars = map[string]any{
+			"non_admin_user": "true",
+		}
+		tgtAppNonAdmin.ExtraVars = map[string]any{
+			"non_admin_user": "true",
+		}
+
+		kubectlSrc := scenario.KubectlSrc
+		kubectlTgt := scenario.KubectlTgt
+		paths, err := NewScenarioPaths("crane-na1-*")
+		runner := scenario.CraneNonAdmin
+
+		exportOpts := ExportOptions{Namespace: srcAppNonAdmin.Namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
+		Expect(err).NotTo(HaveOccurred())
+
+		crb := ClusterRoleBinding{Name: clusterRoleBindingName, ClusterRoleName: clusterRoleName}
+		cr := ClusterRole{Name: clusterRoleName, Verb: "get,list,watch", Resource: "pods"}
+
+		By("Granting namespace-admin permissions to non-admin user on source and target")
+		kubectlSrcNonAdmin, kubectlTgtNonAdmin, rbacCleanup, err := SetupNamespaceAdminUsersForScenario(scenario, namespace)
+		Expect(err).NotTo(HaveOccurred())
+
+		DeferCleanup(rbacCleanup)
+		DeferCleanup(func() {
+			ResourceCleanup([]KubectlRunner{kubectlSrc, kubectlTgt}, []Resource{crb, cr})
+			CleanupScenario(paths.TempDir, srcAppNonAdmin, tgtAppNonAdmin)
+
+		})
+
+		By("Deploying app as namespace-admin on source cluster")
+		err = PrepareSourceApp(srcAppNonAdmin, kubectlSrcNonAdmin)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating ClusterRole")
+		Expect(cr.Create(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Creating ClusterRoleBinding")
+		Expect(crb.Create(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Waiting for source pods and endpoints to drain")
+		WaitForSourceQuiesce(kubectlSrcNonAdmin, namespace, "app="+appName, serviceName)
+
+		By("Running crane export, transform, apply as namespace-admin")
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
+
+		By("Verifying cluster resources failed to export (expected for namespace-admin)")
+		Expect(utils.AssertFilesExist(filepath.Join(paths.ExportDir, "failures"), deniedResources)).To(HaveOccurred())
+
+		By("Verifying no cluster resources in output _cluster directory")
+		Expect(utils.AssertNoKindsInOutput(paths.OutputDir, []string{"ClusterRole", "ClusterRoleBinding"})).NotTo(HaveOccurred())
+
+		By("Applying namespace resources to target as namespace-admin")
+		Expect(kubectlTgt.ApplyDir(filepath.Join(paths.OutputDir, "resources", namespace))).NotTo(HaveOccurred())
+
+		By("Scaling target deployment and validating app")
+		Expect(kubectlTgtNonAdmin.ScaleDeployment(namespace, appName, 1)).NotTo(HaveOccurred())
+		Eventually(tgtAppNonAdmin.Validate, "2m", "10s").Should(gomega.Succeed())
+
+	})
+
+})

--- a/e2e-tests/tests/tier0/mta_853_split_apply_test.go
+++ b/e2e-tests/tests/tier0/mta_853_split_apply_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 var _ = Describe("Namespace-admin cluster-level migration", func() {
-	It("[MTA-853] Should migrate workload with split apply: namespace-admin + cluster-admin", Label("namespace-admin"), func() {
+	It("[MTA-853] Should migrate workload with split apply: namespace-admin + cluster-admin", Label("tier0"), func() {
 		appName := "simple-nginx-nopv"
 		namespace := "simple-nginx-nopv"
 		serviceName := "my-" + appName

--- a/e2e-tests/tests/tier0/mta_853_split_apply_test.go
+++ b/e2e-tests/tests/tier0/mta_853_split_apply_test.go
@@ -1,13 +1,13 @@
 package e2e
 
 import (
+	"log"
 	"path/filepath"
 
 	"github.com/konveyor/crane/e2e-tests/config"
 	. "github.com/konveyor/crane/e2e-tests/framework"
 	"github.com/konveyor/crane/e2e-tests/utils"
 	. "github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
 )
 
@@ -46,13 +46,13 @@ var _ = Describe("Namespace-admin cluster-level migration", func() {
 		kubectlSrc := scenario.KubectlSrc
 		kubectlTgt := scenario.KubectlTgt
 		paths, err := NewScenarioPaths("crane-na1-*")
+		Expect(err).NotTo(HaveOccurred())
 		runner := scenario.CraneNonAdmin
 
 		exportOpts := ExportOptions{Namespace: srcAppNonAdmin.Namespace, ExportDir: paths.ExportDir}
 		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
 		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
 			OutputDir: paths.OutputDir}
-		Expect(err).NotTo(HaveOccurred())
 
 		crb := ClusterRoleBinding{Name: clusterRoleBindingName, ClusterRoleName: clusterRoleName}
 		cr := ClusterRole{Name: clusterRoleName, Verb: "get,list,watch", Resource: "pods"}
@@ -63,8 +63,12 @@ var _ = Describe("Namespace-admin cluster-level migration", func() {
 
 		DeferCleanup(rbacCleanup)
 		DeferCleanup(func() {
-			ResourceCleanup([]KubectlRunner{kubectlSrc, kubectlTgt}, []Resource{crb, cr})
-			CleanupScenario(paths.TempDir, srcAppNonAdmin, tgtAppNonAdmin)
+			if err := ResourceCleanup([]KubectlRunner{kubectlSrc, kubectlTgt}, []Resource{crb, cr}); err != nil {
+				log.Printf("Resources cleanup: %v", err)
+			}
+			if err := CleanupScenario(paths.TempDir, srcAppNonAdmin, tgtAppNonAdmin); err != nil {
+				log.Printf("Scenario cleanup: %v", err)
+			}
 
 		})
 
@@ -85,7 +89,7 @@ var _ = Describe("Namespace-admin cluster-level migration", func() {
 		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 
 		By("Verifying cluster resources failed to export (expected for namespace-admin)")
-		Expect(utils.AssertFilesExist(filepath.Join(paths.ExportDir, "failures"), deniedResources)).To(HaveOccurred())
+		Expect(utils.AssertFilesExist(filepath.Join(paths.ExportDir, "failures", namespace), deniedResources)).NotTo(HaveOccurred())
 
 		By("Verifying no cluster resources in output _cluster directory")
 		Expect(utils.AssertNoKindsInOutput(paths.OutputDir, []string{"ClusterRole", "ClusterRoleBinding"})).NotTo(HaveOccurred())
@@ -95,7 +99,7 @@ var _ = Describe("Namespace-admin cluster-level migration", func() {
 
 		By("Scaling target deployment and validating app")
 		Expect(kubectlTgtNonAdmin.ScaleDeployment(namespace, appName, 1)).NotTo(HaveOccurred())
-		Eventually(tgtAppNonAdmin.Validate, "2m", "10s").Should(gomega.Succeed())
+		Eventually(tgtAppNonAdmin.Validate, "2m", "10s").Should(Succeed())
 
 	})
 

--- a/e2e-tests/tests/tier1/mta_854_two_clusterroles_test.go
+++ b/e2e-tests/tests/tier1/mta_854_two_clusterroles_test.go
@@ -45,13 +45,13 @@ var _ = Describe("Cluster-level RBAC export", func() {
 		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
 			OutputDir: paths.OutputDir}
 		DeferCleanup(func() {
-			ResourceCleanup([]KubectlRunner{kubectlSrc, kubectlTgt}, []Resource{
-				readCR, writeCR, readCRB, writeCRB, sa,
-			})
-		})
+			if err := ResourceCleanup([]KubectlRunner{kubectlSrc, kubectlTgt}, []Resource{readCR, writeCR, readCRB, writeCRB, sa}); err != nil {
+				log.Printf("Resources cleanup: %v", err)
+			}
 
-		DeferCleanup(func() {
-			CleanupScenario(paths.TempDir, srcApp, tgtApp)
+			if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
+				log.Printf("Scenario cleanup: %v", err)
+			}
 		})
 
 		By("Deploying app with ServiceAccount on source cluster")

--- a/e2e-tests/tests/tier1/mta_854_two_clusterroles_test.go
+++ b/e2e-tests/tests/tier1/mta_854_two_clusterroles_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 var _ = Describe("Cluster-level RBAC export", func() {
-	It("[MTA-854] Should export two ClusterRoles and two ClusterRoleBindings for one Deployment", Label("cluster-admin"), func() {
-		appName := "nginx-with-serviceaccount"
+	It("[MTA-854] Should export two ClusterRoles and two ClusterRoleBindings for one Deployment", Label("tier1"), func() {
+		appName := "simple-nginx-nopv"
 		namespace := "simple-nginx-nopv"
 		serviceName := "my-" + appName
 		readClusterRole := "crane-e2e-pod-reader"
@@ -40,10 +40,12 @@ var _ = Describe("Cluster-level RBAC export", func() {
 		readCRB := ClusterRoleBinding{Name: readClusterRoleBindingName, ClusterRoleName: readClusterRole}
 		writeCRB := ClusterRoleBinding{Name: writeClusterRoleBindingName, ClusterRoleName: writeClusterRole}
 		sa := ServiceAccount{Name: "nginx-sa", Namespace: namespace}
+
 		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
 		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
 		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
 			OutputDir: paths.OutputDir}
+
 		DeferCleanup(func() {
 			if err := ResourceCleanup([]KubectlRunner{kubectlSrc, kubectlTgt}, []Resource{readCR, writeCR, readCRB, writeCRB, sa}); err != nil {
 				log.Printf("Resources cleanup: %v", err)
@@ -54,7 +56,7 @@ var _ = Describe("Cluster-level RBAC export", func() {
 			}
 		})
 
-		By("Deploying app with ServiceAccount on source cluster")
+		By("Deploying app with on source cluster")
 		Expect(PrepareSourceApp(srcApp, kubectlSrc)).NotTo(HaveOccurred())
 
 		By("Creating ClusterRole with pod read permissions")
@@ -68,6 +70,9 @@ var _ = Describe("Cluster-level RBAC export", func() {
 
 		By("Creating ClusterRoleBinding for write ClusterRole")
 		Expect(writeCRB.Create(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Creating Service-Account on Namespace")
+		Expect(sa.Create(kubectlSrc)).NotTo(HaveOccurred())
 
 		By("Bind Relevent Service-Account to Read cluster role")
 		Expect(readCRB.AddSubject(kubectlSrc, sa)).NotTo(HaveOccurred())

--- a/e2e-tests/tests/tier1/mta_854_two_clusterroles_test.go
+++ b/e2e-tests/tests/tier1/mta_854_two_clusterroles_test.go
@@ -1,0 +1,101 @@
+package e2e
+
+import (
+	"log"
+
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Cluster-level RBAC export", func() {
+	It("[MTA-854] Should export two ClusterRoles and two ClusterRoleBindings for one Deployment", Label("cluster-admin"), func() {
+		appName := "nginx-with-serviceaccount"
+		namespace := "simple-nginx-nopv"
+		serviceName := "my-" + appName
+		readClusterRole := "crane-e2e-pod-reader"
+		writeClusterRole := "crane-e2e-pod-writer"
+		readClusterRoleBindingName := "reader-crane-e2e-pod-binding"
+		writeClusterRoleBindingName := "writer-crane-e2e-pod-binding"
+		scenario := NewMigrationScenario(
+			appName,
+			namespace,
+			config.K8sDeployBin,
+			config.CraneBin,
+			config.SourceContext,
+			config.TargetContext,
+		)
+		srcApp := scenario.SrcApp
+		tgtApp := scenario.TgtApp
+		kubectlSrc := scenario.KubectlSrc
+		kubectlTgt := scenario.KubectlTgt
+		runner := scenario.Crane
+
+		paths, err := NewScenarioPaths("crane-ca3-*")
+		Expect(err).NotTo(HaveOccurred())
+
+		readCR := ClusterRole{Name: readClusterRole, Verb: "get,list,watch", Resource: "pods"}
+		writeCR := ClusterRole{Name: writeClusterRole, Verb: "get,list,watch,create,update,delete", Resource: "pods"}
+		readCRB := ClusterRoleBinding{Name: readClusterRoleBindingName, ClusterRoleName: readClusterRole}
+		writeCRB := ClusterRoleBinding{Name: writeClusterRoleBindingName, ClusterRoleName: writeClusterRole}
+		sa := ServiceAccount{Name: "nginx-sa", Namespace: namespace}
+		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
+		DeferCleanup(func() {
+			ResourceCleanup([]KubectlRunner{kubectlSrc, kubectlTgt}, []Resource{
+				readCR, writeCR, readCRB, writeCRB, sa,
+			})
+		})
+
+		DeferCleanup(func() {
+			CleanupScenario(paths.TempDir, srcApp, tgtApp)
+		})
+
+		By("Deploying app with ServiceAccount on source cluster")
+		Expect(PrepareSourceApp(srcApp, kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Creating ClusterRole with pod read permissions")
+		Expect(readCR.Create(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Creating ClusterRole with pod write permissions")
+		Expect(writeCR.Create(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Creating ClusterRoleBinding for read ClusterRole")
+		Expect(readCRB.Create(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Creating ClusterRoleBinding for write ClusterRole")
+		Expect(writeCRB.Create(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Bind Relevent Service-Account to Read cluster role")
+		Expect(readCRB.AddSubject(kubectlSrc, sa)).NotTo(HaveOccurred())
+
+		By("Bind Relevent Service-Account to Write cluster role")
+		Expect(writeCRB.AddSubject(kubectlSrc, sa)).NotTo(HaveOccurred())
+
+		By("Waiting for source pods and endpoints to drain")
+		WaitForSourceQuiesce(kubectlSrc, namespace, "app="+appName, serviceName)
+
+		By("Running crane export, transform, apply")
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
+
+		By("Create namespace on target, dryrun validate and Applying migrated manifests to target cluster")
+		Expect(ApplyOutputToTarget(kubectlTgt, namespace, paths.OutputDir)).NotTo(HaveOccurred())
+
+		By("Scale target deployment and validate app")
+		log.Printf("Scaling target deployment(s) with label app=%s to 1\n", appName)
+		Expect(kubectlTgt.ScaleDeployment(tgtApp.Namespace, appName, 1)).NotTo(HaveOccurred())
+
+		log.Printf("Validating app %s on target cluster\n", tgtApp.Name)
+		Eventually(tgtApp.Validate, "2m", "10s").Should(Succeed())
+		log.Printf("Target validation completed for app %s\n", tgtApp.Name)
+
+		By("Verifying both ClusterRoleBindings on target reference correct ClusterRoles and ServiceAccount")
+		Expect(ValidateClusterRBAC(kubectlTgt, []ExpectedClusterRoleBinding{
+			{ClusterRoleBindingName: readClusterRoleBindingName, ClusterRoleName: readClusterRole, SubjectName: sa.Name},
+			{ClusterRoleBindingName: writeClusterRoleBindingName, ClusterRoleName: writeClusterRole, SubjectName: sa.Name},
+		})).NotTo(HaveOccurred())
+	})
+})

--- a/e2e-tests/tests/tier1/mta_855_crd_custom_resource_test.go
+++ b/e2e-tests/tests/tier1/mta_855_crd_custom_resource_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 var _ = Describe("Cluster-level RBAC export", func() {
-	It("[MTA-855] Should export CRD to _cluster and custom resource to namespace directory", Label("cluster-admin"), func() {
+	It("[MTA-855] Should export CRD to _cluster and custom resource to namespace directory", Label("tier1"), func() {
 		appName := "simple-nginx-nopv"
 		namespace := "simple-nginx-nopv"
 		serviceName := "my-" + appName

--- a/e2e-tests/tests/tier1/mta_855_crd_custom_resource_test.go
+++ b/e2e-tests/tests/tier1/mta_855_crd_custom_resource_test.go
@@ -1,0 +1,99 @@
+package e2e
+
+import (
+	"path/filepath"
+
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	"github.com/konveyor/crane/e2e-tests/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Cluster-level RBAC export", func() {
+	It("[MTA-855] Should export CRD to _cluster and custom resource to namespace directory", Label("cluster-admin"), func() {
+		appName := "simple-nginx-nopv"
+		namespace := "simple-nginx-nopv"
+		serviceName := "my-" + appName
+		scenario := NewMigrationScenario(
+			appName,
+			namespace,
+			config.K8sDeployBin,
+			config.CraneBin,
+			config.SourceContext,
+			config.TargetContext,
+		)
+		srcApp := scenario.SrcApp
+		tgtApp := scenario.TgtApp
+		kubectlSrc := scenario.KubectlSrc
+		kubectlTgt := scenario.KubectlTgt
+		runner := scenario.Crane
+
+		crName := "test-widget"
+		paths, err := NewScenarioPaths("crane-ca9-*")
+		Expect(err).NotTo(HaveOccurred())
+		crdYAML, err := utils.ReadTestdataFile("widget_crd.yaml")
+		Expect(err).NotTo(HaveOccurred())
+		crYAML, err := utils.ReadTestdataFile("widget_cr.yaml")
+		Expect(err).NotTo(HaveOccurred())
+
+		crd := CustomResourceDefinition{
+			Name: "widgets.crane-e2e.example.com",
+			YAML: crdYAML,
+		}
+		cr := CustomResource{
+			Name:      "test-widget",
+			Namespace: namespace,
+			Kind:      "Widget",
+			YAML:      crYAML,
+		}
+		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
+
+		DeferCleanup(func() {
+			ResourceCleanup([]KubectlRunner{kubectlSrc, kubectlTgt}, []Resource{cr, crd})
+			CleanupScenario(paths.TempDir, srcApp, tgtApp)
+		})
+
+		By("Deploying app on source cluster")
+		Expect(PrepareSourceApp(srcApp, kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Creating Widget CRD on source")
+		Expect(crd.Create(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Waiting for CRD to be established")
+		Expect(crd.WaitForEstablished(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Creating Widget custom resource in namespace")
+		Expect(cr.Create(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Waiting for source pods and endpoints to drain")
+		WaitForSourceQuiesce(kubectlSrc, namespace, "app="+appName, serviceName)
+
+		By("Running crane export, transform, apply")
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
+
+		By("Creating namespace on target cluster")
+		Expect(kubectlTgt.CreateNamespace(namespace)).NotTo(HaveOccurred())
+
+		By("Applying cluster resources to target")
+		Expect(kubectlTgt.ApplyDir(filepath.Join(paths.OutputDir, "resources", "_cluster"))).NotTo(HaveOccurred())
+
+		By("Waiting for CRD to be established on target")
+		Expect(crd.WaitForEstablished(kubectlTgt)).NotTo(HaveOccurred())
+
+		By("Applying namespace resources to target")
+		Expect(kubectlTgt.ApplyDir(filepath.Join(paths.OutputDir, "resources", namespace))).NotTo(HaveOccurred())
+
+		By("Verifying Widget CR exists on target")
+		_, err = kubectlTgt.Run("get", "widget", crName, "-n", namespace)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Verifying Widget CR has correct spec values on target")
+		Expect(cr.AssertField(kubectlTgt, "{.spec.color}", "blue")).NotTo(HaveOccurred())
+
+	})
+
+})

--- a/e2e-tests/tests/tier1/mta_855_crd_custom_resource_test.go
+++ b/e2e-tests/tests/tier1/mta_855_crd_custom_resource_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"log"
 	"path/filepath"
 
 	"github.com/konveyor/crane/e2e-tests/config"
@@ -46,6 +47,7 @@ var _ = Describe("Cluster-level RBAC export", func() {
 			Namespace: namespace,
 			Kind:      "Widget",
 			YAML:      crYAML,
+			Resource:  "widgets",
 		}
 		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
 		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
@@ -53,8 +55,12 @@ var _ = Describe("Cluster-level RBAC export", func() {
 			OutputDir: paths.OutputDir}
 
 		DeferCleanup(func() {
-			ResourceCleanup([]KubectlRunner{kubectlSrc, kubectlTgt}, []Resource{cr, crd})
-			CleanupScenario(paths.TempDir, srcApp, tgtApp)
+			if err := ResourceCleanup([]KubectlRunner{kubectlSrc, kubectlTgt}, []Resource{cr, crd}); err != nil {
+				log.Printf("Resources cleanup: %v", err)
+			}
+			if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
+				log.Printf("Scenario cleanup: %v", err)
+			}
 		})
 
 		By("Deploying app on source cluster")

--- a/e2e-tests/utils/utils.go
+++ b/e2e-tests/utils/utils.go
@@ -10,8 +10,8 @@ import (
 	"runtime"
 	"slices"
 	"sort"
-	"strings"
 	"strconv"
+	"strings"
 
 	"github.com/google/go-cmp/cmp"
 	"gopkg.in/yaml.v3"
@@ -953,4 +953,27 @@ func ExtractCPUAverageUtilization(spec map[string]any) int64 {
 		return val
 	}
 	return 0
+}
+
+func AssertFilesExist(dir string, expectedFiles []string) error {
+	files, err := ListFilesRecursivelyAsList(dir)
+	if err != nil {
+		return err
+	}
+
+	fileSet := make(map[string]bool)
+	for _, f := range files {
+		fileSet[f] = true
+	}
+
+	var missing []string
+	for _, f := range expectedFiles {
+		if !fileSet[f] {
+			missing = append(missing, f)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("missing files: %v", missing)
+	}
+	return nil
 }


### PR DESCRIPTION
closes: #579, closes: #578,  closes:#334,  closes:#333,  closes:#332 

## Summary
- Introduces `Resource` interface with `Create`/`Delete` methods for consistent K8s resource lifecycle management in tests
- Adds typed helpers: `ClusterRole`, `ClusterRoleBinding`, `ServiceAccount`, `CustomResourceDefinition`, `CustomResource`, `Namespace`
- Adds `ResourceCleanup` for multi-cluster test teardown
- Adds `ValidateClusterRBAC` helper for verifying cluster role bindings on target
- Adds `ReadTestdataFile` utility for loading test fixtures

## New Tests
| Test | Description |
|------|-------------|
| MTA-851 | Verifies no `_cluster` directory for namespace-only workloads |
| MTA-852 | ClusterRole/ClusterRoleBinding export for linked ServiceAccount |
| MTA-853 | Namespace-admin split-apply (cluster + namespace resources) |
| MTA-854 | Two ClusterRoles/ClusterRoleBindings for one Deployment |
| MTA-855 | CRD export to `_cluster`, custom resource to namespace directory |

## Test plan
- [ ] Run tier0 tests: `ginkgo -v --label-filter="tier0" ./e2e-tests/...`
- [ ] Run tier1 tests: `ginkgo -v --label-filter="tier1" ./e2e-tests/...`
- [ ] Verify cluster-admin tests pass with appropriate kubeconfig
- [ ] Verify namespace-admin test (MTA-853) skips gracefully without non-admin context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added Tier0/Tier1 end-to-end scenarios for cluster-level export control, RBAC export, split-apply behavior, and CRD/Custom Resource migration.
  * Added reusable Kubernetes e2e resource helpers and a utility to validate exported ClusterRoleBindings and subjects.
  * Introduced widget CR/CRD test manifests and a file-existence assertion to confirm expected export outputs.
* **Bug Fixes**
  * Improved e2e resource cleanup to attempt full teardown and then report all delete errors together, instead of stopping at the first failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->