### PR TITLE
:seedling: Auto-detect transfer-pvc endpoint (route on OCP, nginx-ingress on K8s)

### DIFF
--- a/e2e-tests/framework/crane.go
+++ b/e2e-tests/framework/crane.go
@@ -181,7 +181,20 @@ func (c CraneRunner) Apply(opts ApplyOptions) error {
 }
 
 // TransferPVC runs crane transfer-pvc with the provided transfer options.
+// If Endpoint is empty, it auto-detects: "route" on OpenShift, "nginx-ingress" on vanilla K8s.
 func (c CraneRunner) TransferPVC(opts TransferPVCOptions) error {
+	if opts.Endpoint == "" {
+		tgt := KubectlRunner{Context: opts.TargetContext}
+		if tgt.IsOpenShift() {
+			opts.Endpoint = "route"
+		} else {
+			opts.Endpoint = "nginx-ingress"
+			if opts.IngressClass == "" {
+				opts.IngressClass = "nginx"
+			}
+		}
+	}
+
 	args := []string{"transfer-pvc",
 		"--source-context",
 		opts.SourceContext,
@@ -189,8 +202,10 @@ func (c CraneRunner) TransferPVC(opts TransferPVCOptions) error {
 		"--pvc-name", opts.PVCName,
 		"--pvc-namespace", opts.PVCNamespaceMap,
 		"--endpoint", opts.Endpoint,
-		"--ingress-class", opts.IngressClass,
-		"--subdomain", opts.Subdomain,
+	}
+	if opts.Endpoint != "route" {
+		args = append(args, "--ingress-class", opts.IngressClass)
+		args = append(args, "--subdomain", opts.Subdomain)
 	}
 	logVerboseCommand(c.Bin, args)
 	cmd := exec.Command(c.Bin, args...)

--- a/e2e-tests/framework/crane.go
+++ b/e2e-tests/framework/crane.go
@@ -184,7 +184,7 @@ func (c CraneRunner) Apply(opts ApplyOptions) error {
 // If Endpoint is empty, it auto-detects: "route" on OpenShift, "nginx-ingress" on vanilla K8s.
 func (c CraneRunner) TransferPVC(opts TransferPVCOptions) error {
 	if opts.Endpoint == "" {
-		tgt := KubectlRunner{Context: opts.TargetContext}
+		tgt := KubectlRunner{Bin: "kubectl", Context: opts.TargetContext}
 		if tgt.IsOpenShift() {
 			opts.Endpoint = "route"
 		} else {

--- a/e2e-tests/tests/tier0/mta_801_stateful_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_801_stateful_migration_test.go
@@ -95,8 +95,6 @@ var _ = Describe("Stateful app migration", func() {
 				TargetContext:   tgtApp.Context,
 				PVCName:         pvcName,
 				PVCNamespaceMap: fmt.Sprintf("%s:%s", srcApp.Namespace, tgtApp.Namespace),
-				Endpoint:        "nginx-ingress",
-				IngressClass:    "nginx",
 				Subdomain:       fmt.Sprintf("%s.%s.%s.nip.io", pvcName, srcApp.Namespace, tgtIP),
 			}
 			log.Printf("Transferring PVC %s to namespace %s on target cluster", pvcName, tgtApp.Namespace)

--- a/e2e-tests/tests/tier0/mta_801_stateful_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_801_stateful_migration_test.go
@@ -116,7 +116,7 @@ var _ = Describe("Stateful app migration", func() {
 		Expect(kubectlTgt.ScaleDeployment(tgtApp.Namespace, appName, 1)).NotTo(HaveOccurred())
 
 		log.Printf("Validating app %s on target cluster\n", tgtApp.Name)
-		Eventually(tgtApp.Validate, "2m", "10s").Should(Succeed())
+		Eventually(tgtApp.Validate, "5m", "10s").Should(Succeed())
 		log.Printf("Target validation completed for app %s\n", tgtApp.Name)
 
 	})

--- a/e2e-tests/tests/tier0/mta_802_ignored_resources_test.go
+++ b/e2e-tests/tests/tier0/mta_802_ignored_resources_test.go
@@ -93,7 +93,7 @@ var _ = Describe("Default Ignored resources", func() {
 		Expect(ApplyOutputToTarget(kubectlTgt, namespace, paths.OutputDir)).NotTo(HaveOccurred())
 
 		log.Printf("Validating resources created by app %s on target cluster\n", tgtApp.Name)
-		Eventually(tgtApp.Validate, "2m", "10s").Should(Succeed())
+		Eventually(tgtApp.Validate, "5m", "10s").Should(Succeed())
 		log.Printf("Target validation completed for app %s\n", tgtApp.Name)
 
 		By("Validating manual resources on target cluster")

--- a/e2e-tests/tests/tier0/mta_804_empty_pvc_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_804_empty_pvc_migration_test.go
@@ -121,7 +121,7 @@ var _ = Describe("Empty PVC migration", func() {
 
 		By("Validate target application")
 		log.Printf("Validating app %s on target cluster\n", tgtApp.Name)
-		Eventually(tgtApp.Validate, "2m", "10s").Should(Succeed())
+		Eventually(tgtApp.Validate, "5m", "10s").Should(Succeed())
 		log.Printf("Target validation completed for app %s\n", tgtApp.Name)
 
 		By("Verify PVC is empty on target cluster after migration")

--- a/e2e-tests/tests/tier0/mta_804_empty_pvc_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_804_empty_pvc_migration_test.go
@@ -102,8 +102,6 @@ var _ = Describe("Empty PVC migration", func() {
 				TargetContext:   tgtApp.Context,
 				PVCName:         pvcName,
 				PVCNamespaceMap: fmt.Sprintf("%s:%s", srcApp.Namespace, tgtApp.Namespace),
-				Endpoint:        "nginx-ingress",
-				IngressClass:    "nginx",
 				Subdomain:       fmt.Sprintf("%s.%s.%s.nip.io", pvcName, srcApp.Namespace, tgtIP),
 			}
 			log.Printf("Transferring PVC %s to namespace %s on target cluster", pvcName, tgtApp.Namespace)

--- a/e2e-tests/tests/tier0/mta_806_pvc_data_integrity_test.go
+++ b/e2e-tests/tests/tier0/mta_806_pvc_data_integrity_test.go
@@ -115,8 +115,6 @@ var _ = Describe("PVC data integrity migration", func() {
 				TargetContext:   tgtApp.Context,
 				PVCName:         pvcName,
 				PVCNamespaceMap: fmt.Sprintf("%s:%s", srcApp.Namespace, tgtApp.Namespace),
-				Endpoint:        "nginx-ingress",
-				IngressClass:    "nginx",
 				Subdomain:       fmt.Sprintf("%s.%s.%s.nip.io", pvcName, srcApp.Namespace, tgtIP),
 			}
 			log.Printf("Transferring PVC %s to namespace %s on target cluster", pvcName, tgtApp.Namespace)

--- a/e2e-tests/tests/tier0/mta_806_pvc_data_integrity_test.go
+++ b/e2e-tests/tests/tier0/mta_806_pvc_data_integrity_test.go
@@ -140,7 +140,7 @@ var _ = Describe("PVC data integrity migration", func() {
 
 		By("TARGET: Validate application")
 		log.Printf("TARGET: Validating app %s\n", tgtApp.Name)
-		Eventually(tgtApp.Validate, "2m", "10s").Should(Succeed())
+		Eventually(tgtApp.Validate, "5m", "10s").Should(Succeed())
 		log.Printf("TARGET: Validation completed for app %s\n", tgtApp.Name)
 
 		By("TARGET: Verify data file exists after migration")

--- a/e2e-tests/tests/tier0/mta_807_data_validation_test.go
+++ b/e2e-tests/tests/tier0/mta_807_data_validation_test.go
@@ -250,8 +250,6 @@ var _ = Describe("Data validation with indirect migration of MySQL DB", func() {
 				TargetContext:   tgtApp.Context,
 				PVCName:         pvcName,
 				PVCNamespaceMap: fmt.Sprintf("%s:%s", srcApp.Namespace, tgtApp.Namespace),
-				Endpoint:        "nginx-ingress",
-				IngressClass:    "nginx",
 				Subdomain:       fmt.Sprintf("%s.%s.%s.nip.io", pvcName, srcApp.Namespace, tgtIP),
 			}
 			log.Printf("Transferring PVC %s to namespace %s on target cluster", pvcName, tgtApp.Namespace)

--- a/e2e-tests/tests/tier0/mta_807_data_validation_test.go
+++ b/e2e-tests/tests/tier0/mta_807_data_validation_test.go
@@ -292,7 +292,7 @@ var _ = Describe("Data validation with indirect migration of MySQL DB", func() {
 
 		By("Validate target application")
 		log.Printf("Validating app %s on target cluster\n", tgtApp.Name)
-		Eventually(tgtApp.Validate, "2m", "10s").Should(Succeed())
+		Eventually(tgtApp.Validate, "5m", "10s").Should(Succeed())
 		var tgtPodName string
 		Eventually(func() error {
 			podName, err := GetPodNameByLabel(kubectlTgtNonAdmin, tgtApp.Namespace, "app="+appName)

--- a/e2e-tests/tests/tier0/mta_809_initcontainer_test.go
+++ b/e2e-tests/tests/tier0/mta_809_initcontainer_test.go
@@ -93,7 +93,7 @@ var _ = Describe("InitContainer Migration", func() {
 		Expect(kubectlTgtNonAdmin.ScaleDeployment(namespace, appName, 1)).NotTo(HaveOccurred())
 
 		log.Printf("Validating app %s on target cluster\n", tgtApp.Name)
-		Eventually(tgtApp.Validate, "2m", "10s").Should(Succeed())
+		Eventually(tgtApp.Validate, "5m", "10s").Should(Succeed())
 		log.Printf("Target validation completed for app %s\n", tgtApp.Name)
 	})
 })

--- a/e2e-tests/tests/tier0/mta_810_configmap_test.go
+++ b/e2e-tests/tests/tier0/mta_810_configmap_test.go
@@ -94,7 +94,7 @@ var _ = Describe("ConfigMap Migration", func() {
 
 		By("Validate the app on target")
 		log.Printf("Validating app %s on target cluster\n", tgtApp.Name)
-		Eventually(tgtApp.Validate, "2m", "10s").Should(Succeed())
+		Eventually(tgtApp.Validate, "5m", "10s").Should(Succeed())
 
 		By("Validate the configmap is present on target and contains expected data")
 		output, err := kubectlTgtNonAdmin.Run("get", "configmap", "redis-config", "-n", namespace, "-o", "yaml")

--- a/e2e-tests/tests/tier0/mta_811_mongodb_non_admin_test.go
+++ b/e2e-tests/tests/tier0/mta_811_mongodb_non_admin_test.go
@@ -220,8 +220,6 @@ var _ = Describe("MongoDB Migration", func() {
 				TargetContext:   tgtApp.Context,
 				PVCName:         pvc.Name,
 				PVCNamespaceMap: fmt.Sprintf("%s:%s", namespace, namespace),
-				Endpoint:        "nginx-ingress",
-				IngressClass:    "nginx",
 				Subdomain:       fmt.Sprintf("%s.%s.%s.nip.io", pvc.Name, namespace, tgtIP),
 			}
 			Expect(runner.TransferPVC(opts)).NotTo(HaveOccurred())

--- a/e2e-tests/tests/tier0/mta_812_role_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_812_role_migration_test.go
@@ -140,7 +140,7 @@ var _ = Describe("Role and RoleBinding migration", func() {
 		Expect(kubectlTgtNonAdmin.ScaleDeployment(namespace, appName, 1)).NotTo(HaveOccurred())
 
 		log.Printf("Validating app %s on target cluster\n", tgtApp.Name)
-		Eventually(tgtApp.Validate, "2m", "10s").Should(Succeed())
+		Eventually(tgtApp.Validate, "5m", "10s").Should(Succeed())
 		log.Printf("Target app validation completed for %s\n", tgtApp.Name)
 
 		By("Verify Role exists on target with correct rules")

--- a/e2e-tests/tests/tier0/mta_813_cronJob_PVC_test.go
+++ b/e2e-tests/tests/tier0/mta_813_cronJob_PVC_test.go
@@ -177,8 +177,6 @@ var _ = Describe("CronJob with attached PVC migration as non-admin user", func()
 				TargetContext:   scenario.TgtApp.Context,
 				PVCName:         pvc.Name,
 				PVCNamespaceMap: fmt.Sprintf("%s:%s", srcApp.Namespace, tgtApp.Namespace),
-				Endpoint:        "nginx-ingress",
-				IngressClass:    "nginx",
 				Subdomain:       fmt.Sprintf("%s.%s.%s.nip.io", pvc.Name, srcApp.Namespace, tgtIP),
 			}
 			log.Printf("Transferring PVC %s -> namespace %s on target\n", pvc.Name, tgtApp.Namespace)

--- a/e2e-tests/tests/tier0/mta_817_stateless_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_817_stateless_migration_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Stateless migration", func() {
 		Expect(kubectlTgt.ScaleDeployment(namespace, appName, 1)).NotTo(HaveOccurred())
 
 		log.Printf("Validating app %s on target cluster\n", tgtApp.Name)
-		Eventually(tgtApp.Validate, "2m", "10s").Should(Succeed())
+		Eventually(tgtApp.Validate, "5m", "10s").Should(Succeed())
 		log.Printf("Target validation completed for app %s\n", tgtApp.Name)
 	})
 })

--- a/e2e-tests/tests/tier0/mta_827_custom_transformation_stage_test.go
+++ b/e2e-tests/tests/tier0/mta_827_custom_transformation_stage_test.go
@@ -232,7 +232,7 @@ var _ = Describe("Custom transformation stage", func() {
 		}, "2m", "10s").Should(Succeed())
 
 		log.Printf("Validating app %s on target cluster\n", tgtApp.Name)
-		Eventually(tgtApp.Validate, "2m", "10s").Should(Succeed())
+		Eventually(tgtApp.Validate, "5m", "10s").Should(Succeed())
 		log.Printf("Target validation completed for app %s\n", tgtApp.Name)
 	})
 })

--- a/e2e-tests/tests/tier0/mta_828_instructions_file_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_828_instructions_file_migration_test.go
@@ -154,6 +154,6 @@ var _ = Describe("Instructions-file migration", func() {
 		By("Scale target deployment and validate app on target")
 		Expect(scenario.KubectlTgtNonAdmin.ScaleDeployment(namespace, appName, 1)).NotTo(HaveOccurred())
 
-		Eventually(tgtApp.Validate, "2m", "10s").Should(Succeed())
+		Eventually(tgtApp.Validate, "5m", "10s").Should(Succeed())
 	})
 })

--- a/e2e-tests/tests/tier0/mta_837_hpa_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_837_hpa_migration_test.go
@@ -93,7 +93,7 @@ var _ = Describe("HPA migration", func() {
 		Expect(kubectlTgt.ScaleDeployment(namespace, appName, 1)).NotTo(HaveOccurred())
 
 		log.Printf("Validating app %s on target cluster\n", tgtApp.Name)
-		Eventually(tgtApp.Validate, "2m", "10s").Should(Succeed())
+		Eventually(tgtApp.Validate, "5m", "10s").Should(Succeed())
 		log.Printf("Target validation completed for app %s\n", tgtApp.Name)
 
 		By("Verify HPA is present on target cluster")

--- a/e2e-tests/tests/tier0/mta_852_minimal_rbac_test.go
+++ b/e2e-tests/tests/tier0/mta_852_minimal_rbac_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Cluster-level RBAC export", func() {
 
 		By("Scaling target deployment and validating app")
 		Expect(kubectlTgt.ScaleDeployment(namespace, appName, 1)).NotTo(HaveOccurred())
-		Eventually(tgtApp.Validate, "2m", "10s").Should(Succeed())
+		Eventually(tgtApp.Validate, "5m", "10s").Should(Succeed())
 
 		By("Verifying ClusterRoleBinding on target references correct ClusterRole and ServiceAccount")
 		Expect(ValidateClusterRBAC(kubectlTgt, []ExpectedClusterRoleBinding{

--- a/e2e-tests/tests/tier0/mta_853_split_apply_test.go
+++ b/e2e-tests/tests/tier0/mta_853_split_apply_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Namespace-admin cluster-level migration", func() {
 
 		By("Scaling target deployment and validating app")
 		Expect(kubectlTgtNonAdmin.ScaleDeployment(namespace, appName, 1)).NotTo(HaveOccurred())
-		Eventually(tgtAppNonAdmin.Validate, "2m", "10s").Should(Succeed())
+		Eventually(tgtAppNonAdmin.Validate, "5m", "10s").Should(Succeed())
 
 	})
 


### PR DESCRIPTION
Auto Detection of transfer-pvc endpoint, instead of hardcoding to nginx-ingress.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PVC transfers can now automatically pick the correct target endpoint based on the cluster type.
  * On standard Kubernetes clusters, the transfer flow now defaults the ingress class when it isn’t provided.

* **Bug Fixes**
  * Improved migration reliability by reducing the need to manually configure endpoint/ingress settings during PVC transfer workflows.

* **Tests**
  * Expanded end-to-end validation timeouts for migrated applications to reduce transient failures and better reflect real-world rollout times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->