### PR TITLE
:test_tube: Add input validation for --run-as flag

### DIFF
--- a/e2e-tests/config/config.go
+++ b/e2e-tests/config/config.go
@@ -1,5 +1,7 @@
 package config
 
+import "log"
+
 var (
 	K8sDeployBin          string
 	SourceContext         string
@@ -11,3 +13,18 @@ var (
 	InsecureSkipTLSVerify bool
 	RunAs                 string
 )
+
+// Validates the --run-as flag value and logs the active mode.
+// This should be called in BeforeSuite hooks in test suites.
+func ValidateAndLogRunAsFlag() {
+	// Validate --run-as flag value
+	if RunAs != "" && RunAs != "admin" {
+		log.Fatalf("Invalid --run-as value: %q. Valid values: \"admin\" or empty string (for non-admin mode)", RunAs)
+	}
+
+	if RunAs == "admin" {
+		log.Printf("[E2E] Running tests with --run-as=admin (cluster-admin credentials)")
+	} else {
+		log.Printf("[E2E] Running tests in non-admin mode")
+	}
+}

--- a/e2e-tests/config/config.go
+++ b/e2e-tests/config/config.go
@@ -1,6 +1,9 @@
 package config
 
-import "log"
+import (
+	"fmt"
+	"log"
+)
 
 var (
 	K8sDeployBin          string
@@ -16,10 +19,11 @@ var (
 
 // Validates the --run-as flag value and logs the active mode.
 // This should be called in BeforeSuite hooks in test suites.
-func ValidateAndLogRunAsFlag() {
+// Returns an error if the --run-as value is invalid.
+func ValidateAndLogRunAsFlag() error {
 	// Validate --run-as flag value
 	if RunAs != "" && RunAs != "admin" {
-		log.Fatalf("Invalid --run-as value: %q. Valid values: \"admin\" or empty string (for non-admin mode)", RunAs)
+		return fmt.Errorf("invalid --run-as value: %q. Valid values: \"admin\" or empty string (for non-admin mode)", RunAs)
 	}
 
 	if RunAs == "admin" {
@@ -27,4 +31,5 @@ func ValidateAndLogRunAsFlag() {
 	} else {
 		log.Printf("[E2E] Running tests in non-admin mode")
 	}
+	return nil
 }

--- a/e2e-tests/tests/tier0/e2e_suite_test.go
+++ b/e2e-tests/tests/tier0/e2e_suite_test.go
@@ -24,6 +24,10 @@ func init() {
 	flag.StringVar(&config.RunAs, "run-as", "", "Override user context: set to 'admin' to run all tests with cluster-admin credentials")
 }
 
+var _ = BeforeSuite(func() {
+	config.ValidateAndLogRunAsFlag()
+})
+
 // TestE2E configures Ginkgo and executes the e2e test suite.
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/e2e-tests/tests/tier0/e2e_suite_test.go
+++ b/e2e-tests/tests/tier0/e2e_suite_test.go
@@ -25,7 +25,7 @@ func init() {
 }
 
 var _ = BeforeSuite(func() {
-	config.ValidateAndLogRunAsFlag()
+	Expect(config.ValidateAndLogRunAsFlag()).To(Succeed())
 })
 
 // TestE2E configures Ginkgo and executes the e2e test suite.

--- a/e2e-tests/tests/tier1/e2e_suite_test.go
+++ b/e2e-tests/tests/tier1/e2e_suite_test.go
@@ -24,6 +24,10 @@ func init() {
 	flag.StringVar(&config.RunAs, "run-as", "", "Override user context: set to 'admin' to run all tests with cluster-admin credentials")
 }
 
+var _ = BeforeSuite(func() {
+	config.ValidateAndLogRunAsFlag()
+})
+
 // TestE2E configures Ginkgo and executes the e2e test suite.
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/e2e-tests/tests/tier1/e2e_suite_test.go
+++ b/e2e-tests/tests/tier1/e2e_suite_test.go
@@ -25,7 +25,7 @@ func init() {
 }
 
 var _ = BeforeSuite(func() {
-	config.ValidateAndLogRunAsFlag()
+	Expect(config.ValidateAndLogRunAsFlag()).To(Succeed())
 })
 
 // TestE2E configures Ginkgo and executes the e2e test suite.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for the E2E `run-as` setting so invalid values stop the test run early.
  * Improved startup logging to clearly show whether tests are running in admin or non-admin mode.

The --run-as flag accepts any string, but only "admin" has special behavior. Typos like --run-as=admon or --run-as=adming  do nothing  and fall back to non-admin mode and the test is run as non-admin.  Users get unexpected behavior without any error message

  Example of the problem:
  $ User makes a typo
 ```$ ginkgo run -v --focus="\[MTA-850\]" e2e-tests/tests/tier1 --   --k8sdeploy-bin=~/k8s-apps-deployer/venv/bin/k8sdeploy   --crane-bin=~/migtools-crane/crane/crane   --source-context=kind-source-cluster   --target-context=kind-dest-cluster   --source-nonadmin-context=crane-source-context   --target-nonadmin-context=crane-dest-context --run-as=admon```

  Solution:
  Fail fast with a clear error message:
  Invalid --run-as value: "admon". Valid values: "admin" or empty string (for non-admin mode)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added startup validation for the test run mode so invalid `run-as` values are caught early.
  * Improved test run logging to clearly show whether suites are running in admin or non-admin mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->