### PR TITLE
Use binary from os.Args for shell completion

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/konveyor/crane/cmd/apply"
 	"github.com/konveyor/crane/cmd/convert"
@@ -21,7 +22,7 @@ import (
 func main() {
 	f := &flags.GlobalFlags{}
 	root := cobra.Command{
-		Use: "crane",
+		Use: filepath.Base(os.Args[0]),
 	}
 	f.ApplyFlags(&root)
 	root.AddCommand(export.NewExportCommand(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}, f))


### PR DESCRIPTION
There was a hardcoded `crane` in shell autocompletion-related code. Updated to use binary name of called command to allow flexible binary naming.

Fixes https://github.com/migtools/mta-crane/issues/8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The CLI now uses the executable’s actual filename as its command name, making renamed or aliased installs behave more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->