### PR TITLE
drop empty maps in comparison

### DIFF
--- a/e2e-tests/utils/utils.go
+++ b/e2e-tests/utils/utils.go
@@ -814,7 +814,13 @@ func normalizeWithPath(value any, path []string) any {
 				continue
 			}
 			nextPath := append(append([]string{}, path...), k)
-			out[k] = normalizeWithPath(child, nextPath)
+			normalized := normalizeWithPath(child, nextPath)
+			// Drop empty maps — an empty map {} is semantically identical to
+			// the field not existing and should not cause comparison failures.
+			if m, ok := normalized.(map[string]any); ok && len(m) == 0 {
+				continue
+			}
+			out[k] = normalized
 		}
 		return out
 	case []any:

--- a/e2e-tests/utils/utils.go
+++ b/e2e-tests/utils/utils.go
@@ -822,10 +822,12 @@ func normalizeWithPath(value any, path []string) any {
 			}
 			nextPath := append(append([]string{}, path...), k)
 			normalized := normalizeWithPath(child, nextPath)
-			// Drop empty maps — an empty map {} is semantically identical to
-			// the field not existing and should not cause comparison failures.
-			if m, ok := normalized.(map[string]any); ok && len(m) == 0 {
-				continue
+			// An empty securityContext: {} is semantically identical to absent.
+			// Some plugins strip it, others preserve it — treat both as equal.
+			if k == "securityContext" {
+				if m, ok := normalized.(map[string]any); ok && len(m) == 0 {
+					continue
+				}
 			}
 			out[k] = normalized
 		}

--- a/e2e-tests/utils/utils.go
+++ b/e2e-tests/utils/utils.go
@@ -522,6 +522,13 @@ func compareYAMLFileBytes(relPath string, golden, got []byte) error {
 		return fmt.Errorf("parse got file %q: %w", relPath, err)
 	}
 
+	for i := range goldenDocs {
+		goldenDocs[i] = normalizeWithPath(goldenDocs[i], nil)
+	}
+	for i := range gotDocs {
+		gotDocs[i] = normalizeWithPath(gotDocs[i], nil)
+	}
+
 	if !cmp.Equal(goldenDocs, gotDocs) {
 		return fmt.Errorf("YAML differs in %q:\n%s", relPath, cmp.Diff(goldenDocs, gotDocs))
 	}


### PR DESCRIPTION
Dropping empty maps for comparison of golden manifests. 

It causes issue while comparing the outputs on minikube vs ocp