### PR TITLE
:test_tube: Add tier1 tests for cluster-level RBAC subject types

### DIFF
--- a/e2e-tests/framework/resources.go
+++ b/e2e-tests/framework/resources.go
@@ -69,10 +69,15 @@ type ClusterRoleBinding struct {
 	Name            string
 	ClusterRoleName string
 	Label           string
+	Subject         string
 }
 
 func (crb ClusterRoleBinding) Create(k KubectlRunner) error {
-	_, err := k.Run("create", "clusterrolebinding", crb.Name, "--clusterrole="+crb.ClusterRoleName)
+	args := []string{"create", "clusterrolebinding", crb.Name, "--clusterrole=" + crb.ClusterRoleName}
+	if crb.Subject != "" {
+		args = append(args, crb.Subject)
+	}
+	_, err := k.Run(args...)
 	if err != nil {
 		return fmt.Errorf("failed to create ClusterRoleBinding %s: %w", crb.Name, err)
 	}

--- a/e2e-tests/tests/tier1/mta_857_service_account_subject_test.go
+++ b/e2e-tests/tests/tier1/mta_857_service_account_subject_test.go
@@ -36,8 +36,8 @@ var _ = Describe("Cluster-level RBAC export", func() {
 		subjectName := sa.Name
 		subject := "--serviceaccount=" + namespace + ":" + sa.Name
 
-		cr := ClusterRole{Name: "crane-cr", Verb: "get,list,watch,create,update,delete", Resource: "pods"}
-		crb := ClusterRoleBinding{Name: "crane-crb", ClusterRoleName: cr.Name, Subject: subject}
+		cr := ClusterRole{Name: "crane-cr-subject-sa", Verb: "get,list,watch,create,update,delete", Resource: "pods"}
+		crb := ClusterRoleBinding{Name: "crane-crb-subject-sa", ClusterRoleName: cr.Name, Subject: subject}
 		tgtNamespace := Namespace{Name: namespace}
 
 		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}

--- a/e2e-tests/tests/tier1/mta_857_service_account_subject_test.go
+++ b/e2e-tests/tests/tier1/mta_857_service_account_subject_test.go
@@ -1,0 +1,99 @@
+package e2e
+
+import (
+	"log"
+	"path/filepath"
+
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	"github.com/konveyor/crane/e2e-tests/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Cluster-level RBAC export", func() {
+	It("[MTA-857] Should export CRB with ServiceAccount subject referencing ServiceAccount", Label("tier1"), func() {
+		appName := "simple-nginx-nopv"
+		namespace := "simple-nginx-nopv"
+		serviceName := "my-" + appName
+		scenario := NewMigrationScenario(
+			appName,
+			namespace,
+			config.K8sDeployBin,
+			config.CraneBin,
+			config.SourceContext,
+			config.TargetContext,
+		)
+		srcApp := scenario.SrcApp
+		tgtApp := scenario.TgtApp
+		kubectlSrc := scenario.KubectlSrc
+		kubectlTgt := scenario.KubectlTgt
+		runner := scenario.Crane
+		paths, err := NewScenarioPaths("crane-*")
+		Expect(err).NotTo(HaveOccurred())
+
+		sa := ServiceAccount{Name: "crane-sa", Namespace: namespace}
+		subjectName := sa.Name
+		subject := "--serviceaccount=" + namespace + ":" + sa.Name
+
+		cr := ClusterRole{Name: "crane-cr", Verb: "get,list,watch,create,update,delete", Resource: "pods"}
+		crb := ClusterRoleBinding{Name: "crane-crb", ClusterRoleName: cr.Name, Subject: subject}
+		tgtNamespace := Namespace{Name: namespace}
+
+		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
+
+		DeferCleanup(func() {
+			if err := ResourceCleanup([]KubectlRunner{kubectlSrc, kubectlTgt}, []Resource{cr, crb}); err != nil {
+				log.Printf("Resources cleanup: %v", err)
+			}
+			if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
+				log.Printf("Scenario cleanup: %v", err)
+			}
+		})
+
+		By("Deploying app on source cluster")
+		Expect(PrepareSourceApp(srcApp, kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Creating Creating first Service-account source")
+		Expect(sa.Create(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Creating ClusterRole on source Clusster")
+		Expect(cr.Create(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Creating ClusterRoleBinding with User subject referencing ServiceAccount")
+		Expect(crb.Create(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Waiting for source pods and endpoints to drain")
+		WaitForSourceQuiesce(kubectlSrc, namespace, "app="+appName, serviceName)
+
+		By("Running crane export, transform, apply")
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
+
+		By("Verifying no resources failed to export")
+		failuresDir := filepath.Join(paths.ExportDir, "failures", namespace)
+		hasFiles, _, err := utils.HasFilesRecursively(failuresDir)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(hasFiles).To(BeFalse())
+
+		By("Create Namespace On target cluster")
+		Expect(tgtNamespace.Create(kubectlTgt)).NotTo(HaveOccurred())
+
+		By("Dry-run applying output manifests on target")
+		Expect(kubectlTgt.ValidateApplyDir(paths.OutputDir)).NotTo(HaveOccurred())
+
+		By("Applying migrated manifests to target cluster")
+		Expect(ApplyOutputToTarget(kubectlTgt, tgtNamespace.Name, paths.OutputDir)).NotTo(HaveOccurred())
+
+		By("Scaling target deployment and validating app")
+		Expect(kubectlTgt.ScaleDeployment(tgtNamespace.Name, appName, 1)).NotTo(HaveOccurred())
+		Eventually(tgtApp.Validate, "2m", "10s").Should(Succeed())
+
+		By("Verifying ClusterRoleBinding on target references correct ClusterRole and User subject")
+		Expect(ValidateClusterRBAC(kubectlTgt, []ExpectedClusterRoleBinding{
+			{ClusterRoleBindingName: crb.Name, ClusterRoleName: crb.ClusterRoleName, SubjectName: subjectName},
+		})).NotTo(HaveOccurred())
+	})
+})

--- a/e2e-tests/tests/tier1/mta_857_service_account_subject_test.go
+++ b/e2e-tests/tests/tier1/mta_857_service_account_subject_test.go
@@ -57,13 +57,13 @@ var _ = Describe("Cluster-level RBAC export", func() {
 		By("Deploying app on source cluster")
 		Expect(PrepareSourceApp(srcApp, kubectlSrc)).NotTo(HaveOccurred())
 
-		By("Creating Creating first Service-account source")
+		By("Creating first Service-account source")
 		Expect(sa.Create(kubectlSrc)).NotTo(HaveOccurred())
 
 		By("Creating ClusterRole on source Clusster")
 		Expect(cr.Create(kubectlSrc)).NotTo(HaveOccurred())
 
-		By("Creating ClusterRoleBinding with User subject referencing ServiceAccount")
+		By("Creating ClusterRoleBinding with Service account subject")
 		Expect(crb.Create(kubectlSrc)).NotTo(HaveOccurred())
 
 		By("Waiting for source pods and endpoints to drain")
@@ -86,6 +86,10 @@ var _ = Describe("Cluster-level RBAC export", func() {
 
 		By("Applying migrated manifests to target cluster")
 		Expect(ApplyOutputToTarget(kubectlTgt, tgtNamespace.Name, paths.OutputDir)).NotTo(HaveOccurred())
+
+		By("Verify the referenced SA exists on target")
+		_, err = kubectlTgt.Run("get", "serviceaccount", sa.Name, "-n", namespace)
+		Expect(err).NotTo(HaveOccurred())
 
 		By("Scaling target deployment and validating app")
 		Expect(kubectlTgt.ScaleDeployment(tgtNamespace.Name, appName, 1)).NotTo(HaveOccurred())

--- a/e2e-tests/tests/tier1/mta_858_user_subject_test.go
+++ b/e2e-tests/tests/tier1/mta_858_user_subject_test.go
@@ -1,0 +1,99 @@
+package e2e
+
+import (
+	"log"
+	"path/filepath"
+
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	"github.com/konveyor/crane/e2e-tests/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Cluster-level RBAC export", func() {
+	It("[MTA-858] Should export CRB with User subject referencing ServiceAccount", Label("tier1"), func() {
+		appName := "simple-nginx-nopv"
+		namespace := "simple-nginx-nopv"
+		serviceName := "my-" + appName
+		scenario := NewMigrationScenario(
+			appName,
+			namespace,
+			config.K8sDeployBin,
+			config.CraneBin,
+			config.SourceContext,
+			config.TargetContext,
+		)
+		srcApp := scenario.SrcApp
+		tgtApp := scenario.TgtApp
+		kubectlSrc := scenario.KubectlSrc
+		kubectlTgt := scenario.KubectlTgt
+		runner := scenario.Crane
+		paths, err := NewScenarioPaths("crane-*")
+		Expect(err).NotTo(HaveOccurred())
+
+		sa := ServiceAccount{Name: "crane-sa", Namespace: namespace}
+		subjectName := "system:serviceaccount:" + namespace + ":" + sa.Name
+		subject := "--user=" + subjectName
+
+		cr := ClusterRole{Name: "crane-cr", Verb: "get,list,watch,create,update,delete", Resource: "pods"}
+		crb := ClusterRoleBinding{Name: "crane-crb", ClusterRoleName: cr.Name, Subject: subject}
+		tgtNamespace := Namespace{Name: namespace}
+
+		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
+
+		DeferCleanup(func() {
+			if err := ResourceCleanup([]KubectlRunner{kubectlSrc, kubectlTgt}, []Resource{cr, crb}); err != nil {
+				log.Printf("Resources cleanup: %v", err)
+			}
+			if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
+				log.Printf("Scenario cleanup: %v", err)
+			}
+		})
+
+		By("Deploying app on source cluster")
+		Expect(PrepareSourceApp(srcApp, kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Creating Creating first Service-account source")
+		Expect(sa.Create(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Creating ClusterRole on source Clusster")
+		Expect(cr.Create(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Creating ClusterRoleBinding with User subject referencing ServiceAccount")
+		Expect(crb.Create(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Waiting for source pods and endpoints to drain")
+		WaitForSourceQuiesce(kubectlSrc, namespace, "app="+appName, serviceName)
+
+		By("Running crane export, transform, apply")
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
+
+		By("Verifying no resources failed to export")
+		failuresDir := filepath.Join(paths.ExportDir, "failures", namespace)
+		hasFiles, _, err := utils.HasFilesRecursively(failuresDir)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(hasFiles).To(BeFalse())
+
+		By("Create Namespace On target cluster")
+		Expect(tgtNamespace.Create(kubectlTgt)).NotTo(HaveOccurred())
+
+		By("Dry-run applying output manifests on target")
+		Expect(kubectlTgt.ValidateApplyDir(paths.OutputDir)).NotTo(HaveOccurred())
+
+		By("Applying migrated manifests to target cluster")
+		Expect(ApplyOutputToTarget(kubectlTgt, tgtNamespace.Name, paths.OutputDir)).NotTo(HaveOccurred())
+
+		By("Scaling target deployment and validating app")
+		Expect(kubectlTgt.ScaleDeployment(tgtNamespace.Name, appName, 1)).NotTo(HaveOccurred())
+		Eventually(tgtApp.Validate, "2m", "10s").Should(Succeed())
+
+		By("Verifying ClusterRoleBinding on target references correct ClusterRole and User subject")
+		Expect(ValidateClusterRBAC(kubectlTgt, []ExpectedClusterRoleBinding{
+			{ClusterRoleBindingName: crb.Name, ClusterRoleName: crb.ClusterRoleName, SubjectName: subjectName},
+		})).NotTo(HaveOccurred())
+	})
+})

--- a/e2e-tests/tests/tier1/mta_858_user_subject_test.go
+++ b/e2e-tests/tests/tier1/mta_858_user_subject_test.go
@@ -36,8 +36,8 @@ var _ = Describe("Cluster-level RBAC export", func() {
 		subjectName := "system:serviceaccount:" + namespace + ":" + sa.Name
 		subject := "--user=" + subjectName
 
-		cr := ClusterRole{Name: "crane-cr", Verb: "get,list,watch,create,update,delete", Resource: "pods"}
-		crb := ClusterRoleBinding{Name: "crane-crb", ClusterRoleName: cr.Name, Subject: subject}
+		cr := ClusterRole{Name: "crane-cr-subject-user", Verb: "get,list,watch,create,update,delete", Resource: "pods"}
+		crb := ClusterRoleBinding{Name: "crane-crb-subject-user", ClusterRoleName: cr.Name, Subject: subject}
 		tgtNamespace := Namespace{Name: namespace}
 
 		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}

--- a/e2e-tests/tests/tier1/mta_858_user_subject_test.go
+++ b/e2e-tests/tests/tier1/mta_858_user_subject_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Cluster-level RBAC export", func() {
 		By("Creating ClusterRole on source Clusster")
 		Expect(cr.Create(kubectlSrc)).NotTo(HaveOccurred())
 
-		By("Creating ClusterRoleBinding with User subject referencing ServiceAccount")
+		By("Creating ClusterRoleBinding with User subject")
 		Expect(crb.Create(kubectlSrc)).NotTo(HaveOccurred())
 
 		By("Waiting for source pods and endpoints to drain")

--- a/e2e-tests/tests/tier1/mta_859_group_subject_test.go
+++ b/e2e-tests/tests/tier1/mta_859_group_subject_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Cluster-level RBAC export", func() {
 		By("Creating ClusterRole with pod read permissions")
 		Expect(cr.Create(kubectlSrc)).NotTo(HaveOccurred())
 
-		By("Creating ClusterRoleBinding with Group subject for namespace ServiceAccounts")
+		By("Creating ClusterRoleBinding with Group subject")
 		Expect(crb.Create(kubectlSrc)).NotTo(HaveOccurred())
 
 		By("Waiting for source pods and endpoints to drain")

--- a/e2e-tests/tests/tier1/mta_859_group_subject_test.go
+++ b/e2e-tests/tests/tier1/mta_859_group_subject_test.go
@@ -37,8 +37,8 @@ var _ = Describe("Cluster-level RBAC export", func() {
 		subjectName := "system:serviceaccounts:" + namespace
 		subject := "--group=" + subjectName
 
-		cr := ClusterRole{Name: "crane-cr", Verb: "get,list,watch,create,update,delete", Resource: "pods"}
-		crb := ClusterRoleBinding{Name: "crane-crb", ClusterRoleName: cr.Name, Subject: subject}
+		cr := ClusterRole{Name: "crane-cr-subject-group", Verb: "get,list,watch,create,update,delete", Resource: "pods"}
+		crb := ClusterRoleBinding{Name: "crane-crb-subject-group", ClusterRoleName: cr.Name, Subject: subject}
 		tgtNamespace := Namespace{Name: namespace}
 
 		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}

--- a/e2e-tests/tests/tier1/mta_859_group_subject_test.go
+++ b/e2e-tests/tests/tier1/mta_859_group_subject_test.go
@@ -1,0 +1,101 @@
+package e2e
+
+import (
+	"log"
+	"path/filepath"
+
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	"github.com/konveyor/crane/e2e-tests/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Cluster-level RBAC export", func() {
+	It("[MTA-859] Should export CRB with Group subject referencing namespace ServiceAccounts", Label("tier1"), func() {
+		appName := "simple-nginx-nopv"
+		namespace := "simple-nginx-nopv"
+		serviceName := "my-" + appName
+
+		scenario := NewMigrationScenario(
+			appName,
+			namespace,
+			config.K8sDeployBin,
+			config.CraneBin,
+			config.SourceContext,
+			config.TargetContext,
+		)
+		srcApp := scenario.SrcApp
+		tgtApp := scenario.TgtApp
+		kubectlSrc := scenario.KubectlSrc
+		kubectlTgt := scenario.KubectlTgt
+		runner := scenario.Crane
+		paths, err := NewScenarioPaths("crane-ca4c-*")
+		Expect(err).NotTo(HaveOccurred())
+
+		sa := ServiceAccount{Name: "crane-sa", Namespace: namespace}
+		subjectName := "system:serviceaccounts:" + namespace
+		subject := "--group=" + subjectName
+
+		cr := ClusterRole{Name: "crane-cr", Verb: "get,list,watch,create,update,delete", Resource: "pods"}
+		crb := ClusterRoleBinding{Name: "crane-crb", ClusterRoleName: cr.Name, Subject: subject}
+		tgtNamespace := Namespace{Name: namespace}
+
+		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
+
+		DeferCleanup(func() {
+			if err := ResourceCleanup([]KubectlRunner{kubectlSrc, kubectlTgt}, []Resource{cr, crb}); err != nil {
+				log.Printf("Resources cleanup: %v", err)
+			}
+			if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
+				log.Printf("Scenario cleanup: %v", err)
+			}
+		})
+
+		By("Deploying app with ServiceAccount on source cluster")
+		Expect(PrepareSourceApp(srcApp, kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Creating Creating first Service-account source")
+		Expect(sa.Create(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Creating ClusterRole with pod read permissions")
+		Expect(cr.Create(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Creating ClusterRoleBinding with Group subject for namespace ServiceAccounts")
+		Expect(crb.Create(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Waiting for source pods and endpoints to drain")
+		WaitForSourceQuiesce(kubectlSrc, namespace, "app="+appName, serviceName)
+
+		By("Running crane export, transform, apply")
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
+
+		By("Verifying no resources failed to export")
+		failuresDir := filepath.Join(paths.ExportDir, "failures", namespace)
+		hasFiles, _, err := utils.HasFilesRecursively(failuresDir)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(hasFiles).To(BeFalse())
+
+		By("Create Namespace On target cluster")
+		Expect(tgtNamespace.Create(kubectlTgt)).NotTo(HaveOccurred())
+
+		By("Dry-run applying output manifests on target")
+		Expect(kubectlTgt.ValidateApplyDir(paths.OutputDir)).NotTo(HaveOccurred())
+
+		By("Applying migrated manifests to target cluster")
+		Expect(ApplyOutputToTarget(kubectlTgt, namespace, paths.OutputDir)).NotTo(HaveOccurred())
+
+		By("Scaling target deployment and validating app")
+		Expect(kubectlTgt.ScaleDeployment(tgtNamespace.Name, appName, 1)).NotTo(HaveOccurred())
+		Eventually(tgtApp.Validate, "2m", "10s").Should(Succeed())
+
+		By("Verifying ClusterRoleBinding on target references correct ClusterRole and Group subject")
+		Expect(ValidateClusterRBAC(kubectlTgt, []ExpectedClusterRoleBinding{
+			{ClusterRoleBindingName: crb.Name, ClusterRoleName: crb.ClusterRoleName, SubjectName: subjectName},
+		})).NotTo(HaveOccurred())
+	})
+
+})


### PR DESCRIPTION
closes #587, closes #582  closes #583 

**verified passing on ocp and minikube**

## Summary
- Add MTA-857 test: ClusterRoleBinding with ServiceAccount subject exports correctly alongside the referenced ServiceAccount
- Add MTA-858 test: ClusterRoleBinding with User subject type exports correctly
- Add MTA-859 test: ClusterRoleBinding with Group subject type exports correctly
- Minor update to resources.go framework helper

## Test plan
- [ ] Run `ginkgo -v --label-filter="tier1" ./e2e-tests/tests/tier1/` to verify new tests pass
- [ ] Confirm existing tier0 tests still pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enhanced ClusterRoleBinding migration to correctly preserve/export subject references for service accounts, computed user subjects, and group-style subjects.

* **Tests**
  * Added Tier1 end-to-end coverage for MTA-857, MTA-858, and MTA-859 to validate exported and applied ClusterRoleBindings retain the expected ClusterRole and exact subject strings on the target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
