### PR TITLE
 :test_tube: Add e2e test for Same-cluster migration

### DIFF
--- a/e2e-tests/framework/kubectl.go
+++ b/e2e-tests/framework/kubectl.go
@@ -27,7 +27,11 @@ func (k KubectlRunner) Run(args ...string) (string, error) {
 func (k KubectlRunner) RunWithStdin(stdin string, args ...string) (string, error) {
 	return k.executeWithStdin(stdin, args...)
 }
-
+// ApplyStdin applies a YAML manifest provided as a string via stdin.
+  func (k KubectlRunner) ApplyStdin(content string) error {
+      _, err := k.RunWithStdin(content, "apply", "-f", "-")
+      return err
+  }
 // executeWithStdin executes an arbitrary kubectl command using stdin content.
 func (k KubectlRunner) executeWithStdin(stdin string, args ...string) (string, error) {
 	finalArgs := append([]string{}, normalizeKubectlArgs(args...)...)

--- a/e2e-tests/framework/kubectl.go
+++ b/e2e-tests/framework/kubectl.go
@@ -27,11 +27,6 @@ func (k KubectlRunner) Run(args ...string) (string, error) {
 func (k KubectlRunner) RunWithStdin(stdin string, args ...string) (string, error) {
 	return k.executeWithStdin(stdin, args...)
 }
-// ApplyStdin applies a YAML manifest provided as a string via stdin.
-  func (k KubectlRunner) ApplyStdin(content string) error {
-      _, err := k.RunWithStdin(content, "apply", "-f", "-")
-      return err
-  }
 // executeWithStdin executes an arbitrary kubectl command using stdin content.
 func (k KubectlRunner) executeWithStdin(stdin string, args ...string) (string, error) {
 	finalArgs := append([]string{}, normalizeKubectlArgs(args...)...)

--- a/e2e-tests/framework/pipeline.go
+++ b/e2e-tests/framework/pipeline.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"log"
 	"strings"
+    "os"
+    "path/filepath"
 
 	"github.com/konveyor/crane/e2e-tests/utils"
 	"github.com/onsi/gomega"
@@ -135,6 +137,19 @@ func ApplyOutputToTarget(kubectlTgt KubectlRunner, namespace string, outputDir s
 // ApplyOutputToTargetNonAdmin validates and applies rendered manifests without creating namespace.
 func ApplyOutputToTargetNonAdmin(kubectlTgt KubectlRunner, outputDir string) error {
 	return applyOutputManifests(kubectlTgt, outputDir)
+}
+
+// ApplyOutputToTargetWithNamespaceRemap reads output.yaml, replaces all occurrences
+func ApplyOutputToTargetWithNamespaceRemap(kubectl KubectlRunner, srcNamespace, tgtNamespace, outputDir string) error {
+      content, err := os.ReadFile(filepath.Join(outputDir, "output.yaml"))
+      if err != nil {
+          return fmt.Errorf("reading output.yaml: %w", err)
+      }
+      remapped := strings.ReplaceAll(string(content), "namespace: "+srcNamespace, "namespace: "+tgtNamespace)
+      if err := kubectl.CreateNamespace(tgtNamespace); err != nil {
+          return err
+      }
+      return kubectl.ApplyStdin(remapped)
 }
 
 func applyOutputManifests(kubectlTgt KubectlRunner, outputDir string) error {

--- a/e2e-tests/framework/pipeline.go
+++ b/e2e-tests/framework/pipeline.go
@@ -145,7 +145,7 @@ func ApplyOutputToTargetWithNamespaceRemap(kubectl KubectlRunner, srcNamespace, 
       if err != nil {
           return fmt.Errorf("reading output.yaml: %w", err)
       }
-      remapped := strings.ReplaceAll(string(content), "namespace: "+srcNamespace, "namespace: "+tgtNamespace)
+      remapped := strings.ReplaceAll(string(content), "namespace: "+srcNamespace+"\n", "namespace: "+tgtNamespace+"\n")
       if err := kubectl.CreateNamespace(tgtNamespace); err != nil {
           return err
       }

--- a/e2e-tests/framework/pipeline.go
+++ b/e2e-tests/framework/pipeline.go
@@ -145,11 +145,17 @@ func ApplyOutputToTargetWithNamespaceRemap(kubectl KubectlRunner, srcNamespace, 
       if err != nil {
           return fmt.Errorf("reading output.yaml: %w", err)
       }
-      remapped := strings.ReplaceAll(string(content), "namespace: "+srcNamespace+"\n", "namespace: "+tgtNamespace+"\n")
-      if err := kubectl.CreateNamespace(tgtNamespace); err != nil {
-          return err
+      remapped ,err := utils.RemapNamespaceInYAML(content, srcNamespace, tgtNamespace)
+	  if err != nil {
+          return fmt.Errorf("remapping namespace in output: %w", err)
       }
-      return kubectl.ApplyStdin(remapped)
+      if err := kubectl.CreateNamespace(tgtNamespace); err != nil {
+        return fmt.Errorf("creating target namespace %q: %w", tgtNamespace, err)
+      }
+      if err := kubectl.ApplyYAMLSpec(remapped, tgtNamespace); err != nil {
+        return fmt.Errorf("applying remapped manifests to namespace %q: %w", tgtNamespace, err)
+      }
+return nil
 }
 
 func applyOutputManifests(kubectlTgt KubectlRunner, outputDir string) error {

--- a/e2e-tests/tests/tier0/mta_840_same_cluster_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_840_same_cluster_migration_test.go
@@ -1,0 +1,77 @@
+package e2e
+
+import (
+      
+      "log"
+     
+
+      "github.com/konveyor/crane/e2e-tests/config"
+      . "github.com/konveyor/crane/e2e-tests/framework"
+      . "github.com/onsi/ginkgo/v2"
+      . "github.com/onsi/gomega"
+  )
+var _ = Describe("Same-cluster namespace migration", func() {
+	It("[MTA-840] nginx app migrated to a different namespace on the same cluster", Label("tier0"), func() {
+		appName := "simple-nginx-nopv"
+		srcNamespace := "crane-same-src"
+        tgtNamespace := "crane-same-tgt"
+		serviceName := "my-" + appName
+		scenario := NewMigrationScenario(
+			appName,
+			srcNamespace,
+			config.K8sDeployBin,
+			config.CraneBin,
+			config.SourceContext,
+			config.SourceContext,
+		)
+		scenario.TgtApp.Namespace = tgtNamespace
+		srcApp := scenario.SrcApp
+		tgtApp := scenario.TgtApp
+		kubectlSrc := scenario.KubectlSrc
+		kubectlTgt := scenario.KubectlTgt
+		By("Prepare source app")
+		log.Printf("Preparing source app %s in namespace %s\n", srcApp.Name, srcApp.Namespace)
+		Expect(PrepareSourceApp(srcApp, kubectlSrc)).NotTo(HaveOccurred())
+		log.Printf("Source app %s prepared successfully\n", srcApp.Name)
+		
+		paths, err := NewScenarioPaths("crane-export-*")
+		Expect(err).NotTo(HaveOccurred())
+		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
+		DeferCleanup(func() {
+			By("Cleanup source and target resources")
+			if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
+				log.Printf("cleanup: %v", err)
+			}
+			By("Delete source and target namespaces")
+			for _, ns := range []string{srcNamespace, tgtNamespace} {
+               if _, err := kubectlSrc.Run("delete", "namespace", ns, "--ignore-not-found=true", "--wait=true"); err != nil {
+				log.Printf("cleanup: %v", err)
+			 } 
+            }
+		})
+		runner := scenario.Crane
+		runner.WorkDir = paths.TempDir
+		By("Run crane export/transform/apply pipeline")
+		By("Wait for source quiesce to stabilize before export")
+		WaitForSourceQuiesce(kubectlSrc, srcNamespace, "app="+appName, serviceName)
+
+		log.Printf("Running crane pipeline for namespace %s\n", srcApp.Namespace)
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
+		log.Printf("Crane pipeline completed for namespace %s\n", srcApp.Namespace)
+
+		By("Apply remapped manifests to target namespace on same cluster")
+        Expect(ApplyOutputToTargetWithNamespaceRemap(kubectlTgt, srcNamespace, tgtNamespace, paths.OutputDir)).NotTo(HaveOccurred())
+		
+		By("Scale target deployment and validate app")
+		log.Printf("Scaling target deployment(s) with label app=%s to 1\n", appName)
+		Expect(kubectlTgt.ScaleDeployment(tgtNamespace, appName, 1)).NotTo(HaveOccurred())
+
+		log.Printf("Validating app %s on target cluster\n", tgtApp.Name)
+		Eventually(tgtApp.Validate, "2m", "10s").Should(Succeed())
+		log.Printf("Target validation completed for app %s\n", tgtApp.Name)
+
+	})
+})

--- a/e2e-tests/tests/tier0/mta_840_same_cluster_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_840_same_cluster_migration_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Same-cluster namespace migration", func() {
 			}
 			By("Delete source and target namespaces")
 			for _, ns := range []string{srcNamespace, tgtNamespace} {
-               if _, err := kubectlSrc.Run("delete", "namespace", ns, "--ignore-not-found=true", "--wait=true"); err != nil {
+               if _, err := kubectlSrc.Run("delete", "namespace", ns, "--ignore-not-found=true", "--wait=true", "--timeout=60s"); err != nil {
 				log.Printf("cleanup: %v", err)
 			 } 
             }

--- a/e2e-tests/utils/utils.go
+++ b/e2e-tests/utils/utils.go
@@ -1191,3 +1191,32 @@ func AssertFilesExist(dir string, expectedFiles []string) error {
 	}
 	return nil
 }
+ 
+  // RemapNamespaceInYAML parses each document in a multi-doc YAML stream,
+  // replaces srcNamespace with tgtNamespace in metadata.namespace,
+  // and returns the re-serialized YAML string.
+  func RemapNamespaceInYAML(content []byte, srcNamespace, tgtNamespace string) (string, error) {
+      docs, err := parseYAMLDocuments(content)
+      if err != nil {
+          return "", fmt.Errorf("parsing YAML documents: %w", err)
+      }
+
+      var parts []string
+      for _, doc := range docs {
+          obj, ok := doc.(map[string]any)
+          if !ok {
+              continue
+          }
+          if meta, ok := obj["metadata"].(map[string]any); ok {
+              if meta["namespace"] == srcNamespace {
+                  meta["namespace"] = tgtNamespace
+              }
+          }
+          out, err := yaml.Marshal(obj)
+          if err != nil {
+              return "", fmt.Errorf("marshaling YAML document: %w", err)
+          }
+          parts = append(parts, string(out))
+      }
+      return strings.Join(parts, "---\n"), nil
+  }

--- a/e2e-tests/utils/utils.go
+++ b/e2e-tests/utils/utils.go
@@ -1202,10 +1202,10 @@ func AssertFilesExist(dir string, expectedFiles []string) error {
       }
 
       var parts []string
-      for _, doc := range docs {
+      for i, doc := range docs {
           obj, ok := doc.(map[string]any)
           if !ok {
-              continue
+              return "", fmt.Errorf("document %d: expected map[string]any, got %T", i, doc)
           }
           if meta, ok := obj["metadata"].(map[string]any); ok {
               if meta["namespace"] == srcNamespace {


### PR DESCRIPTION
-   Introduced a new test file `mta_840_same_cluster_migration_test.go` to validate
  that crane correctly migrates a namespace to a different namespace on the same
  cluster (same-cluster migration).
     

-   The test verifies that the full export/transform/apply pipeline completes
  without errors when source and target share the same kubeconfig context, and
  that the application is successfully validated by k8sdeploy in the target
  namespace.

-   Added `ApplyOutputToTargetWithNamespaceRemap` to the e2e framework (pipeline.go)
  to handle namespace remapping in the output manifests before applying to the
  target namespace, and ApplyStdin to `kubectl.go` as the underlying kubectl
  operation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a way to run `kubectl` using provided standard input.
  * Introduced utilities to remap `metadata.namespace` in exported multi-document YAML and apply it to a target namespace.
  * Added a tier0 end-to-end test verifying nginx app migration between namespaces on the same cluster.
* **Bug Fixes**
  * Improved namespace migration reliability by ensuring the target namespace is created and the remapped manifests are applied consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->