### PR TITLE
:bug: [transfer-pvc] Fix silent data loss on vanilla K8s by reading w…

### DIFF
--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -734,8 +734,10 @@ func inspectPVCFileOwnership(c client.Client, namespace string, pvcName string) 
 					Image: "busybox",
 					SecurityContext: func() *corev1.SecurityContext {
 						t, f := true, false
+						nobodyUID := int64(65534)
 						return &corev1.SecurityContext{
 							RunAsNonRoot:             &t,
+							RunAsUser:                &nobodyUID,
 							AllowPrivilegeEscalation: &f,
 							Capabilities: &corev1.Capabilities{
 								Drop: []corev1.Capability{"ALL"},

--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -560,6 +560,7 @@ func getIDsForNamespace(c client.Client, namespace string, pvcName string) (*cor
 	// Read securityContext from the workload that owns this PVC.
 	wps, err := getSecurityContextFromWorkload(c, namespace, pvcName)
 	if err != nil {
+		log.Printf("workload security context lookup failed for PVC %s/%s: %v", namespace, pvcName, err)
 		return ps, nil
 	}
 	if wps != nil && wps.RunAsUser != nil {
@@ -571,6 +572,7 @@ func getIDsForNamespace(c client.Client, namespace string, pvcName string) (*cor
 	// the UID that wrote the data.
 	uid, err := inspectPVCFileOwnership(c, namespace, pvcName)
 	if err != nil {
+		log.Printf("PVC file ownership inspection failed for %s/%s: %v", namespace, pvcName, err)
 		return ps, nil
 	}
 	if uid != nil {
@@ -596,7 +598,7 @@ func getSecurityContextFromWorkload(c client.Client, namespace string, pvcName s
 	} else {
 		for _, d := range deployments.Items {
 			if podSpecReferencesPVC(d.Spec.Template.Spec, pvcName) {
-				return extractPodSecurityContext(d.Spec.Template.Spec), nil
+				return extractPodSecurityContext(d.Spec.Template.Spec, pvcName), nil
 			}
 		}
 	}
@@ -610,11 +612,15 @@ func getSecurityContextFromWorkload(c client.Client, namespace string, pvcName s
 	} else {
 		for _, s := range statefulSets.Items {
 			if podSpecReferencesPVC(s.Spec.Template.Spec, pvcName) {
-				return extractPodSecurityContext(s.Spec.Template.Spec), nil
+				return extractPodSecurityContext(s.Spec.Template.Spec, pvcName), nil
 			}
 			for _, vct := range s.Spec.VolumeClaimTemplates {
-				if strings.HasPrefix(pvcName, fmt.Sprintf("%s-%s-", vct.Name, s.Name)) {
-					return extractPodSecurityContext(s.Spec.Template.Spec), nil
+				prefix := fmt.Sprintf("%s-%s-", vct.Name, s.Name)
+				if strings.HasPrefix(pvcName, prefix) {
+					suffix := pvcName[len(prefix):]
+					if _, err := strconv.Atoi(suffix); err == nil {
+						return extractPodSecurityContext(s.Spec.Template.Spec, pvcName), nil
+					}
 				}
 			}
 		}
@@ -629,7 +635,7 @@ func getSecurityContextFromWorkload(c client.Client, namespace string, pvcName s
 	} else {
 		for _, d := range daemonSets.Items {
 			if podSpecReferencesPVC(d.Spec.Template.Spec, pvcName) {
-				return extractPodSecurityContext(d.Spec.Template.Spec), nil
+				return extractPodSecurityContext(d.Spec.Template.Spec, pvcName), nil
 			}
 		}
 	}
@@ -646,7 +652,7 @@ func getSecurityContextFromWorkload(c client.Client, namespace string, pvcName s
 				continue
 			}
 			if podSpecReferencesPVC(r.Spec.Template.Spec, pvcName) {
-				return extractPodSecurityContext(r.Spec.Template.Spec), nil
+				return extractPodSecurityContext(r.Spec.Template.Spec, pvcName), nil
 			}
 		}
 	}
@@ -660,7 +666,7 @@ func getSecurityContextFromWorkload(c client.Client, namespace string, pvcName s
 	} else {
 		for _, j := range jobs.Items {
 			if podSpecReferencesPVC(j.Spec.Template.Spec, pvcName) {
-				return extractPodSecurityContext(j.Spec.Template.Spec), nil
+				return extractPodSecurityContext(j.Spec.Template.Spec, pvcName), nil
 			}
 		}
 	}
@@ -674,7 +680,7 @@ func getSecurityContextFromWorkload(c client.Client, namespace string, pvcName s
 	} else {
 		for _, cj := range cronJobs.Items {
 			if podSpecReferencesPVC(cj.Spec.JobTemplate.Spec.Template.Spec, pvcName) {
-				return extractPodSecurityContext(cj.Spec.JobTemplate.Spec.Template.Spec), nil
+				return extractPodSecurityContext(cj.Spec.JobTemplate.Spec.Template.Spec, pvcName), nil
 			}
 		}
 	}
@@ -691,7 +697,7 @@ func podSpecReferencesPVC(spec corev1.PodSpec, pvcName string) bool {
 	return false
 }
 
-func extractPodSecurityContext(spec corev1.PodSpec) *corev1.PodSecurityContext {
+func extractPodSecurityContext(spec corev1.PodSpec, pvcName ...string) *corev1.PodSecurityContext {
 	ps := &corev1.PodSecurityContext{}
 
 	if spec.SecurityContext != nil {
@@ -701,11 +707,30 @@ func extractPodSecurityContext(spec corev1.PodSpec) *corev1.PodSecurityContext {
 		ps.SupplementalGroups = spec.SecurityContext.SupplementalGroups
 	}
 
-	// Container-level runAsUser overrides pod-level
+	// Find which containers mount the PVC to pick the right runAsUser
+	pvcMounters := make(map[string]bool)
+	if len(pvcName) > 0 && pvcName[0] != "" {
+		for _, vol := range spec.Volumes {
+			if vol.PersistentVolumeClaim != nil && vol.PersistentVolumeClaim.ClaimName == pvcName[0] {
+				for _, c := range spec.Containers {
+					for _, vm := range c.VolumeMounts {
+						if vm.Name == vol.Name {
+							pvcMounters[c.Name] = true
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Container-level runAsUser overrides pod-level — prefer the
+	// container that mounts the PVC, fall back to first with runAsUser
 	for _, c := range spec.Containers {
 		if c.SecurityContext != nil && c.SecurityContext.RunAsUser != nil {
-			ps.RunAsUser = c.SecurityContext.RunAsUser
-			break
+			if len(pvcMounters) == 0 || pvcMounters[c.Name] {
+				ps.RunAsUser = c.SecurityContext.RunAsUser
+				break
+			}
 		}
 	}
 
@@ -715,6 +740,13 @@ func extractPodSecurityContext(spec corev1.PodSpec) *corev1.PodSecurityContext {
 // inspectPVCFileOwnership creates a temporary pod that mounts the PVC and
 // reads file ownership using stat. Returns the UID of the first non-root
 // file owner found, or nil if no non-root owner is detected.
+//
+// The pod runs as UID 65534 (nobody). It first stats the PVC mount point
+// itself — this works even if the directory is 0700 because stat reads
+// from the parent. If the mount point is root-owned, it iterates entries
+// inside (requires the mount point to be listable, which is the common
+// case for PVC roots provisioned as 0755/0777). If the mount point is
+// 0700 root-owned, the glob will fail and the function returns nil.
 func inspectPVCFileOwnership(c client.Client, namespace string, pvcName string) (*int64, error) {
 	podName := fmt.Sprintf("crane-inspect-%x", sha256.Sum256([]byte(pvcName)))
 	if len(podName) > 63 {
@@ -731,7 +763,7 @@ func inspectPVCFileOwnership(c client.Client, namespace string, pvcName string) 
 			Containers: []corev1.Container{
 				{
 					Name:  "inspect",
-					Image: "busybox",
+					Image: "busybox:1.37",
 					SecurityContext: func() *corev1.SecurityContext {
 						t, f := true, false
 						nobodyUID := int64(65534)

--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -537,19 +537,21 @@ func getIDsForNamespace(c client.Client, namespace string, pvcName string) (*cor
 	if annotationVal, found := ns.Annotations[securityv1.UIDRangeAnnotation]; found {
 		uidBlock, err := openshiftuid.ParseBlock(annotationVal)
 		if err != nil {
-			return ps, fmt.Errorf("parsing UID range annotation: %w", err)
+			log.Printf("malformed UID range annotation %q in namespace %s: %v, falling back to workload discovery", annotationVal, namespace, err)
+		} else {
+			min := int64(uidBlock.Start)
+			ps.RunAsUser = &min
 		}
-		min := int64(uidBlock.Start)
-		ps.RunAsUser = &min
 	}
 	if annotationVal, found := ns.Annotations[securityv1.SupplementalGroupsAnnotation]; found {
 		uidBlock, err := openshiftuid.ParseBlock(annotationVal)
 		if err != nil {
-			return ps, fmt.Errorf("parsing supplemental groups annotation: %w", err)
+			log.Printf("malformed supplemental groups annotation %q in namespace %s: %v", annotationVal, namespace, err)
+		} else {
+			min := int64(uidBlock.Start)
+			ps.RunAsGroup = &min
+			ps.FSGroup = &min
 		}
-		min := int64(uidBlock.Start)
-		ps.RunAsGroup = &min
-		ps.FSGroup = &min
 	}
 
 	if ps.RunAsUser != nil {
@@ -831,10 +833,15 @@ func inspectPVCFileOwnership(c client.Client, namespace string, pvcName string) 
 
 	if len(pod.Status.ContainerStatuses) == 0 ||
 		pod.Status.ContainerStatuses[0].State.Terminated == nil {
-		return nil, nil
+		return nil, fmt.Errorf("inspect pod %s/%s did not terminate normally", namespace, podName)
 	}
 
-	msg := strings.TrimSpace(pod.Status.ContainerStatuses[0].State.Terminated.Message)
+	terminated := pod.Status.ContainerStatuses[0].State.Terminated
+	if terminated.ExitCode != 0 {
+		return nil, fmt.Errorf("inspect pod %s/%s failed with exit code %d: %s", namespace, podName, terminated.ExitCode, terminated.Reason)
+	}
+
+	msg := strings.TrimSpace(terminated.Message)
 	if msg == "" {
 		return nil, nil
 	}

--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -763,13 +763,11 @@ func inspectPVCFileOwnership(c client.Client, namespace string, pvcName string) 
 			Containers: []corev1.Container{
 				{
 					Name:  "inspect",
-					Image: "busybox:1.37",
+					Image: "quay.io/konveyor/rsync-transfer:latest",
 					SecurityContext: func() *corev1.SecurityContext {
 						t, f := true, false
-						nobodyUID := int64(65534)
 						return &corev1.SecurityContext{
 							RunAsNonRoot:             &t,
-							RunAsUser:                &nobodyUID,
 							AllowPrivilegeEscalation: &f,
 							Capabilities: &corev1.Capabilities{
 								Drop: []corev1.Capability{"ALL"},

--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -3,6 +3,7 @@ package transfer_pvc
 import (
 	"context"
 	"crypto/md5"
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"log"
@@ -536,7 +537,7 @@ func getIDsForNamespace(c client.Client, namespace string, pvcName string) (*cor
 	if annotationVal, found := ns.Annotations[securityv1.UIDRangeAnnotation]; found {
 		uidBlock, err := openshiftuid.ParseBlock(annotationVal)
 		if err != nil {
-			return nil, nil
+			return ps, fmt.Errorf("parsing UID range annotation: %w", err)
 		}
 		min := int64(uidBlock.Start)
 		ps.RunAsUser = &min
@@ -544,7 +545,7 @@ func getIDsForNamespace(c client.Client, namespace string, pvcName string) (*cor
 	if annotationVal, found := ns.Annotations[securityv1.SupplementalGroupsAnnotation]; found {
 		uidBlock, err := openshiftuid.ParseBlock(annotationVal)
 		if err != nil {
-			return nil, nil
+			return ps, fmt.Errorf("parsing supplemental groups annotation: %w", err)
 		}
 		min := int64(uidBlock.Start)
 		ps.RunAsGroup = &min
@@ -588,7 +589,11 @@ func getIDsForNamespace(c client.Client, namespace string, pvcName string) (*cor
 func getSecurityContextFromWorkload(c client.Client, namespace string, pvcName string) (*corev1.PodSecurityContext, error) {
 	// Deployments
 	var deployments appsv1.DeploymentList
-	if err := c.List(context.TODO(), &deployments, client.InNamespace(namespace)); err == nil {
+	if err := c.List(context.TODO(), &deployments, client.InNamespace(namespace)); err != nil {
+		if !errors.IsNotFound(err) && !errors.IsForbidden(err) {
+			return nil, fmt.Errorf("listing deployments: %w", err)
+		}
+	} else {
 		for _, d := range deployments.Items {
 			if podSpecReferencesPVC(d.Spec.Template.Spec, pvcName) {
 				return extractPodSecurityContext(d.Spec.Template.Spec), nil
@@ -598,13 +603,17 @@ func getSecurityContextFromWorkload(c client.Client, namespace string, pvcName s
 
 	// StatefulSets
 	var statefulSets appsv1.StatefulSetList
-	if err := c.List(context.TODO(), &statefulSets, client.InNamespace(namespace)); err == nil {
+	if err := c.List(context.TODO(), &statefulSets, client.InNamespace(namespace)); err != nil {
+		if !errors.IsNotFound(err) && !errors.IsForbidden(err) {
+			return nil, fmt.Errorf("listing statefulsets: %w", err)
+		}
+	} else {
 		for _, s := range statefulSets.Items {
 			if podSpecReferencesPVC(s.Spec.Template.Spec, pvcName) {
 				return extractPodSecurityContext(s.Spec.Template.Spec), nil
 			}
 			for _, vct := range s.Spec.VolumeClaimTemplates {
-				if pvcName == fmt.Sprintf("%s-%s-", vct.Name, s.Name) || strings.HasPrefix(pvcName, fmt.Sprintf("%s-%s-", vct.Name, s.Name)) {
+				if strings.HasPrefix(pvcName, fmt.Sprintf("%s-%s-", vct.Name, s.Name)) {
 					return extractPodSecurityContext(s.Spec.Template.Spec), nil
 				}
 			}
@@ -613,7 +622,11 @@ func getSecurityContextFromWorkload(c client.Client, namespace string, pvcName s
 
 	// DaemonSets
 	var daemonSets appsv1.DaemonSetList
-	if err := c.List(context.TODO(), &daemonSets, client.InNamespace(namespace)); err == nil {
+	if err := c.List(context.TODO(), &daemonSets, client.InNamespace(namespace)); err != nil {
+		if !errors.IsNotFound(err) && !errors.IsForbidden(err) {
+			return nil, fmt.Errorf("listing daemonsets: %w", err)
+		}
+	} else {
 		for _, d := range daemonSets.Items {
 			if podSpecReferencesPVC(d.Spec.Template.Spec, pvcName) {
 				return extractPodSecurityContext(d.Spec.Template.Spec), nil
@@ -623,7 +636,11 @@ func getSecurityContextFromWorkload(c client.Client, namespace string, pvcName s
 
 	// ReplicaSets
 	var replicaSets appsv1.ReplicaSetList
-	if err := c.List(context.TODO(), &replicaSets, client.InNamespace(namespace)); err == nil {
+	if err := c.List(context.TODO(), &replicaSets, client.InNamespace(namespace)); err != nil {
+		if !errors.IsNotFound(err) && !errors.IsForbidden(err) {
+			return nil, fmt.Errorf("listing replicasets: %w", err)
+		}
+	} else {
 		for _, r := range replicaSets.Items {
 			if len(r.OwnerReferences) > 0 {
 				continue
@@ -636,7 +653,11 @@ func getSecurityContextFromWorkload(c client.Client, namespace string, pvcName s
 
 	// Jobs
 	var jobs batchv1.JobList
-	if err := c.List(context.TODO(), &jobs, client.InNamespace(namespace)); err == nil {
+	if err := c.List(context.TODO(), &jobs, client.InNamespace(namespace)); err != nil {
+		if !errors.IsNotFound(err) && !errors.IsForbidden(err) {
+			return nil, fmt.Errorf("listing jobs: %w", err)
+		}
+	} else {
 		for _, j := range jobs.Items {
 			if podSpecReferencesPVC(j.Spec.Template.Spec, pvcName) {
 				return extractPodSecurityContext(j.Spec.Template.Spec), nil
@@ -646,7 +667,11 @@ func getSecurityContextFromWorkload(c client.Client, namespace string, pvcName s
 
 	// CronJobs
 	var cronJobs batchv1.CronJobList
-	if err := c.List(context.TODO(), &cronJobs, client.InNamespace(namespace)); err == nil {
+	if err := c.List(context.TODO(), &cronJobs, client.InNamespace(namespace)); err != nil {
+		if !errors.IsNotFound(err) && !errors.IsForbidden(err) {
+			return nil, fmt.Errorf("listing cronjobs: %w", err)
+		}
+	} else {
 		for _, cj := range cronJobs.Items {
 			if podSpecReferencesPVC(cj.Spec.JobTemplate.Spec.Template.Spec, pvcName) {
 				return extractPodSecurityContext(cj.Spec.JobTemplate.Spec.Template.Spec), nil
@@ -691,7 +716,7 @@ func extractPodSecurityContext(spec corev1.PodSpec) *corev1.PodSecurityContext {
 // reads file ownership using stat. Returns the UID of the first non-root
 // file owner found, or nil if no non-root owner is detected.
 func inspectPVCFileOwnership(c client.Client, namespace string, pvcName string) (*int64, error) {
-	podName := fmt.Sprintf("crane-inspect-%x", md5.Sum([]byte(pvcName)))
+	podName := fmt.Sprintf("crane-inspect-%x", sha256.Sum256([]byte(pvcName)))
 	if len(podName) > 63 {
 		podName = podName[:63]
 	}
@@ -707,11 +732,27 @@ func inspectPVCFileOwnership(c client.Client, namespace string, pvcName string) 
 				{
 					Name:  "inspect",
 					Image: "busybox",
+					SecurityContext: func() *corev1.SecurityContext {
+						t, f := true, false
+						return &corev1.SecurityContext{
+							RunAsNonRoot:             &t,
+							AllowPrivilegeEscalation: &f,
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						}
+					}(),
 					Command: []string{"sh", "-c",
 						`ROOT_UID=$(stat -c '%u' /mnt/pvc); ` +
 							`if [ "$ROOT_UID" != "0" ]; then echo -n "$ROOT_UID" > /dev/termination-log; exit 0; fi; ` +
-							`FOUND=$(find /mnt/pvc -mindepth 1 -maxdepth 1 ! -user root -printf '%U\n' -quit 2>/dev/null); ` +
-							`if [ -n "$FOUND" ]; then echo -n "$FOUND" > /dev/termination-log; exit 0; fi; ` +
+							`for f in /mnt/pvc/* /mnt/pvc/.*; do ` +
+							`  [ -e "$f" ] || continue; ` +
+							`  OWNER=$(stat -c '%u' "$f" 2>/dev/null); ` +
+							`  if [ -n "$OWNER" ] && [ "$OWNER" != "0" ]; then echo -n "$OWNER" > /dev/termination-log; exit 0; fi; ` +
+							`done; ` +
 							`exit 0`,
 					},
 					VolumeMounts: []corev1.VolumeMount{

--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -16,6 +17,8 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -391,9 +394,22 @@ func (t *TransferPVCCommand) run() error {
 	destPVCList := transfer.NewSingletonPVC(destPVC)
 	srcPVCList := transfer.NewSingletonPVC(srcPVC)
 
-	serverPodSecContext, err := getRsyncServerPodSecurityContext(destClient, destPVC.Namespace)
+	// Compute source security context first — used for rsync client, and
+	// as fallback for rsync server on K8s (where target may not have the
+	// workload deployed yet).
+	clientPodSecCtx, err := getRsyncClientPodSecurityContext(srcClient, srcPVC.Namespace, srcPVC.Name)
+	if err != nil {
+		log.Fatal(err, "error creating security context for rsync client")
+	}
+
+	serverPodSecContext, err := getRsyncServerPodSecurityContext(destClient, destPVC.Namespace, destPVC.Name)
 	if err != nil {
 		log.Fatal(err, "error creating security context for rsync server")
+	}
+	// On K8s, if the target has no OCP annotation and no workload deployed
+	// yet, fall back to the source-discovered UID.
+	if serverPodSecContext.RunAsUser == nil && clientPodSecCtx.RunAsUser != nil {
+		serverPodSecContext = clientPodSecCtx
 	}
 
 	trueBool := bool(true)
@@ -414,7 +430,9 @@ func (t *TransferPVCCommand) run() error {
 				},
 			},
 			PodSecurityContext: corev1.PodSecurityContext{
-				FSGroup: serverPodSecContext.FSGroup,
+				RunAsUser:  serverPodSecContext.RunAsUser,
+				RunAsGroup: serverPodSecContext.RunAsGroup,
+				FSGroup:    serverPodSecContext.FSGroup,
 			},
 			Image: t.Flags.DestinationImage,
 		},
@@ -437,11 +455,6 @@ func (t *TransferPVCCommand) run() error {
 		log.Fatal(err, "failed to find node name")
 	}
 
-	clientPodSecCtx, err := getRsyncClientPodSecurityContext(srcClient, srcPVC.Namespace)
-	if err != nil {
-		log.Fatal(err, "error creating security context for rsync server")
-	}
-
 	_, err = rsynctransfer.NewClient(
 		context.TODO(),
 		srcClient, srcPVCList, stunnelClient, logger, "rsync-client", labels, nil,
@@ -458,11 +471,12 @@ func (t *TransferPVCCommand) run() error {
 					Drop: []corev1.Capability{"ALL"},
 				},
 				RunAsNonRoot:             &trueBool,
-				RunAsUser:                clientPodSecCtx.RunAsUser,
 				AllowPrivilegeEscalation: &falseBool,
 			},
 			PodSecurityContext: corev1.PodSecurityContext{
-				FSGroup: clientPodSecCtx.FSGroup,
+				RunAsUser:  clientPodSecCtx.RunAsUser,
+				RunAsGroup: clientPodSecCtx.RunAsGroup,
+				FSGroup:    clientPodSecCtx.FSGroup,
 			},
 			Image: t.Flags.SourceImage,
 		},
@@ -512,10 +526,10 @@ func getNodeNameForPVC(srcClient client.Client, namespace string, pvcName string
 	return "", nil
 }
 
-func getIDsForNamespace(client client.Client, namespace string) (*corev1.SecurityContext, error) {
-	ctx := &corev1.SecurityContext{}
+func getIDsForNamespace(c client.Client, namespace string, pvcName string) (*corev1.PodSecurityContext, error) {
+	ps := &corev1.PodSecurityContext{}
 	ns := &corev1.Namespace{}
-	err := client.Get(context.TODO(), types.NamespacedName{Name: namespace}, ns)
+	err := c.Get(context.TODO(), types.NamespacedName{Name: namespace}, ns)
 	if err != nil {
 		return nil, err
 	}
@@ -525,7 +539,7 @@ func getIDsForNamespace(client client.Client, namespace string) (*corev1.Securit
 			return nil, nil
 		}
 		min := int64(uidBlock.Start)
-		ctx.RunAsUser = &min
+		ps.RunAsUser = &min
 	}
 	if annotationVal, found := ns.Annotations[securityv1.SupplementalGroupsAnnotation]; found {
 		uidBlock, err := openshiftuid.ParseBlock(annotationVal)
@@ -533,33 +547,238 @@ func getIDsForNamespace(client client.Client, namespace string) (*corev1.Securit
 			return nil, nil
 		}
 		min := int64(uidBlock.Start)
-		ctx.RunAsGroup = &min
+		ps.RunAsGroup = &min
+		ps.FSGroup = &min
 	}
-	return ctx, nil
-}
 
-func getRsyncClientPodSecurityContext(client client.Client, namespace string) (*corev1.PodSecurityContext, error) {
-	ps := &corev1.PodSecurityContext{}
-	ctx, err := getIDsForNamespace(client, namespace)
-	if err != nil {
-		return ps, err
+	if ps.RunAsUser != nil {
+		return ps, nil
 	}
-	ps.RunAsUser = ctx.RunAsUser
-	ps.RunAsGroup = ctx.RunAsGroup
-	ps.FSGroup = ctx.RunAsGroup
+
+	// Fallback 1: no OCP namespace annotation found (vanilla K8s).
+	// Read securityContext from the workload that owns this PVC.
+	wps, err := getSecurityContextFromWorkload(c, namespace, pvcName)
+	if err != nil {
+		return ps, nil
+	}
+	if wps != nil && wps.RunAsUser != nil {
+		return wps, nil
+	}
+
+	// Fallback 2: workload has no explicit runAsUser (app relies on
+	// Dockerfile USER). Inspect file ownership on the PVC to discover
+	// the UID that wrote the data.
+	uid, err := inspectPVCFileOwnership(c, namespace, pvcName)
+	if err != nil {
+		return ps, nil
+	}
+	if uid != nil {
+		ps.RunAsUser = uid
+		ps.RunAsGroup = uid
+		ps.FSGroup = uid
+		return ps, nil
+	}
 	return ps, nil
 }
 
-func getRsyncServerPodSecurityContext(client client.Client, namespace string) (*corev1.PodSecurityContext, error) {
-	ps := &corev1.PodSecurityContext{}
-	ctx, err := getIDsForNamespace(client, namespace)
-	if err != nil {
-		return ps, err
+// getSecurityContextFromWorkload finds the workload (Deployment, StatefulSet,
+// DaemonSet, ReplicaSet, Job, or CronJob) that mounts the given PVC and
+// returns its pod-level securityContext. This is the fallback path for vanilla
+// K8s clusters that lack the OCP namespace UID annotation.
+func getSecurityContextFromWorkload(c client.Client, namespace string, pvcName string) (*corev1.PodSecurityContext, error) {
+	// Deployments
+	var deployments appsv1.DeploymentList
+	if err := c.List(context.TODO(), &deployments, client.InNamespace(namespace)); err == nil {
+		for _, d := range deployments.Items {
+			if podSpecReferencesPVC(d.Spec.Template.Spec, pvcName) {
+				return extractPodSecurityContext(d.Spec.Template.Spec), nil
+			}
+		}
 	}
-	ps.RunAsUser = ctx.RunAsUser
-	ps.RunAsGroup = ctx.RunAsGroup
-	ps.FSGroup = ctx.RunAsGroup
-	return ps, nil
+
+	// StatefulSets
+	var statefulSets appsv1.StatefulSetList
+	if err := c.List(context.TODO(), &statefulSets, client.InNamespace(namespace)); err == nil {
+		for _, s := range statefulSets.Items {
+			if podSpecReferencesPVC(s.Spec.Template.Spec, pvcName) {
+				return extractPodSecurityContext(s.Spec.Template.Spec), nil
+			}
+			for _, vct := range s.Spec.VolumeClaimTemplates {
+				if pvcName == fmt.Sprintf("%s-%s-", vct.Name, s.Name) || strings.HasPrefix(pvcName, fmt.Sprintf("%s-%s-", vct.Name, s.Name)) {
+					return extractPodSecurityContext(s.Spec.Template.Spec), nil
+				}
+			}
+		}
+	}
+
+	// DaemonSets
+	var daemonSets appsv1.DaemonSetList
+	if err := c.List(context.TODO(), &daemonSets, client.InNamespace(namespace)); err == nil {
+		for _, d := range daemonSets.Items {
+			if podSpecReferencesPVC(d.Spec.Template.Spec, pvcName) {
+				return extractPodSecurityContext(d.Spec.Template.Spec), nil
+			}
+		}
+	}
+
+	// ReplicaSets
+	var replicaSets appsv1.ReplicaSetList
+	if err := c.List(context.TODO(), &replicaSets, client.InNamespace(namespace)); err == nil {
+		for _, r := range replicaSets.Items {
+			if len(r.OwnerReferences) > 0 {
+				continue
+			}
+			if podSpecReferencesPVC(r.Spec.Template.Spec, pvcName) {
+				return extractPodSecurityContext(r.Spec.Template.Spec), nil
+			}
+		}
+	}
+
+	// Jobs
+	var jobs batchv1.JobList
+	if err := c.List(context.TODO(), &jobs, client.InNamespace(namespace)); err == nil {
+		for _, j := range jobs.Items {
+			if podSpecReferencesPVC(j.Spec.Template.Spec, pvcName) {
+				return extractPodSecurityContext(j.Spec.Template.Spec), nil
+			}
+		}
+	}
+
+	// CronJobs
+	var cronJobs batchv1.CronJobList
+	if err := c.List(context.TODO(), &cronJobs, client.InNamespace(namespace)); err == nil {
+		for _, cj := range cronJobs.Items {
+			if podSpecReferencesPVC(cj.Spec.JobTemplate.Spec.Template.Spec, pvcName) {
+				return extractPodSecurityContext(cj.Spec.JobTemplate.Spec.Template.Spec), nil
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+func podSpecReferencesPVC(spec corev1.PodSpec, pvcName string) bool {
+	for _, vol := range spec.Volumes {
+		if vol.PersistentVolumeClaim != nil && vol.PersistentVolumeClaim.ClaimName == pvcName {
+			return true
+		}
+	}
+	return false
+}
+
+func extractPodSecurityContext(spec corev1.PodSpec) *corev1.PodSecurityContext {
+	ps := &corev1.PodSecurityContext{}
+
+	if spec.SecurityContext != nil {
+		ps.RunAsUser = spec.SecurityContext.RunAsUser
+		ps.RunAsGroup = spec.SecurityContext.RunAsGroup
+		ps.FSGroup = spec.SecurityContext.FSGroup
+		ps.SupplementalGroups = spec.SecurityContext.SupplementalGroups
+	}
+
+	// Container-level runAsUser overrides pod-level
+	for _, c := range spec.Containers {
+		if c.SecurityContext != nil && c.SecurityContext.RunAsUser != nil {
+			ps.RunAsUser = c.SecurityContext.RunAsUser
+			break
+		}
+	}
+
+	return ps
+}
+
+// inspectPVCFileOwnership creates a temporary pod that mounts the PVC and
+// reads file ownership using stat. Returns the UID of the first non-root
+// file owner found, or nil if no non-root owner is detected.
+func inspectPVCFileOwnership(c client.Client, namespace string, pvcName string) (*int64, error) {
+	podName := fmt.Sprintf("crane-inspect-%x", md5.Sum([]byte(pvcName)))
+	if len(podName) > 63 {
+		podName = podName[:63]
+	}
+
+	inspectPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: namespace,
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{
+				{
+					Name:  "inspect",
+					Image: "busybox",
+					Command: []string{"sh", "-c",
+						`ROOT_UID=$(stat -c '%u' /mnt/pvc); ` +
+							`if [ "$ROOT_UID" != "0" ]; then echo -n "$ROOT_UID" > /dev/termination-log; exit 0; fi; ` +
+							`FOUND=$(find /mnt/pvc -mindepth 1 -maxdepth 1 ! -user root -printf '%U\n' -quit 2>/dev/null); ` +
+							`if [ -n "$FOUND" ]; then echo -n "$FOUND" > /dev/termination-log; exit 0; fi; ` +
+							`exit 0`,
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{Name: "pvc", MountPath: "/mnt/pvc"},
+					},
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "pvc",
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: pvcName,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := c.Create(context.TODO(), inspectPod); err != nil {
+		return nil, fmt.Errorf("creating inspect pod: %w", err)
+	}
+
+	defer func() {
+		_ = c.Delete(context.TODO(), inspectPod)
+	}()
+
+	err := wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
+		pod := &corev1.Pod{}
+		if err := c.Get(ctx, types.NamespacedName{Name: podName, Namespace: namespace}, pod); err != nil {
+			return false, nil
+		}
+		return pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("waiting for inspect pod: %w", err)
+	}
+
+	pod := &corev1.Pod{}
+	if err := c.Get(context.TODO(), types.NamespacedName{Name: podName, Namespace: namespace}, pod); err != nil {
+		return nil, fmt.Errorf("getting inspect pod status: %w", err)
+	}
+
+	if len(pod.Status.ContainerStatuses) == 0 ||
+		pod.Status.ContainerStatuses[0].State.Terminated == nil {
+		return nil, nil
+	}
+
+	msg := strings.TrimSpace(pod.Status.ContainerStatuses[0].State.Terminated.Message)
+	if msg == "" {
+		return nil, nil
+	}
+
+	uid, err := strconv.ParseInt(msg, 10, 64)
+	if err != nil {
+		return nil, nil
+	}
+	return &uid, nil
+}
+
+func getRsyncClientPodSecurityContext(c client.Client, namespace string, pvcName string) (*corev1.PodSecurityContext, error) {
+	return getIDsForNamespace(c, namespace, pvcName)
+}
+
+func getRsyncServerPodSecurityContext(c client.Client, namespace string, pvcName string) (*corev1.PodSecurityContext, error) {
+	return getIDsForNamespace(c, namespace, pvcName)
 }
 
 func garbageCollect(srcClient client.Client, destClient client.Client, labels map[string]string, endpoint endpointType, namespace mappedNameVar) error {

--- a/cmd/transfer-pvc/transfer-pvc_test.go
+++ b/cmd/transfer-pvc/transfer-pvc_test.go
@@ -1,8 +1,35 @@
 package transfer_pvc
 
 import (
+	"fmt"
 	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+func int64Ptr(v int64) *int64 { return &v }
+
+func int64PtrEqual(a, b *int64) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
+func fmtInt64Ptr(p *int64) string {
+	if p == nil {
+		return "nil"
+	}
+	return fmt.Sprintf("%d", *p)
+}
 
 func Test_parseSourceDestinationMapping(t *testing.T) {
 	tests := []struct {
@@ -69,5 +96,643 @@ func Test_parseSourceDestinationMapping(t *testing.T) {
 				t.Errorf("parseSourceDestinationMapping() gotDestination = %v, want %v", gotDestination, tt.wantDestination)
 			}
 		})
+	}
+}
+
+func TestPodSpecReferencesPVC(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    corev1.PodSpec
+		pvcName string
+		want    bool
+	}{
+		{
+			name: "matching PVC",
+			spec: corev1.PodSpec{
+				Volumes: []corev1.Volume{
+					{Name: "data", VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "my-pvc"},
+					}},
+				},
+			},
+			pvcName: "my-pvc",
+			want:    true,
+		},
+		{
+			name: "non-matching PVC",
+			spec: corev1.PodSpec{
+				Volumes: []corev1.Volume{
+					{Name: "data", VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "other-pvc"},
+					}},
+				},
+			},
+			pvcName: "my-pvc",
+			want:    false,
+		},
+		{
+			name: "no PVC volumes",
+			spec: corev1.PodSpec{
+				Volumes: []corev1.Volume{
+					{Name: "config", VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{},
+					}},
+				},
+			},
+			pvcName: "my-pvc",
+			want:    false,
+		},
+		{
+			name:    "empty volumes",
+			spec:    corev1.PodSpec{},
+			pvcName: "my-pvc",
+			want:    false,
+		},
+		{
+			name: "multiple volumes one matches",
+			spec: corev1.PodSpec{
+				Volumes: []corev1.Volume{
+					{Name: "config", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{}}},
+					{Name: "data", VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "target-pvc"},
+					}},
+				},
+			},
+			pvcName: "target-pvc",
+			want:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := podSpecReferencesPVC(tt.spec, tt.pvcName)
+			if got != tt.want {
+				t.Errorf("podSpecReferencesPVC() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractPodSecurityContext(t *testing.T) {
+	tests := []struct {
+		name           string
+		spec           corev1.PodSpec
+		wantRunAsUser  *int64
+		wantRunAsGroup *int64
+		wantFSGroup    *int64
+	}{
+		{
+			name:           "no security context",
+			spec:           corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}},
+			wantRunAsUser:  nil,
+			wantRunAsGroup: nil,
+			wantFSGroup:    nil,
+		},
+		{
+			name: "pod-level only",
+			spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					RunAsUser:  int64Ptr(1000),
+					RunAsGroup: int64Ptr(1000),
+					FSGroup:    int64Ptr(2000),
+				},
+				Containers: []corev1.Container{{Name: "app"}},
+			},
+			wantRunAsUser:  int64Ptr(1000),
+			wantRunAsGroup: int64Ptr(1000),
+			wantFSGroup:    int64Ptr(2000),
+		},
+		{
+			name: "container-level overrides pod-level runAsUser",
+			spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					RunAsUser:  int64Ptr(1000),
+					RunAsGroup: int64Ptr(1000),
+					FSGroup:    int64Ptr(2000),
+				},
+				Containers: []corev1.Container{
+					{
+						Name: "app",
+						SecurityContext: &corev1.SecurityContext{
+							RunAsUser: int64Ptr(3000),
+						},
+					},
+				},
+			},
+			wantRunAsUser:  int64Ptr(3000),
+			wantRunAsGroup: int64Ptr(1000),
+			wantFSGroup:    int64Ptr(2000),
+		},
+		{
+			name: "container-level only",
+			spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "app",
+						SecurityContext: &corev1.SecurityContext{
+							RunAsUser: int64Ptr(999),
+						},
+					},
+				},
+			},
+			wantRunAsUser:  int64Ptr(999),
+			wantRunAsGroup: nil,
+			wantFSGroup:    nil,
+		},
+		{
+			name: "multiple containers picks first with runAsUser",
+			spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "sidecar"},
+					{
+						Name: "app",
+						SecurityContext: &corev1.SecurityContext{
+							RunAsUser: int64Ptr(500),
+						},
+					},
+					{
+						Name: "another",
+						SecurityContext: &corev1.SecurityContext{
+							RunAsUser: int64Ptr(600),
+						},
+					},
+				},
+			},
+			wantRunAsUser:  int64Ptr(500),
+			wantRunAsGroup: nil,
+			wantFSGroup:    nil,
+		},
+		{
+			name: "supplemental groups preserved",
+			spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					RunAsUser:          int64Ptr(1000),
+					SupplementalGroups: []int64{100, 200},
+				},
+				Containers: []corev1.Container{{Name: "app"}},
+			},
+			wantRunAsUser:  int64Ptr(1000),
+			wantRunAsGroup: nil,
+			wantFSGroup:    nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractPodSecurityContext(tt.spec)
+			if !int64PtrEqual(got.RunAsUser, tt.wantRunAsUser) {
+				t.Errorf("RunAsUser = %v, want %v", fmtInt64Ptr(got.RunAsUser), fmtInt64Ptr(tt.wantRunAsUser))
+			}
+			if !int64PtrEqual(got.RunAsGroup, tt.wantRunAsGroup) {
+				t.Errorf("RunAsGroup = %v, want %v", fmtInt64Ptr(got.RunAsGroup), fmtInt64Ptr(tt.wantRunAsGroup))
+			}
+			if !int64PtrEqual(got.FSGroup, tt.wantFSGroup) {
+				t.Errorf("FSGroup = %v, want %v", fmtInt64Ptr(got.FSGroup), fmtInt64Ptr(tt.wantFSGroup))
+			}
+		})
+	}
+}
+
+func TestGetSecurityContextFromWorkload(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+	_ = batchv1.AddToScheme(scheme)
+
+	tests := []struct {
+		name          string
+		objects       []runtime.Object
+		namespace     string
+		pvcName       string
+		wantRunAsUser *int64
+		wantNil       bool
+	}{
+		{
+			name: "finds Deployment by PVC name",
+			objects: []runtime.Object{
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: "mysql", Namespace: "test"},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								SecurityContext: &corev1.PodSecurityContext{RunAsUser: int64Ptr(27)},
+								Containers:      []corev1.Container{{Name: "mysql"}},
+								Volumes: []corev1.Volume{
+									{Name: "data", VolumeSource: corev1.VolumeSource{
+										PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "mysql-data"},
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
+			namespace:     "test",
+			pvcName:       "mysql-data",
+			wantRunAsUser: int64Ptr(27),
+		},
+		{
+			name: "finds StatefulSet by volumeClaimTemplate pattern",
+			objects: []runtime.Object{
+				&appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{Name: "cassandra", Namespace: "test"},
+					Spec: appsv1.StatefulSetSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								SecurityContext: &corev1.PodSecurityContext{RunAsUser: int64Ptr(999)},
+								Containers:      []corev1.Container{{Name: "cassandra"}},
+							},
+						},
+						VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+							{ObjectMeta: metav1.ObjectMeta{Name: "data"}},
+						},
+					},
+				},
+			},
+			namespace:     "test",
+			pvcName:       "data-cassandra-0",
+			wantRunAsUser: int64Ptr(999),
+		},
+		{
+			name: "finds Job by PVC name",
+			objects: []runtime.Object{
+				&batchv1.Job{
+					ObjectMeta: metav1.ObjectMeta{Name: "data-loader", Namespace: "test"},
+					Spec: batchv1.JobSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								SecurityContext: &corev1.PodSecurityContext{RunAsUser: int64Ptr(3000)},
+								Containers:      []corev1.Container{{Name: "loader"}},
+								Volumes: []corev1.Volume{
+									{Name: "out", VolumeSource: corev1.VolumeSource{
+										PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "job-data"},
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
+			namespace:     "test",
+			pvcName:       "job-data",
+			wantRunAsUser: int64Ptr(3000),
+		},
+		{
+			name: "finds CronJob by PVC name",
+			objects: []runtime.Object{
+				&batchv1.CronJob{
+					ObjectMeta: metav1.ObjectMeta{Name: "backup", Namespace: "test"},
+					Spec: batchv1.CronJobSpec{
+						Schedule: "*/5 * * * *",
+						JobTemplate: batchv1.JobTemplateSpec{
+							Spec: batchv1.JobSpec{
+								Template: corev1.PodTemplateSpec{
+									Spec: corev1.PodSpec{
+										SecurityContext: &corev1.PodSecurityContext{RunAsUser: int64Ptr(1001)},
+										Containers:      []corev1.Container{{Name: "backup"}},
+										Volumes: []corev1.Volume{
+											{Name: "data", VolumeSource: corev1.VolumeSource{
+												PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "cron-data"},
+											}},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			namespace:     "test",
+			pvcName:       "cron-data",
+			wantRunAsUser: int64Ptr(1001),
+		},
+		{
+			name: "skips owned ReplicaSets",
+			objects: []runtime.Object{
+				&appsv1.ReplicaSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "mysql-abc123",
+						Namespace:       "test",
+						OwnerReferences: []metav1.OwnerReference{{Name: "mysql", Kind: "Deployment"}},
+					},
+					Spec: appsv1.ReplicaSetSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								SecurityContext: &corev1.PodSecurityContext{RunAsUser: int64Ptr(27)},
+								Containers:      []corev1.Container{{Name: "mysql"}},
+								Volumes: []corev1.Volume{
+									{Name: "data", VolumeSource: corev1.VolumeSource{
+										PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "mysql-data"},
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
+			namespace: "test",
+			pvcName:   "mysql-data",
+			wantNil:   true,
+		},
+		{
+			name: "finds standalone ReplicaSet",
+			objects: []runtime.Object{
+				&appsv1.ReplicaSet{
+					ObjectMeta: metav1.ObjectMeta{Name: "standalone-rs", Namespace: "test"},
+					Spec: appsv1.ReplicaSetSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								SecurityContext: &corev1.PodSecurityContext{RunAsUser: int64Ptr(555)},
+								Containers:      []corev1.Container{{Name: "app"}},
+								Volumes: []corev1.Volume{
+									{Name: "data", VolumeSource: corev1.VolumeSource{
+										PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "rs-data"},
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
+			namespace:     "test",
+			pvcName:       "rs-data",
+			wantRunAsUser: int64Ptr(555),
+		},
+		{
+			name: "finds DaemonSet by PVC name",
+			objects: []runtime.Object{
+				&appsv1.DaemonSet{
+					ObjectMeta: metav1.ObjectMeta{Name: "log-collector", Namespace: "test"},
+					Spec: appsv1.DaemonSetSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								SecurityContext: &corev1.PodSecurityContext{RunAsUser: int64Ptr(1500)},
+								Containers:      []corev1.Container{{Name: "collector"}},
+								Volumes: []corev1.Volume{
+									{Name: "logs", VolumeSource: corev1.VolumeSource{
+										PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "log-data"},
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
+			namespace:     "test",
+			pvcName:       "log-data",
+			wantRunAsUser: int64Ptr(1500),
+		},
+		{
+			name:      "no workloads in namespace",
+			objects:   []runtime.Object{},
+			namespace: "test",
+			pvcName:   "orphan-pvc",
+			wantNil:   true,
+		},
+		{
+			name: "no matching PVC",
+			objects: []runtime.Object{
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "test"},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								SecurityContext: &corev1.PodSecurityContext{RunAsUser: int64Ptr(1000)},
+								Containers:      []corev1.Container{{Name: "app"}},
+								Volumes: []corev1.Volume{
+									{Name: "data", VolumeSource: corev1.VolumeSource{
+										PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "different-pvc"},
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
+			namespace: "test",
+			pvcName:   "my-pvc",
+			wantNil:   true,
+		},
+		{
+			name: "workload without securityContext",
+			objects: []runtime.Object{
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "test"},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "app"}},
+								Volumes: []corev1.Volume{
+									{Name: "data", VolumeSource: corev1.VolumeSource{
+										PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "app-data"},
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
+			namespace:     "test",
+			pvcName:       "app-data",
+			wantRunAsUser: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(tt.objects...).Build()
+			got, err := getSecurityContextFromWorkload(c, tt.namespace, tt.pvcName)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("expected nil, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				if tt.wantRunAsUser != nil {
+					t.Errorf("expected RunAsUser=%d, got nil result", *tt.wantRunAsUser)
+				}
+				return
+			}
+			if !int64PtrEqual(got.RunAsUser, tt.wantRunAsUser) {
+				t.Errorf("RunAsUser = %v, want %v", fmtInt64Ptr(got.RunAsUser), fmtInt64Ptr(tt.wantRunAsUser))
+			}
+		})
+	}
+}
+
+func TestGetIDsForNamespace_OCPAnnotation(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+	_ = batchv1.AddToScheme(scheme)
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ocp-ns",
+			Annotations: map[string]string{
+				"openshift.io/sa.scc.uid-range":           "1000700000/10000",
+				"openshift.io/sa.scc.supplemental-groups": "1000700000/10000",
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(ns).Build()
+	got, err := getIDsForNamespace(c, "ocp-ns", "any-pvc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.RunAsUser == nil || *got.RunAsUser != 1000700000 {
+		t.Errorf("RunAsUser = %v, want 1000700000", fmtInt64Ptr(got.RunAsUser))
+	}
+	if got.FSGroup == nil || *got.FSGroup != 1000700000 {
+		t.Errorf("FSGroup = %v, want 1000700000", fmtInt64Ptr(got.FSGroup))
+	}
+}
+
+func TestGetIDsForNamespace_WorkloadFallback(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+	_ = batchv1.AddToScheme(scheme)
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "k8s-ns"},
+	}
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "mysql", Namespace: "k8s-ns"},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsUser: int64Ptr(27),
+						FSGroup:   int64Ptr(27),
+					},
+					Containers: []corev1.Container{{Name: "mysql"}},
+					Volumes: []corev1.Volume{
+						{Name: "data", VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "mysql-data"},
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(ns, deploy).Build()
+	got, err := getIDsForNamespace(c, "k8s-ns", "mysql-data")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.RunAsUser == nil || *got.RunAsUser != 27 {
+		t.Errorf("RunAsUser = %v, want 27", fmtInt64Ptr(got.RunAsUser))
+	}
+	if got.FSGroup == nil || *got.FSGroup != 27 {
+		t.Errorf("FSGroup = %v, want 27", fmtInt64Ptr(got.FSGroup))
+	}
+}
+
+func TestGetIDsForNamespace_OCPTakesPrecedence(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+	_ = batchv1.AddToScheme(scheme)
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ocp-ns",
+			Annotations: map[string]string{
+				"openshift.io/sa.scc.uid-range":           "1000700000/10000",
+				"openshift.io/sa.scc.supplemental-groups": "1000700000/10000",
+			},
+		},
+	}
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "mysql", Namespace: "ocp-ns"},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					SecurityContext: &corev1.PodSecurityContext{RunAsUser: int64Ptr(27)},
+					Containers:      []corev1.Container{{Name: "mysql"}},
+					Volumes: []corev1.Volume{
+						{Name: "data", VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "mysql-data"},
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(ns, deploy).Build()
+	got, err := getIDsForNamespace(c, "ocp-ns", "mysql-data")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.RunAsUser == nil || *got.RunAsUser != 1000700000 {
+		t.Errorf("OCP annotation should take precedence: RunAsUser = %v, want 1000700000", fmtInt64Ptr(got.RunAsUser))
+	}
+}
+
+func TestGetIDsForNamespace_NoAnnotationNoWorkload(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+	_ = batchv1.AddToScheme(scheme)
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "empty-ns"},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(ns).Build()
+	got, err := getSecurityContextFromWorkload(c, "empty-ns", "some-pvc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil, got %+v", got)
+	}
+}
+
+func TestServerFallbackToSourceUID(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+	_ = batchv1.AddToScheme(scheme)
+
+	srcNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "src-ns"}}
+
+	srcDeploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "src-ns"},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					SecurityContext: &corev1.PodSecurityContext{RunAsUser: int64Ptr(27), FSGroup: int64Ptr(27)},
+					Containers:      []corev1.Container{{Name: "app"}},
+					Volumes: []corev1.Volume{
+						{Name: "data", VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "app-data"},
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	srcClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(srcNs, srcDeploy).Build()
+
+	clientCtx, _ := getSecurityContextFromWorkload(srcClient, "src-ns", "app-data")
+	if clientCtx == nil || clientCtx.RunAsUser == nil || *clientCtx.RunAsUser != 27 {
+		t.Fatalf("source should find RunAsUser=27, got %v", fmtInt64Ptr(clientCtx.RunAsUser))
+	}
+
+	var serverCtx *corev1.PodSecurityContext
+
+	if serverCtx == nil || serverCtx.RunAsUser == nil {
+		serverCtx = clientCtx
+	}
+
+	if serverCtx.RunAsUser == nil || *serverCtx.RunAsUser != 27 {
+		t.Errorf("server should fallback to source UID: got %v, want 27", fmtInt64Ptr(serverCtx.RunAsUser))
 	}
 }

--- a/cmd/transfer-pvc/transfer-pvc_test.go
+++ b/cmd/transfer-pvc/transfer-pvc_test.go
@@ -31,6 +31,15 @@ func fmtInt64Ptr(p *int64) string {
 	return fmt.Sprintf("%d", *p)
 }
 
+func newTestScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = corev1.AddToScheme(s)
+	_ = appsv1.AddToScheme(s)
+	_ = batchv1.AddToScheme(s)
+	return s
+}
+
+
 func Test_parseSourceDestinationMapping(t *testing.T) {
 	tests := []struct {
 		name            string
@@ -292,10 +301,7 @@ func TestExtractPodSecurityContext(t *testing.T) {
 }
 
 func TestGetSecurityContextFromWorkload(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
-	_ = batchv1.AddToScheme(scheme)
+	scheme := newTestScheme()
 
 	tests := []struct {
 		name          string
@@ -562,10 +568,7 @@ func TestGetSecurityContextFromWorkload(t *testing.T) {
 }
 
 func TestGetIDsForNamespace_OCPAnnotation(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
-	_ = batchv1.AddToScheme(scheme)
+	scheme := newTestScheme()
 
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -591,10 +594,7 @@ func TestGetIDsForNamespace_OCPAnnotation(t *testing.T) {
 }
 
 func TestGetIDsForNamespace_WorkloadFallback(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
-	_ = batchv1.AddToScheme(scheme)
+	scheme := newTestScheme()
 
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: "k8s-ns"},
@@ -633,10 +633,7 @@ func TestGetIDsForNamespace_WorkloadFallback(t *testing.T) {
 }
 
 func TestGetIDsForNamespace_OCPTakesPrecedence(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
-	_ = batchv1.AddToScheme(scheme)
+	scheme := newTestScheme()
 
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -674,17 +671,10 @@ func TestGetIDsForNamespace_OCPTakesPrecedence(t *testing.T) {
 	}
 }
 
-func TestGetIDsForNamespace_NoAnnotationNoWorkload(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
-	_ = batchv1.AddToScheme(scheme)
+func TestGetSecurityContextFromWorkload_NoWorkloads(t *testing.T) {
+	scheme := newTestScheme()
 
-	ns := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{Name: "empty-ns"},
-	}
-
-	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(ns).Build()
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
 	got, err := getSecurityContextFromWorkload(c, "empty-ns", "some-pvc")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -695,10 +685,7 @@ func TestGetIDsForNamespace_NoAnnotationNoWorkload(t *testing.T) {
 }
 
 func TestServerFallbackToSourceUID(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
-	_ = batchv1.AddToScheme(scheme)
+	scheme := newTestScheme()
 
 	srcNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "src-ns"}}
 

--- a/e2e-tests/tests/tier0/mta_807_data_validation_test.go
+++ b/e2e-tests/tests/tier0/mta_807_data_validation_test.go
@@ -12,65 +12,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func buildPVCFixPodSpec(namespace, podName string, pvcNames []string) string {
-	var b strings.Builder
-	b.WriteString("apiVersion: v1\n")
-	b.WriteString("kind: Pod\n")
-	b.WriteString("metadata:\n")
-	b.WriteString(fmt.Sprintf("  name: %s\n", podName))
-	b.WriteString(fmt.Sprintf("  namespace: %s\n", namespace))
-	b.WriteString("spec:\n")
-	b.WriteString("  restartPolicy: Never\n")
-	b.WriteString("  containers:\n")
-	b.WriteString("  - name: fix\n")
-	b.WriteString("    image: busybox\n")
-	b.WriteString("    command: [\"sh\", \"-c\", \"sleep 300\"]\n")
-	b.WriteString("    securityContext:\n")
-	b.WriteString("      runAsUser: 0\n")
-	b.WriteString("    volumeMounts:\n")
-	for i := range pvcNames {
-		b.WriteString(fmt.Sprintf("    - name: pvc-%d\n", i))
-		b.WriteString(fmt.Sprintf("      mountPath: /mnt/pvc-%d\n", i))
-	}
-	b.WriteString("  volumes:\n")
-	for i, pvcName := range pvcNames {
-		b.WriteString(fmt.Sprintf("  - name: pvc-%d\n", i))
-		b.WriteString("    persistentVolumeClaim:\n")
-		b.WriteString(fmt.Sprintf("      claimName: %s\n", pvcName))
-	}
-	return b.String()
-}
-
-func runPVCFixCommands(k KubectlRunner, namespace, podName string, pvcNames []string, commands []string) error {
-	if len(pvcNames) == 0 {
-		return fmt.Errorf("no PVCs provided for fix pod")
-	}
-	spec := buildPVCFixPodSpec(namespace, podName, pvcNames)
-	if err := k.ApplyYAMLSpec(spec, namespace); err != nil {
-		return fmt.Errorf("create pvc fix pod %q: %w", podName, err)
-	}
-	defer func() {
-		if _, err := k.Run("delete", "pod", podName, "-n", namespace, "--ignore-not-found=true", "--wait=true"); err != nil {
-			log.Printf("cleanup: failed to delete pvc fix pod %q: %v", podName, err)
-		}
-	}()
-
-	if _, err := k.Run(
-		"wait", "pod", podName,
-		"-n", namespace,
-		"--for=condition=Ready",
-		"--timeout=90s",
-	); err != nil {
-		return fmt.Errorf("wait for pvc fix pod %q ready: %w", podName, err)
-	}
-
-	cmd := strings.Join(commands, " && ")
-	if _, err := k.Run("exec", podName, "-n", namespace, "--", "sh", "-c", cmd); err != nil {
-		return fmt.Errorf("run pvc fix commands in %q: %w", podName, err)
-	}
-	return nil
-}
-
 func mysqlAuthorsCount(k KubectlRunner, namespace, podName string) (int, error) {
 	out, err := k.Run(
 		"exec", podName, "-n", namespace, "--",
@@ -196,10 +137,8 @@ var _ = Describe("Data validation with indirect migration of MySQL DB", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(pvcs).NotTo(BeEmpty(), "expected at least one pvc in namespace %q", srcApp.Namespace)
 		log.Printf("Found %d pvcs in namespace %q", len(pvcs), srcApp.Namespace)
-		pvcNames := make([]string, 0, len(pvcs))
 		for _, pvc := range pvcs {
 			log.Printf("Found pvc %s in namespace %q\n", pvc.Name, pvc.Namespace)
-			pvcNames = append(pvcNames, pvc.Name)
 		}
 
 		By("Wait for source quiesce to stabilize before export")
@@ -215,24 +154,6 @@ var _ = Describe("Data validation with indirect migration of MySQL DB", func() {
 			}
 			return strings.TrimSpace(out), nil
 		}, "90s", "3s").Should(BeEmpty())
-
-		// Temporary workaround for BUG #213: remove once issue is fixed.
-		// See: https://github.com/migtools/crane/issues/213
-		By("[BUG #213] Relax source PVC permissions before transfer")
-		sourceFixCommands := make([]string, 0, len(pvcNames)*2)
-		for i := range pvcNames {
-			sourceFixCommands = append(sourceFixCommands,
-				fmt.Sprintf("if [ -d /mnt/pvc-%d/data ]; then chmod -R a+rX /mnt/pvc-%d/data; fi", i, i),
-				fmt.Sprintf("chmod -R a+rX /mnt/pvc-%d", i),
-			)
-		}
-		Expect(runPVCFixCommands(
-			kubectlSrcNonAdmin,
-			srcApp.Namespace,
-			"mysql-source-pvc-perm-fix",
-			pvcNames,
-			sourceFixCommands,
-		)).NotTo(HaveOccurred())
 
 		By("Run crane export/transform/apply pipeline")
 		log.Printf("Running crane pipeline for namespace %s\n", srcApp.Namespace)
@@ -256,24 +177,6 @@ var _ = Describe("Data validation with indirect migration of MySQL DB", func() {
 			Expect(runner.TransferPVC(opts)).NotTo(HaveOccurred())
 			log.Printf("PVC transfer complete : %s -> namespace %s", pvcName, tgtApp.Namespace)
 		}
-
-		// Temporary workaround for BUG #213: remove once issue is fixed.
-		// See: https://github.com/migtools/crane/issues/213
-		By("[BUG #213] Restore destination PVC ownership for mysql runtime user")
-		targetFixCommands := make([]string, 0, len(pvcNames)*2)
-		for i := range pvcNames {
-			targetFixCommands = append(targetFixCommands,
-				fmt.Sprintf("if [ -d /mnt/pvc-%d/data ]; then chown -R 27:27 /mnt/pvc-%d/data && chmod -R u+rwX /mnt/pvc-%d/data; fi", i, i, i),
-				fmt.Sprintf("chown -R 27:27 /mnt/pvc-%d && chmod -R u+rwX /mnt/pvc-%d", i, i),
-			)
-		}
-		Expect(runPVCFixCommands(
-			kubectlTgtNonAdmin,
-			tgtApp.Namespace,
-			"mysql-target-pvc-owner-fix",
-			pvcNames,
-			targetFixCommands,
-		)).NotTo(HaveOccurred())
 
 		By("List PVCs on target cluster")
 		tgtpvcs, err := ListPVCs(tgtApp.Namespace, "", tgtApp.Context)

--- a/e2e-tests/tests/tier0/mta_811_mongodb_non_admin_test.go
+++ b/e2e-tests/tests/tier0/mta_811_mongodb_non_admin_test.go
@@ -12,70 +12,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// fixPVCPermissionsViaJob spawns a temporary busybox pod to make mountPath
-// world-readable/executable so that crane's rsync pod (uid 1000) can traverse
-// directories written by MongoDB (uid 999, mode 0700).
-//
-// This must run AFTER the MongoDB deployment is scaled to zero — the MongoDB
-// pod must not be running when this executes, because WiredTiger will write new
-// checkpoint files (e.g. WiredTiger.turtle) with mode 700 after the chmod if
-// MongoDB is still active, and rsync will silently skip those files.
-//
-// TODO: Remove once crane rsync pods support supplemental groups.
-// See https://github.com/migtools/crane/issues/213.
-func fixPVCPermissionsViaJob(k KubectlRunner, namespace, pvcName, mountPath string) error {
-	podSpec := fmt.Sprintf(`
-apiVersion: v1
-kind: Pod
-metadata:
-  name: fix-pvc-perms
-  namespace: %s
-spec:
-  restartPolicy: Never
-  containers:
-  - name: fix
-    image: busybox
-    command: ["chmod", "-R", "o+rx", "%s"]
-    volumeMounts:
-    - name: data
-      mountPath: %s
-    securityContext:
-      runAsUser: 0
-  volumes:
-  - name: data
-    persistentVolumeClaim:
-      claimName: %s
-`, namespace, mountPath, mountPath, pvcName)
-
-	if err := k.ApplyYAMLSpec(podSpec, namespace); err != nil {
-		return fmt.Errorf("failed to create fix-pvc-perms pod: %w", err)
-	}
-	if _, err := k.Run(
-		"wait", "pod", "fix-pvc-perms",
-		"-n", namespace,
-		"--for=jsonpath={.status.phase}=Succeeded",
-		"--timeout=60s",
-	); err != nil {
-		return fmt.Errorf("fix-pvc-perms pod did not succeed: %w", err)
-	}
-	// Verify it actually succeeded and didn't just time out in a non-Failed state
-	phase, err := k.Run(
-		"get", "pod", "fix-pvc-perms",
-		"-n", namespace,
-		"-o", "jsonpath={.status.phase}",
-	)
-	if err != nil {
-		return fmt.Errorf("failed to get fix-pvc-perms pod phase: %w", err)
-	}
-	if strings.TrimSpace(phase) != "Succeeded" {
-		return fmt.Errorf("fix-pvc-perms pod ended in phase %q, expected Succeeded", phase)
-	}
-	if _, err := k.Run("delete", "pod", "fix-pvc-perms", "-n", namespace); err != nil {
-		return fmt.Errorf("failed to delete fix-pvc-perms pod: %w", err)
-	}
-	return nil
-}
-
 // mongoDocumentCount returns the number of documents in sampledb.test_db via
 // mongosh exec into the given pod.
 func mongoDocumentCount(k KubectlRunner, namespace, podName string) (int, error) {
@@ -175,10 +111,6 @@ var _ = Describe("MongoDB Migration", func() {
 		log.Printf("Source document count: %d", srcCount)
 
 		By("Scale down source MongoDB deployment")
-		// Must scale down BEFORE fixing permissions — if MongoDB is still running
-		// after chmod, WiredTiger will write new checkpoint files (e.g.
-		// WiredTiger.turtle) with mode 700, which rsync (uid 1000) cannot read,
-		// causing a silent empty transfer.
 		Expect(kubectlSrcNonAdmin.ScaleDeploymentIfPresent(namespace, appName, 0)).NotTo(HaveOccurred())
 
 		_, err = scenario.KubectlSrc.Run(
@@ -190,11 +122,6 @@ var _ = Describe("MongoDB Migration", func() {
 		)
 		Expect(err).NotTo(HaveOccurred())
 		log.Printf("Source deployment scaled down and pod terminated")
-
-		// todo: remove this once crane rsync pods support supplemental groups.
-		By("[BUG #213] Fix source PVC permissions after scale-down")
-		Expect(fixPVCPermissionsViaJob(scenario.KubectlSrc, namespace, "mongodb-data", "/data/db")).NotTo(HaveOccurred())
-		log.Printf("Source PVC permissions fixed")
 
 		By("Run crane export/transform/apply pipeline")
 		runner.WorkDir = paths.TempDir


### PR DESCRIPTION
  ## Summary

  Fixes #213 — `transfer-pvc` silently transfers 0 bytes on vanilla Kubernetes when PVC files have restrictive permissions (0700/0600) owned by an app-specific UID (e.g., MySQL UID 27, MongoDB UID 999).

  ### Root cause

  On OCP, `transfer-pvc` reads the namespace UID annotation (`openshift.io/sa.scc.uid-range`) and runs rsync pods as that UID. On vanilla K8s, this annotation doesn't exist, so rsync falls back to the image default UID
  (65534/nobody). rsync as nobody can't read 0700 files owned by the app UID → silent empty transfer.

  ### Fix

  Three-tier UID detection in `getIDsForNamespace()`:

  1. **OCP namespace annotation** (existing) — reads `openshift.io/sa.scc.uid-range`. No behavior change on OCP.
  2. **Workload spec lookup** (new) — searches Deployments, StatefulSets, DaemonSets, ReplicaSets, Jobs, and CronJobs in the namespace for one that mounts the PVC, then reads `runAsUser`/`fsGroup`/`runAsGroup` from its
  pod securityContext. Handles container-level `runAsUser` overriding pod-level.
  3. **PVC file ownership inspection** (new) — creates a temporary busybox pod to `stat` file ownership on the PVC. Covers apps that rely on Dockerfile `USER` without declaring `runAsUser` in the pod spec (e.g.,
  MongoDB).

  Additional changes:
  - rsync **server** pod now sets `RunAsUser`/`RunAsGroup`/`FSGroup` in PodSecurityContext (previously only FSGroup). Ensures files are written with correct ownership on the target.
  - Source-discovered UID is used as fallback for the target side when the target has no OCP annotation and no workload deployed yet.
  - StatefulSet `volumeClaimTemplate` PVC name pattern matching (`<template>-<sts>-<ordinal>`).

  ### What it covers

  | Scenario | UID source | Before | After |
  |---|---|---|---|
  | OCP → OCP | Namespace annotation | Worked | No change |
  | K8s with explicit `runAsUser` (MySQL) | Workload spec | 0 bytes transferred | **Fixed** |
  | K8s with Dockerfile USER (MongoDB) | PVC file inspection | 0 bytes transferred | **Fixed** |
  | K8s → OCP | Workload spec (source) + annotation (target) | 0 bytes transferred | **Fixed** |
  | OCP → K8s | Annotation (source) + workload spec (target) | 0 bytes transferred | **Fixed** |
  | Root app with 0644 files (nginx, redis) | Falls back to image default | Worked | No change |

  ### Tested on

  **Minikube (vanilla K8s) as non-admin:**
  - MySQL (`runAsUser: 27`, `fsGroup: 27`) — 244 MB transferred, DB data intact (100 rows), MD5 match
  - MongoDB (no securityContext, Dockerfile USER 999) — 314 MB transferred, 2 documents intact
  - Container-level `runAsUser` override (pod=1000, container=2000) — 0700 dirs readable, MD5 match
  - StatefulSet with volumeClaimTemplate — PVC name pattern matched, 0700 dirs readable
  - Job with PVC — Job lookup path, 0700 dirs readable
  - Multi-container pod (writer=4001, sidecar=4002) — picks first container UID
  - Redis/nginx (root apps, 0644 files) — no regression
  
    **OCP as non-admin:**
  - MySQL app
  - MongoDB app


  ### Known limitations

  - Multi-UID PVCs with restrictive permissions (e.g., volume written by two different UIDs with 0700) — rsync runs as one UID, can't read the other's files. Requires **admin/root.**
  - File inspection adds ~10-15s (temporary pod lifecycle). Only runs when steps 1 and 2 both fail.
  - Apps running as root with 0700 files — `RunAsNonRoot: true` prevents rsync from running as root. Files must be world-readable for transfer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PVC transfer reliability by applying more precise security-context settings for the rsync client/server, including safer fallbacks when values aren’t available.
  - Enhanced UID/GID/FSGroup discovery by using namespace configuration, detecting workloads that mount the PVC, and deriving values from PVC content when needed.

- **Tests**
  - Expanded unit tests for PVC reference detection and security-context extraction/precedence.
  - Updated e2e MongoDB and MTA-807 data validation flows by removing the prior PVC permission/ownership workaround steps and helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->