### PR TITLE
 add label to pvc-transfer tests

### DIFF
--- a/e2e-tests/tests/tier0/mta_801_stateful_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_801_stateful_migration_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 var _ = Describe("Stateful app migration", func() {
-	It("[MTA-801] Migrate all of PVCs that are associated with quiesced resource", Label("tier0"), func() {
+	It("[MTA-801] Migrate all of PVCs that are associated with quiesced resource", Label("tier0", "skip-ocp"), func() {
 		appName := "redis"
 		namespace := appName
 		scenario := NewMigrationScenario(

--- a/e2e-tests/tests/tier0/mta_801_stateful_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_801_stateful_migration_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 var _ = Describe("Stateful app migration", func() {
-	It("[MTA-801] Migrate all of PVCs that are associated with quiesced resource", Label("tier0", "skip-ocp"), func() {
+	It("[MTA-801] Migrate all of PVCs that are associated with quiesced resource", Label("tier0", "pvc-transfer"), func() {
 		appName := "redis"
 		namespace := appName
 		scenario := NewMigrationScenario(

--- a/e2e-tests/tests/tier0/mta_804_empty_pvc_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_804_empty_pvc_migration_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 var _ = Describe("Empty PVC migration", func() {
-	It("[MTA-804] Migrate an empty PVC associated with an application", Label("tier0"), func() {
+	It("[MTA-804] Migrate an empty PVC associated with an application", Label("tier0", "skip-ocp"), func() {
 		appName := "app-with-empty-pvc"
 		namespace := appName
 		scenario := NewMigrationScenario(

--- a/e2e-tests/tests/tier0/mta_804_empty_pvc_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_804_empty_pvc_migration_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 var _ = Describe("Empty PVC migration", func() {
-	It("[MTA-804] Migrate an empty PVC associated with an application", Label("tier0", "skip-ocp"), func() {
+	It("[MTA-804] Migrate an empty PVC associated with an application", Label("tier0", "pvc-transfer"), func() {
 		appName := "app-with-empty-pvc"
 		namespace := appName
 		scenario := NewMigrationScenario(

--- a/e2e-tests/tests/tier0/mta_806_pvc_data_integrity_test.go
+++ b/e2e-tests/tests/tier0/mta_806_pvc_data_integrity_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 var _ = Describe("PVC data integrity migration", func() {
-	It("[MTA-806] Migrate a PVC with data and verify checksum integrity", Label("tier0", "skip-ocp"), func() {
+	It("[MTA-806] Migrate a PVC with data and verify checksum integrity", Label("tier0", "pvc-transfer"), func() {
 		const testFileName = "testfile.txt"
 		appName := "app-with-empty-pvc"
 		namespace := appName

--- a/e2e-tests/tests/tier0/mta_806_pvc_data_integrity_test.go
+++ b/e2e-tests/tests/tier0/mta_806_pvc_data_integrity_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 var _ = Describe("PVC data integrity migration", func() {
-	It("[MTA-806] Migrate a PVC with data and verify checksum integrity", Label("tier0"), func() {
+	It("[MTA-806] Migrate a PVC with data and verify checksum integrity", Label("tier0", "skip-ocp"), func() {
 		const testFileName = "testfile.txt"
 		appName := "app-with-empty-pvc"
 		namespace := appName

--- a/e2e-tests/tests/tier0/mta_807_data_validation_test.go
+++ b/e2e-tests/tests/tier0/mta_807_data_validation_test.go
@@ -118,7 +118,7 @@ func mysqlTestDataMD5(k KubectlRunner, namespace, podName string) (actual string
 
 var _ = Describe("Data validation with indirect migration of MySQL DB", func() {
 
-	It("[BUG #213][MTA-807] Should validate data", Label("BUG #213", "tier0"), func() {
+	It("[BUG #213][MTA-807] Should validate data", Label("BUG #213", "tier0", "skip-ocp"), func() {
 		appName := "mysql"
 		namespace := appName
 		scenario := NewMigrationScenario(

--- a/e2e-tests/tests/tier0/mta_807_data_validation_test.go
+++ b/e2e-tests/tests/tier0/mta_807_data_validation_test.go
@@ -118,7 +118,7 @@ func mysqlTestDataMD5(k KubectlRunner, namespace, podName string) (actual string
 
 var _ = Describe("Data validation with indirect migration of MySQL DB", func() {
 
-	It("[BUG #213][MTA-807] Should validate data", Label("BUG #213", "tier0", "skip-ocp"), func() {
+	It("[BUG #213][MTA-807] Should validate data", Label("BUG #213", "tier0", "pvc-transfer"), func() {
 		appName := "mysql"
 		namespace := appName
 		scenario := NewMigrationScenario(

--- a/e2e-tests/tests/tier0/mta_811_mongodb_non_admin_test.go
+++ b/e2e-tests/tests/tier0/mta_811_mongodb_non_admin_test.go
@@ -96,7 +96,7 @@ func mongoDocumentCount(k KubectlRunner, namespace, podName string) (int, error)
 }
 
 var _ = Describe("MongoDB Migration", func() {
-	It("[BUG #213][MTA-811] Should migrate a MongoDB resource with data intact as nonadmin user", Label("BUG #213", "tier0", "skip-ocp"), func() {
+	It("[BUG #213][MTA-811] Should migrate a MongoDB resource with data intact as nonadmin user", Label("BUG #213", "tier0", "pvc-transfer"), func() {
 		appName := "mongodb"
 		namespace := appName
 		scenario := NewMigrationScenario(

--- a/e2e-tests/tests/tier0/mta_811_mongodb_non_admin_test.go
+++ b/e2e-tests/tests/tier0/mta_811_mongodb_non_admin_test.go
@@ -96,7 +96,7 @@ func mongoDocumentCount(k KubectlRunner, namespace, podName string) (int, error)
 }
 
 var _ = Describe("MongoDB Migration", func() {
-	It("[BUG #213][MTA-811] Should migrate a MongoDB resource with data intact as nonadmin user", Label("BUG #213", "tier0"), func() {
+	It("[BUG #213][MTA-811] Should migrate a MongoDB resource with data intact as nonadmin user", Label("BUG #213", "tier0", "skip-ocp"), func() {
 		appName := "mongodb"
 		namespace := appName
 		scenario := NewMigrationScenario(

--- a/e2e-tests/tests/tier0/mta_813_cronJob_PVC_test.go
+++ b/e2e-tests/tests/tier0/mta_813_cronJob_PVC_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 var _ = Describe("CronJob with attached PVC migration as non-admin user", func() {
-	It("[BUG #330][BUG #408][MTA-813] Should migrate a cronjob and its attached PVC as a namespace-admin user", Label("BUG #330", "BUG #408", "tier0"), func() {
+	It("[BUG #330][BUG #408][MTA-813] Should migrate a cronjob and its attached PVC as a namespace-admin user", Label("BUG #330", "BUG #408", "tier0", "skip-ocp"), func() {
 		appName := "cronjob"
 		namespace := "mta-813-ns"
 		expectedLogSubstring := fmt.Sprintf("Hello! from namespace %s", namespace)

--- a/e2e-tests/tests/tier0/mta_813_cronJob_PVC_test.go
+++ b/e2e-tests/tests/tier0/mta_813_cronJob_PVC_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 var _ = Describe("CronJob with attached PVC migration as non-admin user", func() {
-	It("[BUG #330][BUG #408][MTA-813] Should migrate a cronjob and its attached PVC as a namespace-admin user", Label("BUG #330", "BUG #408", "tier0", "skip-ocp"), func() {
+	It("[BUG #330][BUG #408][MTA-813] Should migrate a cronjob and its attached PVC as a namespace-admin user", Label("BUG #330", "BUG #408", "tier0", "pvc-transfer"), func() {
 		appName := "cronjob"
 		namespace := "mta-813-ns"
 		expectedLogSubstring := fmt.Sprintf("Hello! from namespace %s", namespace)


### PR DESCRIPTION
Added skip-ocp label to the tests having pvc-transfer command execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated multiple tier0 migration and validation end-to-end scenarios to use more specific test labels (adding `pvc-transfer` and/or `skip-ocp`).
  * This changes label-based test selection, so the relevant cases are included/excluded more precisely—especially for OpenShift-based runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->