### PR TITLE
 :test_tube: Add e2e test for pipeline determinism test

### DIFF
--- a/e2e-tests/tests/tier0/mta_843_pipeline_determinism_test.go
+++ b/e2e-tests/tests/tier0/mta_843_pipeline_determinism_test.go
@@ -42,8 +42,12 @@ var _ = Describe("Pipeline determinism", func() {
 
 		DeferCleanup(func() {
 			By("Cleanup temporary directories")
-			os.RemoveAll(paths1.TempDir)
-			os.RemoveAll(paths2.TempDir)
+			if err := os.RemoveAll(paths1.TempDir); err != nil {
+				log.Printf("cleanup: %v", err)
+			}
+			if err := os.RemoveAll(paths2.TempDir); err != nil {
+				log.Printf("cleanup: %v", err)
+			}
 			By("Cleanup app resources")
 			if err := srcApp.Cleanup(); err != nil {
 				log.Printf("cleanup: %v", err)

--- a/e2e-tests/tests/tier0/mta_843_pipeline_determinism_test.go
+++ b/e2e-tests/tests/tier0/mta_843_pipeline_determinism_test.go
@@ -1,0 +1,94 @@
+package e2e
+
+import (
+      
+      "log"
+      "os"
+
+      "github.com/konveyor/crane/e2e-tests/config"
+      . "github.com/konveyor/crane/e2e-tests/framework"
+	  "github.com/konveyor/crane/e2e-tests/utils"
+      . "github.com/onsi/ginkgo/v2"
+      . "github.com/onsi/gomega"
+  )
+var _ = Describe("Pipeline determinism", func() {
+	It("[MTA-843] crane pipeline produces identical output on consecutive runs", Label("tier0"), func() {
+		appName := "simple-nginx-nopv"
+		namespace := "crane-determinism-test"
+		serviceName := "my-" + appName
+		scenario := NewMigrationScenario(
+			appName,
+			namespace,
+			config.K8sDeployBin,
+			config.CraneBin,
+			config.SourceContext,
+			config.SourceContext,
+		)
+		srcApp := scenario.SrcApp
+		kubectlSrc := scenario.KubectlSrc
+	    isOpenShift := kubectlSrc.IsOpenShift()
+
+		paths1, err := NewScenarioPaths("crane-export-*")
+		Expect(err).NotTo(HaveOccurred())
+		exportOpts1 := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths1.ExportDir}
+		transformOpts1 := TransformOptions{ExportDir: paths1.ExportDir, TransformDir: paths1.TransformDir}
+		applyOpts1 := ApplyOptions{ExportDir: paths1.ExportDir, TransformDir: paths1.TransformDir, OutputDir: paths1.OutputDir}
+		
+		paths2, err := NewScenarioPaths("crane-export-*")
+		Expect(err).NotTo(HaveOccurred())
+		exportOpts2 := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths2.ExportDir}
+		transformOpts2 := TransformOptions{ExportDir: paths2.ExportDir, TransformDir: paths2.TransformDir}
+		applyOpts2 := ApplyOptions{ExportDir: paths2.ExportDir, TransformDir: paths2.TransformDir, OutputDir: paths2.OutputDir}
+		
+		DeferCleanup(func() {
+			By("Cleanup temporary directories")
+			os.RemoveAll(paths1.TempDir)
+			os.RemoveAll(paths2.TempDir)
+			By("Cleanup app resources")
+			if err := srcApp.Cleanup(); err != nil {
+				log.Printf("cleanup: %v", err)
+			}
+			By("Delete test namespace")
+			if _, err := kubectlSrc.Run("delete", "namespace", namespace, "--ignore-not-found=true", "--wait=true", "--timeout=60s"); err != nil {
+				log.Printf("cleanup: %v", err)
+			 } 
+		})
+
+		By("Prepare source app")
+		log.Printf("Preparing source app %s in namespace %s\n", srcApp.Name, srcApp.Namespace)
+		Expect(PrepareSourceApp(srcApp, kubectlSrc)).NotTo(HaveOccurred())
+		log.Printf("Source app %s prepared successfully\n", srcApp.Name)
+		
+		By("Run crane export/transform/apply pipeline")
+		runner1 := scenario.Crane
+		runner1.WorkDir = paths1.TempDir
+
+		runner2 := scenario.Crane
+		runner2.WorkDir = paths2.TempDir
+	    
+		By("Wait for source quiesce to stabilize before export")
+		WaitForSourceQuiesce(kubectlSrc, namespace, "app="+appName, serviceName)
+
+		By("Run pipeline - first run")
+		log.Printf("Running crane pipeline for namespace %s\n", srcApp.Namespace)
+		Expect(RunCranePipelineWithChecks(runner1, exportOpts1, transformOpts1, applyOpts1)).NotTo(HaveOccurred())
+		
+		By("Run pipeline - second run")
+		Expect(RunCranePipelineWithChecks(runner2, exportOpts2, transformOpts2, applyOpts2)).NotTo(HaveOccurred())
+		log.Printf("Crane pipeline completed for namespace %s\n", srcApp.Namespace)
+
+		By("Compare export dirs between runs")
+		compareExport := utils.CompareDirectoryYAMLSemanticsExport
+        if isOpenShift {
+            compareExport =
+            utils.CompareDirectoryYAMLSemanticsExportAllowOptionalOCPOutputDefaults
+        }
+		Expect(compareExport(paths1.ExportDir, paths2.ExportDir)).NotTo(HaveOccurred())
+		
+		By("Compare transform dirs between runs")
+		Expect(utils.CompareDirectoryYAMLSemanticsUnordered(paths1.TransformDir, paths2.TransformDir)).NotTo(HaveOccurred())
+		
+		By("Compare output dirs between runs")
+		Expect(utils.CompareDirectoryYAMLSemantics(paths1.OutputDir, paths2.OutputDir)).NotTo(HaveOccurred())
+
+	})})

--- a/e2e-tests/tests/tier0/mta_843_pipeline_determinism_test.go
+++ b/e2e-tests/tests/tier0/mta_843_pipeline_determinism_test.go
@@ -24,9 +24,7 @@ var _ = Describe("Pipeline determinism", func() {
 			config.SourceContext,
 			config.SourceContext,
 		)
-		srcApp := scenario.SrcApp
-		kubectlSrc := scenario.KubectlSrc
-		isOpenShift := kubectlSrc.IsOpenShift()
+		srcApp := scenario.SrcAppNonAdmin
 
 		paths1, err := NewScenarioPaths("crane-export-*")
 		Expect(err).NotTo(HaveOccurred())
@@ -40,6 +38,11 @@ var _ = Describe("Pipeline determinism", func() {
 		transformOpts2 := TransformOptions{ExportDir: paths2.ExportDir, TransformDir: paths2.TransformDir}
 		applyOpts2 := ApplyOptions{ExportDir: paths2.ExportDir, TransformDir: paths2.TransformDir, OutputDir: paths2.OutputDir}
 
+		srcApp.ExtraVars = map[string]any{"non_admin_user": "true"}
+
+		By("Grant ns admin permissions to nonadmin user on source and target")
+		kubectlSrcNonAdmin, cleanup, err := SetupActiveNamespaceAdmin(scenario.KubectlSrc, config.SourceNonAdminContext, namespace)
+		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() {
 			By("Cleanup temporary directories")
 			if err := os.RemoveAll(paths1.TempDir); err != nil {
@@ -53,25 +56,27 @@ var _ = Describe("Pipeline determinism", func() {
 				log.Printf("cleanup: %v", err)
 			}
 			By("Delete test namespace")
-			if _, err := kubectlSrc.Run("delete", "namespace", namespace, "--ignore-not-found=true", "--wait=true", "--timeout=60s"); err != nil {
+			if _, err := scenario.KubectlSrc.Run("delete", "namespace", namespace, "--ignore-not-found=true", "--wait=true", "--timeout=60s"); err != nil {
 				log.Printf("cleanup: %v", err)
 			}
 		})
+		DeferCleanup(cleanup)
+		isOpenShift := kubectlSrcNonAdmin.IsOpenShift()
 
 		By("Prepare source app")
 		log.Printf("Preparing source app %s in namespace %s\n", srcApp.Name, srcApp.Namespace)
-		Expect(PrepareSourceApp(srcApp, kubectlSrc)).NotTo(HaveOccurred())
+		Expect(PrepareSourceApp(srcApp, kubectlSrcNonAdmin)).NotTo(HaveOccurred())
 		log.Printf("Source app %s prepared successfully\n", srcApp.Name)
 
 		By("Run crane export/transform/apply pipeline")
-		runner1 := scenario.Crane
+		runner1 := scenario.CraneNonAdmin
 		runner1.WorkDir = paths1.TempDir
 
-		runner2 := scenario.Crane
+		runner2 := scenario.CraneNonAdmin
 		runner2.WorkDir = paths2.TempDir
 
 		By("Wait for source quiesce to stabilize before export")
-		WaitForSourceQuiesce(kubectlSrc, namespace, "app="+appName, serviceName)
+		WaitForSourceQuiesce(kubectlSrcNonAdmin, namespace, "app="+appName, serviceName)
 
 		By("Run pipeline - first run")
 		log.Printf("Running crane pipeline for namespace %s\n", srcApp.Namespace)
@@ -84,8 +89,7 @@ var _ = Describe("Pipeline determinism", func() {
 		By("Compare export dirs between runs")
 		compareExport := utils.CompareDirectoryYAMLSemanticsExport
 		if isOpenShift {
-			compareExport =
-				utils.CompareDirectoryYAMLSemanticsExportAllowOptionalOCPOutputDefaults
+			compareExport = utils.CompareDirectoryYAMLSemanticsExportAllowOptionalOCPOutputDefaults
 		}
 		Expect(compareExport(paths1.ExportDir, paths2.ExportDir)).NotTo(HaveOccurred())
 

--- a/e2e-tests/tests/tier0/mta_843_pipeline_determinism_test.go
+++ b/e2e-tests/tests/tier0/mta_843_pipeline_determinism_test.go
@@ -1,16 +1,16 @@
 package e2e
 
 import (
-      
-      "log"
-      "os"
+	"log"
+	"os"
 
-      "github.com/konveyor/crane/e2e-tests/config"
-      . "github.com/konveyor/crane/e2e-tests/framework"
-	  "github.com/konveyor/crane/e2e-tests/utils"
-      . "github.com/onsi/ginkgo/v2"
-      . "github.com/onsi/gomega"
-  )
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	"github.com/konveyor/crane/e2e-tests/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
 var _ = Describe("Pipeline determinism", func() {
 	It("[MTA-843] crane pipeline produces identical output on consecutive runs", Label("tier0"), func() {
 		appName := "simple-nginx-nopv"
@@ -26,20 +26,20 @@ var _ = Describe("Pipeline determinism", func() {
 		)
 		srcApp := scenario.SrcApp
 		kubectlSrc := scenario.KubectlSrc
-	    isOpenShift := kubectlSrc.IsOpenShift()
+		isOpenShift := kubectlSrc.IsOpenShift()
 
 		paths1, err := NewScenarioPaths("crane-export-*")
 		Expect(err).NotTo(HaveOccurred())
 		exportOpts1 := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths1.ExportDir}
 		transformOpts1 := TransformOptions{ExportDir: paths1.ExportDir, TransformDir: paths1.TransformDir}
 		applyOpts1 := ApplyOptions{ExportDir: paths1.ExportDir, TransformDir: paths1.TransformDir, OutputDir: paths1.OutputDir}
-		
+
 		paths2, err := NewScenarioPaths("crane-export-*")
 		Expect(err).NotTo(HaveOccurred())
 		exportOpts2 := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths2.ExportDir}
 		transformOpts2 := TransformOptions{ExportDir: paths2.ExportDir, TransformDir: paths2.TransformDir}
 		applyOpts2 := ApplyOptions{ExportDir: paths2.ExportDir, TransformDir: paths2.TransformDir, OutputDir: paths2.OutputDir}
-		
+
 		DeferCleanup(func() {
 			By("Cleanup temporary directories")
 			os.RemoveAll(paths1.TempDir)
@@ -51,44 +51,45 @@ var _ = Describe("Pipeline determinism", func() {
 			By("Delete test namespace")
 			if _, err := kubectlSrc.Run("delete", "namespace", namespace, "--ignore-not-found=true", "--wait=true", "--timeout=60s"); err != nil {
 				log.Printf("cleanup: %v", err)
-			 } 
+			}
 		})
 
 		By("Prepare source app")
 		log.Printf("Preparing source app %s in namespace %s\n", srcApp.Name, srcApp.Namespace)
 		Expect(PrepareSourceApp(srcApp, kubectlSrc)).NotTo(HaveOccurred())
 		log.Printf("Source app %s prepared successfully\n", srcApp.Name)
-		
+
 		By("Run crane export/transform/apply pipeline")
 		runner1 := scenario.Crane
 		runner1.WorkDir = paths1.TempDir
 
 		runner2 := scenario.Crane
 		runner2.WorkDir = paths2.TempDir
-	    
+
 		By("Wait for source quiesce to stabilize before export")
 		WaitForSourceQuiesce(kubectlSrc, namespace, "app="+appName, serviceName)
 
 		By("Run pipeline - first run")
 		log.Printf("Running crane pipeline for namespace %s\n", srcApp.Namespace)
 		Expect(RunCranePipelineWithChecks(runner1, exportOpts1, transformOpts1, applyOpts1)).NotTo(HaveOccurred())
-		
+
 		By("Run pipeline - second run")
 		Expect(RunCranePipelineWithChecks(runner2, exportOpts2, transformOpts2, applyOpts2)).NotTo(HaveOccurred())
 		log.Printf("Crane pipeline completed for namespace %s\n", srcApp.Namespace)
 
 		By("Compare export dirs between runs")
 		compareExport := utils.CompareDirectoryYAMLSemanticsExport
-        if isOpenShift {
-            compareExport =
-            utils.CompareDirectoryYAMLSemanticsExportAllowOptionalOCPOutputDefaults
-        }
+		if isOpenShift {
+			compareExport =
+				utils.CompareDirectoryYAMLSemanticsExportAllowOptionalOCPOutputDefaults
+		}
 		Expect(compareExport(paths1.ExportDir, paths2.ExportDir)).NotTo(HaveOccurred())
-		
+
 		By("Compare transform dirs between runs")
 		Expect(utils.CompareDirectoryYAMLSemanticsUnordered(paths1.TransformDir, paths2.TransformDir)).NotTo(HaveOccurred())
-		
+
 		By("Compare output dirs between runs")
 		Expect(utils.CompareDirectoryYAMLSemantics(paths1.OutputDir, paths2.OutputDir)).NotTo(HaveOccurred())
 
-	})})
+	})
+})

--- a/e2e-tests/tests/tier0/mta_843_pipeline_determinism_test.go
+++ b/e2e-tests/tests/tier0/mta_843_pipeline_determinism_test.go
@@ -68,7 +68,6 @@ var _ = Describe("Pipeline determinism", func() {
 		Expect(PrepareSourceApp(srcApp, kubectlSrcNonAdmin)).NotTo(HaveOccurred())
 		log.Printf("Source app %s prepared successfully\n", srcApp.Name)
 
-		By("Run crane export/transform/apply pipeline")
 		runner1 := scenario.CraneNonAdmin
 		runner1.WorkDir = paths1.TempDir
 

--- a/e2e-tests/utils/utils.go
+++ b/e2e-tests/utils/utils.go
@@ -230,17 +230,18 @@ func CompareDirectoryYAMLSemantics(goldenDir, gotDir string) error {
 }
 
 // sortTopLevelArray returns a sorted copy of arr by canonical JSON representation of
-  // each element, enabling order-independent comparison of top-level YAML sequences
- func sortTopLevelArray(arr []any) []any {
-      sorted := make([]any, len(arr))
-      copy(sorted, arr)
-      sort.Slice(sorted, func(i, j int) bool {
-          a, _ := json.Marshal(sorted[i])
-          b, _ := json.Marshal(sorted[j])
-          return string(a) < string(b)
-      })
-      return sorted
-  }
+// each element, enabling order-independent comparison of top-level YAML sequences
+func sortTopLevelArray(arr []any) []any {
+	sorted := make([]any, len(arr))
+	copy(sorted, arr)
+	sort.Slice(sorted, func(i, j int) bool {
+		a, _ := json.Marshal(sorted[i])
+		b, _ := json.Marshal(sorted[j])
+		return string(a) < string(b)
+	})
+	return sorted
+}
+
 // compareYAMLFileBytesUnordered parses two YAML inputs and compares their decoded
 // document streams treating arrays as unordered sets. relPath is used only for error context.
 func compareYAMLFileBytesUnordered(relPath string, golden, got []byte) error {
@@ -257,14 +258,14 @@ func compareYAMLFileBytesUnordered(relPath string, golden, got []byte) error {
 	for i := range goldenDocs {
 		goldenDocs[i] = normalizeWithPath(goldenDocs[i], nil)
 		if arr, ok := goldenDocs[i].([]any); ok {
-            goldenDocs[i] = sortTopLevelArray(arr)
-        }
+			goldenDocs[i] = sortTopLevelArray(arr)
+		}
 	}
 	for i := range gotDocs {
 		gotDocs[i] = normalizeWithPath(gotDocs[i], nil)
 		if arr, ok := gotDocs[i].([]any); ok {
-            gotDocs[i] = sortTopLevelArray(arr)
-        }
+			gotDocs[i] = sortTopLevelArray(arr)
+		}
 	}
 
 	if !cmp.Equal(goldenDocs, gotDocs) {
@@ -273,7 +274,7 @@ func compareYAMLFileBytesUnordered(relPath string, golden, got []byte) error {
 
 	return nil
 }
- 
+
 // CompareDirectoryYAMLSemanticsUnordered compares YAML semantics for all matching
 // files in two directories treating arrays as unordered sets, so patch ordering
 // differences between runs do not cause false failures.
@@ -305,6 +306,7 @@ func CompareDirectoryYAMLSemanticsUnordered(goldenDir, gotDir string) error {
 	return nil
 
 }
+
 // CompareDirectoryYAMLSemanticsExport compares export YAML semantics using
 // normalization and resource-identity grouping instead of strict filename matching.
 // This avoids false diffs caused by unstable export filenames (for example, Pod or

--- a/e2e-tests/utils/utils.go
+++ b/e2e-tests/utils/utils.go
@@ -201,7 +201,6 @@ func CompareDirectoryFileSets(goldenDir, gotDir string) error {
 
 // CompareDirectoryYAMLSemantics compares YAML semantics for all matching files in
 // two directories using strict file-set equality and no export-specific normalization.
-// This is intended for stable outputs (for example transform/output artifacts).
 func CompareDirectoryYAMLSemantics(goldenDir, gotDir string) error {
 	if err := CompareDirectoryFileSets(goldenDir, gotDir); err != nil {
 		return err
@@ -230,6 +229,82 @@ func CompareDirectoryYAMLSemantics(goldenDir, gotDir string) error {
 	return nil
 }
 
+// sortTopLevelArray returns a sorted copy of arr by canonical JSON representation of
+  // each element, enabling order-independent comparison of top-level YAML sequences
+ func sortTopLevelArray(arr []any) []any {
+      sorted := make([]any, len(arr))
+      copy(sorted, arr)
+      sort.Slice(sorted, func(i, j int) bool {
+          a, _ := json.Marshal(sorted[i])
+          b, _ := json.Marshal(sorted[j])
+          return string(a) < string(b)
+      })
+      return sorted
+  }
+// compareYAMLFileBytesUnordered parses two YAML inputs and compares their decoded
+// document streams treating arrays as unordered sets. relPath is used only for error context.
+func compareYAMLFileBytesUnordered(relPath string, golden, got []byte) error {
+	goldenDocs, err := parseYAMLDocuments(golden)
+	if err != nil {
+		return fmt.Errorf("parse golden file %q: %w", relPath, err)
+	}
+
+	gotDocs, err := parseYAMLDocuments(got)
+	if err != nil {
+		return fmt.Errorf("parse got file %q: %w", relPath, err)
+	}
+
+	for i := range goldenDocs {
+		goldenDocs[i] = normalizeWithPath(goldenDocs[i], nil)
+		if arr, ok := goldenDocs[i].([]any); ok {
+            goldenDocs[i] = sortTopLevelArray(arr)
+        }
+	}
+	for i := range gotDocs {
+		gotDocs[i] = normalizeWithPath(gotDocs[i], nil)
+		if arr, ok := gotDocs[i].([]any); ok {
+            gotDocs[i] = sortTopLevelArray(arr)
+        }
+	}
+
+	if !cmp.Equal(goldenDocs, gotDocs) {
+		return fmt.Errorf("YAML differs in %q:\n%s", relPath, cmp.Diff(goldenDocs, gotDocs))
+	}
+
+	return nil
+}
+ 
+// CompareDirectoryYAMLSemanticsUnordered compares YAML semantics for all matching
+// files in two directories treating arrays as unordered sets, so patch ordering
+// differences between runs do not cause false failures.
+func CompareDirectoryYAMLSemanticsUnordered(goldenDir, gotDir string) error {
+	if err := CompareDirectoryFileSets(goldenDir, gotDir); err != nil {
+		return err
+	}
+
+	relativeFilePaths, err := ListFilesRecursivelyAsList(goldenDir)
+	if err != nil {
+		return fmt.Errorf("list files in golden directory %q: %w", goldenDir, err)
+	}
+
+	for _, relativeFilePath := range relativeFilePaths {
+		goldenPath := filepath.Join(goldenDir, relativeFilePath)
+		gotPath := filepath.Join(gotDir, relativeFilePath)
+		goldenBytes, err := os.ReadFile(goldenPath)
+		if err != nil {
+			return fmt.Errorf("read golden file %q: %w", goldenPath, err)
+		}
+		gotBytes, err := os.ReadFile(gotPath)
+		if err != nil {
+			return fmt.Errorf("read got file %q: %w", gotPath, err)
+		}
+		if err := compareYAMLFileBytesUnordered(relativeFilePath, goldenBytes, gotBytes); err != nil {
+			return fmt.Errorf("compare YAML file %q: %w", relativeFilePath, err)
+		}
+	}
+	return nil
+
+}
 // CompareDirectoryYAMLSemanticsExport compares export YAML semantics using
 // normalization and resource-identity grouping instead of strict filename matching.
 // This avoids false diffs caused by unstable export filenames (for example, Pod or

--- a/e2e-tests/utils/utils.go
+++ b/e2e-tests/utils/utils.go
@@ -229,6 +229,7 @@ func compareDirectoryYAMLSemanticsWithFunc(goldenDir, gotDir string, compareFunc
 
 // CompareDirectoryYAMLSemantics compares YAML semantics for all matching files in
 // two directories using strict file-set equality and no export-specific normalization.
+// This is intended for stable outputs (for example transform/output artifacts).
 func CompareDirectoryYAMLSemantics(goldenDir, gotDir string) error {
 	return compareDirectoryYAMLSemanticsWithFunc(goldenDir, gotDir, compareYAMLFileBytes)
 }
@@ -239,8 +240,11 @@ func sortTopLevelArray(arr []any) []any {
 	sorted := make([]any, len(arr))
 	copy(sorted, arr)
 	sort.Slice(sorted, func(i, j int) bool {
-		a, _ := json.Marshal(sorted[i])
-		b, _ := json.Marshal(sorted[j])
+		a, errA := json.Marshal(sorted[i])
+		b, errB := json.Marshal(sorted[j])
+		if errA != nil || errB != nil {
+			return false
+		}
 		return string(a) < string(b)
 	})
 	return sorted

--- a/e2e-tests/utils/utils.go
+++ b/e2e-tests/utils/utils.go
@@ -199,18 +199,16 @@ func CompareDirectoryFileSets(goldenDir, gotDir string) error {
 	return nil
 }
 
-// CompareDirectoryYAMLSemantics compares YAML semantics for all matching files in
-// two directories using strict file-set equality and no export-specific normalization.
-func CompareDirectoryYAMLSemantics(goldenDir, gotDir string) error {
+// compareDirectoryYAMLSemanticsWithFunc is the shared implementation for directory YAML
+// comparison, parameterized by the per-file comparison function.
+func compareDirectoryYAMLSemanticsWithFunc(goldenDir, gotDir string, compareFunc func(string, []byte, []byte) error) error {
 	if err := CompareDirectoryFileSets(goldenDir, gotDir); err != nil {
 		return err
 	}
-
 	relativeFilePaths, err := ListFilesRecursivelyAsList(goldenDir)
 	if err != nil {
 		return fmt.Errorf("list files in golden directory %q: %w", goldenDir, err)
 	}
-
 	for _, relativeFilePath := range relativeFilePaths {
 		goldenPath := filepath.Join(goldenDir, relativeFilePath)
 		gotPath := filepath.Join(gotDir, relativeFilePath)
@@ -222,11 +220,17 @@ func CompareDirectoryYAMLSemantics(goldenDir, gotDir string) error {
 		if err != nil {
 			return fmt.Errorf("read got file %q: %w", gotPath, err)
 		}
-		if err := compareYAMLFileBytes(relativeFilePath, goldenBytes, gotBytes); err != nil {
+		if err := compareFunc(relativeFilePath, goldenBytes, gotBytes); err != nil {
 			return fmt.Errorf("compare YAML file %q: %w", relativeFilePath, err)
 		}
 	}
 	return nil
+}
+
+// CompareDirectoryYAMLSemantics compares YAML semantics for all matching files in
+// two directories using strict file-set equality and no export-specific normalization.
+func CompareDirectoryYAMLSemantics(goldenDir, gotDir string) error {
+	return compareDirectoryYAMLSemanticsWithFunc(goldenDir, gotDir, compareYAMLFileBytes)
 }
 
 // sortTopLevelArray returns a sorted copy of arr by canonical JSON representation of
@@ -279,32 +283,7 @@ func compareYAMLFileBytesUnordered(relPath string, golden, got []byte) error {
 // files in two directories treating arrays as unordered sets, so patch ordering
 // differences between runs do not cause false failures.
 func CompareDirectoryYAMLSemanticsUnordered(goldenDir, gotDir string) error {
-	if err := CompareDirectoryFileSets(goldenDir, gotDir); err != nil {
-		return err
-	}
-
-	relativeFilePaths, err := ListFilesRecursivelyAsList(goldenDir)
-	if err != nil {
-		return fmt.Errorf("list files in golden directory %q: %w", goldenDir, err)
-	}
-
-	for _, relativeFilePath := range relativeFilePaths {
-		goldenPath := filepath.Join(goldenDir, relativeFilePath)
-		gotPath := filepath.Join(gotDir, relativeFilePath)
-		goldenBytes, err := os.ReadFile(goldenPath)
-		if err != nil {
-			return fmt.Errorf("read golden file %q: %w", goldenPath, err)
-		}
-		gotBytes, err := os.ReadFile(gotPath)
-		if err != nil {
-			return fmt.Errorf("read got file %q: %w", gotPath, err)
-		}
-		if err := compareYAMLFileBytesUnordered(relativeFilePath, goldenBytes, gotBytes); err != nil {
-			return fmt.Errorf("compare YAML file %q: %w", relativeFilePath, err)
-		}
-	}
-	return nil
-
+	return compareDirectoryYAMLSemanticsWithFunc(goldenDir, gotDir, compareYAMLFileBytesUnordered)
 }
 
 // CompareDirectoryYAMLSemanticsExport compares export YAML semantics using

--- a/e2e-tests/utils/utils.go
+++ b/e2e-tests/utils/utils.go
@@ -440,6 +440,9 @@ func buildNormalizedExportIndex(dir string) (map[string][]exportIndexedDoc, erro
 		for i, doc := range docs {
 			identity, err := extractResourceIdentity(doc)
 			if err != nil {
+				if strings.Contains(relativeFilePath, "failures/") {
+					continue
+				}
 				return nil, fmt.Errorf("extract identity for %q doc #%d: %w", relativeFilePath, i+1, err)
 			}
 			normalized := normalizeUnstableFields(doc)

--- a/e2e-tests/utils/utils_test.go
+++ b/e2e-tests/utils/utils_test.go
@@ -1458,3 +1458,182 @@ func TestNormalizeUnstableFields(t *testing.T) {
 		})
 	}
 }
+
+func TestSortTopLevelArray(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    []any
+		expected []any
+	}{
+		{
+			name:     "already_sorted",
+			input:    []any{"a", "b", "c"},
+			expected: []any{"a", "b", "c"},
+		},
+		{
+			name:     "different_order",
+			input:    []any{"c", "a", "b"},
+			expected: []any{"a", "b", "c"},
+		},
+		{
+			name:     "empty",
+			input:    []any{},
+			expected: []any{},
+		},
+		{
+			name:     "nested_maps",
+			input:    []any{map[string]any{"z": 1}, map[string]any{"a": 1}},
+			expected: []any{map[string]any{"a": 1}, map[string]any{"z": 1}},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			result := sortTopLevelArray(tc.input)
+			if !cmp.Equal(tc.expected, result) {
+				t.Fatalf("sortTopLevelArray(%v): got %v, want %v", tc.input, result, tc.expected)
+			}
+		})
+	}
+}
+func TestCompareYAMLFileBytesUnordered(t *testing.T) {
+	cases := []struct {
+		name        string
+		relPath     string
+		golden      []byte
+		got         []byte
+		wantErr     bool
+		errContains []string
+	}{
+		{
+			name:    "identical_order",
+			relPath: "patches.yaml",
+			golden:  []byte("- a: 1\n- b: 2\n"),
+			got:     []byte("- a: 1\n- b: 2\n"),
+		},
+		{
+			name:    "different_order",
+			relPath: "patches.yaml",
+			golden:  []byte("- a: 1\n- b: 2\n"),
+			got:     []byte("- b: 2\n- a: 1\n"),
+		},
+		{
+			name:    "non_array_root",
+			relPath: "cm.yaml",
+			golden:  []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\n"),
+			got:     []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\n"),
+		},
+		{
+			name:        "semantic_mismatch",
+			relPath:     "patches.yaml",
+			golden:      []byte("- a: 1\n"),
+			got:         []byte("- a: 2\n"),
+			wantErr:     true,
+			errContains: []string{"YAML differs"},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := compareYAMLFileBytesUnordered(tc.relPath, tc.golden, tc.got)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				for _, s := range tc.errContains {
+					if !strings.Contains(err.Error(), s) {
+						t.Fatalf("error %q does not contain %q", err.Error(), s)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("compareYAMLFileBytesUnordered: %v", err)
+			}
+		})
+	}
+}
+func TestCompareDirectoryYAMLSemanticsUnordered(t *testing.T) {
+	write := func(t *testing.T, dir, rel, content string) {
+		t.Helper()
+		path := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cases := []struct {
+		name        string
+		build       func(t *testing.T) (string, string)
+		wantErr     bool
+		errContains []string
+	}{
+		{
+			name: "identical_content",
+			build: func(t *testing.T) (string, string) {
+				golden, got := t.TempDir(), t.TempDir()
+				write(t, golden, "patches.yaml", "- a: 1\n- b: 2\n")
+				write(t, got, "patches.yaml", "- a: 1\n- b: 2\n")
+				return golden, got
+			},
+		},
+		{
+			name: "different_array_order",
+			build: func(t *testing.T) (string, string) {
+				golden, got := t.TempDir(), t.TempDir()
+				write(t, golden, "patches.yaml", "- a: 1\n- b: 2\n")
+				write(t, got, "patches.yaml", "- b: 2\n- a: 1\n")
+				return golden, got
+			},
+		},
+		{
+			name: "semantic_mismatch",
+			build: func(t *testing.T) (string, string) {
+				golden, got := t.TempDir(), t.TempDir()
+				write(t, golden, "patches.yaml", "- a: 1\n")
+				write(t, got, "patches.yaml", "- a: 2\n")
+				return golden, got
+			},
+			wantErr:     true,
+			errContains: []string{"YAML differs"},
+		},
+		{
+			name: "file_set_mismatch",
+			build: func(t *testing.T) (string, string) {
+				golden, got := t.TempDir(), t.TempDir()
+				write(t, golden, "only-golden.yaml", "a: 1\n")
+				write(t, got, "only-got.yaml", "a: 1\n")
+				return golden, got
+			},
+			wantErr:     true,
+			errContains: []string{"file sets differ"},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			goldenDir, gotDir := tc.build(t)
+			err := CompareDirectoryYAMLSemanticsUnordered(goldenDir, gotDir)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				for _, s := range tc.errContains {
+					if !strings.Contains(err.Error(), s) {
+						t.Fatalf("error %q does not contain %q", err.Error(), s)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("CompareDirectoryYAMLSemanticsUnordered: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
###  **MTA-843**: Pipeline Determinism E2E Test

#### Description
Adds an E2E test case to verify that running the full Crane pipeline consecutively on the same namespace produces identical outputs at every stage: `export`, `transform`, and `apply`.

#### How it works
* Runs the `export` ➔ `transform` ➔ `apply` pipeline twice on the same quiesced namespace.
* Compares the results across all stages using semantic YAML verification to ensure determinism and prevent dynamic/mutable fields leakage.

#### Verification Logic
* **Export stage:** `utils.CompareDirectoryYAMLSemanticsExport` - semantic comparison with normalization of dynamic fields; on OpenShift uses `CompareDirectoryYAMLSemanticsExportAllowOptionalOCPOutputDefaults`
* **Transform stage:** `utils.CompareDirectoryYAMLSemanticsUnordered` - semantic comparison that treats top-level YAML arrays as unordered sets, so non-deterministic patch operation ordering in `KubernetesPlugin` does not cause false failures
* **Output stage:** `utils.CompareDirectoryYAMLSemantics` - standard semantic comparison; `output.yaml` is fully deterministic between runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end determinism test to ensure the crane export → transform → apply pipeline yields identical results across consecutive runs.
  * Extended YAML comparison coverage with new unit and directory-level tests for unordered matching, including order-insensitive handling of top-level arrays.
* **Bug Fixes**
  * Improved YAML directory validation to be order-independent where appropriate, reducing false differences when YAML top-level list ordering changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->