### PR TITLE
:bug: Replace transform --force flag with --overwrite

### DIFF
--- a/cmd/transform/transform.go
+++ b/cmd/transform/transform.go
@@ -348,8 +348,8 @@ func (o *Options) runStageWithCleanup(orchestrator *internalTransform.Orchestrat
 
 // reconcileInstructionStages compares discovered stage directories in transform/
 // against the desired stage names generated from --instructions-file.
-// Without --force, it fails if extra stage directories are found.
-// With --force, it deletes those extra stage directories so transform/
+// Without --overwrite, it fails if extra stage directories are found.
+// With --overwrite, it deletes those extra stage directories so transform/
 // matches the instructions-defined stage set.
 func (o *Options) reconcileInstructionStages(transformDir string, desiredStages []string, log *logrus.Logger) error {
 	existingStages, err := internalTransform.DiscoverStages(transformDir)

--- a/cmd/transform/transform.go
+++ b/cmd/transform/transform.go
@@ -46,7 +46,7 @@ type Flags struct {
 	IgnoredPatchesDir string   `mapstructure:"ignored-patches-dir"`
 	SkipPlugins       []string `mapstructure:"skip-plugins"`
 	OptionalFlags     string   `mapstructure:"optional-flags"`
-	Force             bool     `mapstructure:"force"`
+	Overwrite         bool     `mapstructure:"overwrite"`
 	// Kustomize arguments
 	KustomizeArgs string `mapstructure:"kustomize-args"`
 	// Instructions file
@@ -159,7 +159,7 @@ func addFlagsForOptions(o *Flags, cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&o.TransformDir, "transform-dir", "t", "transform", "The path where files that contain the transformations are saved")
 	cmd.Flags().StringVar(&o.IgnoredPatchesDir, "ignored-patches-dir", "", "The path where files that contain transformations that were discarded due to conflicts are saved. If left blank, these files will not be saved.")
 	cmd.Flags().StringVar(&o.InstructionsFile, "instructions-file", "", "Path to the transform instructions file")
-	cmd.Flags().BoolVar(&o.Force, "force", false, "Force overwrite of existing stage directories even if they contain user modifications")
+	cmd.Flags().BoolVar(&o.Overwrite, "overwrite", false, "Overwrite existing stage directories even if they contain user modifications")
 
 	// Deprecated: optional-flags will be removed in a future version
 	cmd.Flags().StringVar(&o.OptionalFlags, "optional-flags", "", "(DEPRECATED) JSON string holding flag value pairs to be passed to all plugins. Use custom stages with kustomization instead. (ie. '{\"foo-flag\": \"foo-a=/data,foo-b=/data\", \"bar-flag\": \"bar-value\"}')")
@@ -231,7 +231,7 @@ func (o *Options) run() error {
 		PluginDir:          pluginDir,
 		SkipPlugins:        o.SkipPlugins,
 		OptionalFlags:      optionalFlags,
-		Force:              o.Force,
+		Overwrite:          o.Overwrite,
 		CraneVersion:       "v1.0.0", // TODO: Get from build version
 		NewlyCreatedStages: make(map[string]bool),
 		KustomizeArgs:      kustomizeArgs,
@@ -375,9 +375,9 @@ func (o *Options) reconcileInstructionStages(transformDir string, desiredStages 
 
 	sort.Strings(extras)
 
-	if !o.Force {
+	if !o.Overwrite {
 		return fmt.Errorf(
-			"stages in transform/ do not match --instructions-file: extra stage directories: %s. Re-run with --force to reconcile",
+			"stages in transform/ do not match --instructions-file: extra stage directories: %s. Re-run with --overwrite to reconcile",
 			strings.Join(extras, ", "),
 		)
 	}
@@ -431,9 +431,8 @@ func (o *Options) ensureStagesHaveOutput(orchestrator *internalTransform.Orchest
 			// Stage hasn't been run yet, run it
 			log.Infof("Stage %s hasn't been run yet, running it...", stage.DirName)
 
-			// Run the stage - it will regenerate based on its type:
-			// - Plugin stages: auto-regenerate (no --force needed)
-			// - Custom stages: fail if directory not empty (require --force)
+			// Run the stage - it will regenerate if needed
+			// All stages respect --overwrite flag when rewriting existing content
 			selector := internalTransform.StageSelector{Stages: []string{stage.DirName}}
 			if err := orchestrator.RunMultiStage(selector); err != nil {
 				return fmt.Errorf("failed to run stage %s: %w", stage.DirName, err)

--- a/cmd/transform/transform_test.go
+++ b/cmd/transform/transform_test.go
@@ -430,7 +430,7 @@ func TestCreateDefaultStagesForAllPlugins_PathTraversalProtection(t *testing.T) 
 
 // Tests from upstream for instructions file functionality
 
-func TestReconcileInstructionStages_Force(t *testing.T) {
+func TestReconcileInstructionStages_Overwrite(t *testing.T) {
 	tmpDir := t.TempDir()
 	transformDir := filepath.Join(tmpDir, "transform")
 	if err := os.MkdirAll(transformDir, 0755); err != nil {
@@ -447,7 +447,7 @@ func TestReconcileInstructionStages_Force(t *testing.T) {
 
 	o := &Options{
 		Flags: Flags{
-			Force: true,
+			Overwrite: true,
 		},
 	}
 

--- a/docs/kustomize-multistage.md
+++ b/docs/kustomize-multistage.md
@@ -117,17 +117,16 @@ This creates a `10_KubernetesPlugin` stage directory and runs all plugins (inclu
 
 **Plugin Filtering** (optional):
 
-To run only specific plugins:
+To run only specific stages:
 
 ```bash
 crane transform \
   --export-dir export \
   --transform-dir transform \
-  --stage-name 10_KubernetesPlugin \
-  --plugin-name kubernetes
+  10_KubernetesPlugin
 ```
 
-**Note**: When `--plugin-name` is omitted (default), ALL available plugins are used. This is recommended to ensure proper resource cleanup.
+**Note**: When no stages are specified, ALL discovered stages are run. This is recommended to ensure proper resource cleanup.
 
 #### Multi-Stage Mode
 
@@ -135,15 +134,15 @@ Execute specific stages:
 
 ```bash
 # Run a specific stage
-crane transform --stage 20_OpenshiftPlugin
+crane transform 20_OpenshiftPlugin
 ```
 
-#### Force Overwrite
+#### Overwrite Existing Stages
 
 Override dirty check protection:
 
 ```bash
-crane transform --force --stage-name 10_KubernetesPlugin
+crane transform --overwrite 10_KubernetesPlugin
 ```
 
 ### Apply Command
@@ -244,20 +243,17 @@ crane export --kubeconfig source.yaml --export-dir export
 crane transform \
   --export-dir export \
   --transform-dir transform \
-  --stage-name 10_KubernetesPlugin \
-  --plugin-name kubernetes
+  10_KubernetesPlugin
 
 # Create OpenShift-specific transformations
 crane transform \
   --transform-dir transform \
-  --stage-name 20_OpenshiftPlugin \
-  --plugin-name openshift
+  20_OpenshiftPlugin
 
 # Create ImageStream transformations
 crane transform \
   --transform-dir transform \
-  --stage-name 30_ImagestreamPlugin \
-  --plugin-name imagestream
+  30_ImagestreamPlugin
 
 # Apply final stage
 crane apply --transform-dir transform --output-dir output
@@ -277,10 +273,10 @@ crane transform --export-dir export --transform-dir transform
 # Error: contains user modifications
 
 # Force overwrite if needed
-crane transform --export-dir export --transform-dir transform --force
+crane transform --export-dir export --transform-dir transform --overwrite
 
 # Or preserve changes by using a different stage name
-crane transform --stage-name 20_custom
+crane transform 20_custom
 ```
 
 ## Migration from JSONPatch Workflow
@@ -371,8 +367,8 @@ if err != nil {
 **Cause**: Stage directory has been manually edited after creation.
 
 **Solution**:
-1. Use `--force` to overwrite changes
-2. Use a different `--stage-name` to preserve changes
+1. Use `--overwrite` to overwrite changes
+2. Use a different stage name to preserve changes
 3. Commit changes to Git before re-running transform
 
 ### Issue: Apply fails with "kustomization.yaml validation failed"
@@ -487,9 +483,9 @@ Stages don't have to correspond to a plugin. If a stage directory name doesn't m
 
 ```bash
 # Create a multi-stage pipeline
-crane transform --stage-name 10_KubernetesPlugin   # Plugin-backed
-crane transform --stage-name 50_ManualEdits        # No matching plugin
-crane transform --stage-name 90_FinalCleanup       # No matching plugin
+crane transform 10_KubernetesPlugin   # Plugin-backed
+crane transform 50_ManualEdits        # No matching plugin
+crane transform 90_FinalCleanup       # No matching plugin
 ```
 
 **What happens:**

--- a/docs/stateless-migration-quickstart.md
+++ b/docs/stateless-migration-quickstart.md
@@ -145,10 +145,10 @@ In most pipelines, your custom stage is the last stage under `transform/`, so re
 
 For a deeper explanation of stage ordering, stage structure, and multi-stage behavior, see [Multi-Stage Kustomize Transform Pipeline](./multistage-pipeline.md).
 
-If a custom stage already contains edits, rerun with `--force` to regenerate the custom stage directories and custom stage artifacts under `transform/` (for example: `input/`, `output/`, `kustomization.yaml`):
+If a custom stage already contains edits, rerun with `--overwrite` to regenerate the custom stage directories and custom stage artifacts under `transform/` (for example: `input/`, `output/`, `kustomization.yaml`):
 
 ```bash
-crane transform -e export -t transform --force
+crane transform -e export -t transform --overwrite
 ```
 
 ## 5) Apply (Render Final Manifests)
@@ -311,7 +311,7 @@ Use `--overwrite` with `crane apply` or `crane validate`.
 
 ### Existing custom stage blocks rerun
 
-Use `crane transform --force` to regenerate stage directories.
+Use `crane transform --overwrite` to regenerate stage directories.
 
 ### Validation shows incompatibilities
 

--- a/docs/transform.md
+++ b/docs/transform.md
@@ -66,7 +66,7 @@ kubectl apply -k transform/10_KubernetesPlugin/
 
 **Important**: 
 - **Plugin stages** (ending with `Plugin`): Automatically regenerate on rerun - your manual edits will be overwritten
-- **Custom stages** (not ending with `Plugin`): Refuse to overwrite without `--force` flag to protect your edits
+- **Custom stages** (not ending with `Plugin`): Refuse to overwrite without `--overwrite` flag to protect your edits
 
 ## Multi-Stage Pipelines
 
@@ -127,15 +127,15 @@ transform/*/output/
 crane transform
 
 # Run specific stage only (creates it if doesn't exist)
-crane transform --stage 10_KubernetesPlugin
+crane transform 10_KubernetesPlugin
 
 # Create a new plugin-based stage automatically
 # Stage name ending with "Plugin" will use that plugin
-crane transform --stage 35_OpenshiftPlugin
+crane transform 35_OpenshiftPlugin
 
 # Create a new pass-through stage for manual editing
 # Stage name NOT ending with "Plugin" creates empty pass-through
-crane transform --stage 40_CustomManualEdits
+crane transform 40_CustomManualEdits
 ```
 
 ### Applying Transforms
@@ -168,7 +168,7 @@ output/
 
 ## Automatic Stage Creation
 
-Crane automatically creates new stages when you reference them with `--stage`. The stage name determines whether a plugin will be used or if it's a pass-through stage for manual editing.
+Crane automatically creates new stages when you reference them as positional arguments. The stage name determines whether a plugin will be used or if it's a pass-through stage for manual editing.
 
 ### Stage Naming Convention
 
@@ -190,7 +190,7 @@ Stage names ending with `Plugin` **must** have a corresponding plugin installed.
 
 ```bash
 # Creates a stage using OpenshiftPlugin
-crane transform --stage 20_OpenshiftPlugin
+crane transform 20_OpenshiftPlugin
 
 # Output:
 # - resources/ (from previous stage or export)
@@ -201,7 +201,7 @@ crane transform --stage 20_OpenshiftPlugin
 **If the plugin doesn't exist, you'll get an error:**
 
 ```bash
-crane transform --stage 20_NonexistentPlugin
+crane transform 20_NonexistentPlugin
 # Error: stage 20_NonexistentPlugin requires plugin 'NonexistentPlugin' 
 #        but it was not found (available plugins: KubernetesPlugin, NamespaceCleanup)
 ```
@@ -212,7 +212,7 @@ Stage names **not** ending with `Plugin` create pass-through stages where resour
 
 ```bash
 # Creates a pass-through stage for manual editing
-crane transform --stage 30_CustomEdits
+crane transform 30_CustomEdits
 
 # Output:
 # - resources/ (copied unchanged from previous stage)
@@ -232,18 +232,18 @@ EOF
 
 # Update kustomization.yaml to reference the patch
 # Then run transform to apply it
-# Note: Custom stage requires --force to overwrite (protects your edits)
-crane transform --force
+# Note: Custom stage requires --overwrite to overwrite (protects your edits)
+crane transform --overwrite
 ```
 
-**Important**: Custom stages (not ending with `Plugin`) are protected from accidental overwrites. You must use `--force` to regenerate them.
+**Important**: Custom stages (not ending with `Plugin`) are protected from accidental overwrites. You must use `--overwrite` to regenerate them.
 
 **Best Practice**: Always add custom stages as the **last stage** in your pipeline. This ensures that:
 - The `resources/` directory contains the most up-to-date output from all previous stages
 - You're editing the final state of resources after all plugin transformations
 - Re-running earlier plugin stages won't leave your custom stage with stale data
 
-If you add a custom stage in the middle of the pipeline and later update an earlier stage, you'll need to use `--force` to refresh the custom stage's `resources/` directory with the updated output. **Warning**: Using `--force` will delete the entire stage directory including any manual changes you made to `resources/`, `patches/`, and `kustomization.yaml`.
+If you add a custom stage in the middle of the pipeline and later update an earlier stage, you'll need to use `--overwrite` to refresh the custom stage's `resources/` directory with the updated output. **Warning**: Using `--overwrite` will delete the entire stage directory including any manual changes you made to `resources/`, `patches/`, and `kustomization.yaml`.
 
 ## Directory Contents Explained
 
@@ -324,7 +324,7 @@ kubectl kustomize transform/10_KubernetesPlugin/ > review.yaml
 
 ```bash
 # Create a custom stage for manual edits
-crane transform --stage 40_CustomEdits
+crane transform 40_CustomEdits
 
 # Edit resources
 vi transform/40_CustomEdits/resources/Deployment_apps_v1_default_wordpress.yaml
@@ -347,14 +347,14 @@ vi transform/40_CustomEdits/kustomization.yaml
 crane transform
 
 # Plugin stages (ending with "Plugin") regenerate automatically
-# Custom stages (not ending with "Plugin") require --force to overwrite
-crane transform --force
+# Custom stages (not ending with "Plugin") require --overwrite to overwrite
+crane transform --overwrite
 
 # Run specific plugin stage (regenerates automatically)
-crane transform --stage 10_KubernetesPlugin
+crane transform 10_KubernetesPlugin
 
-# Run specific custom stage (requires --force if directory not empty)
-crane transform --stage 40_CustomEdits --force
+# Run specific custom stage (requires --overwrite if directory not empty)
+crane transform 40_CustomEdits --overwrite
 ```
 
 ### 4. Working with Multiple Stages
@@ -364,18 +364,18 @@ crane transform --stage 40_CustomEdits --force
 crane transform
 
 # Automatically add more plugin stages
-crane transform --stage 20_OpenshiftPlugin
-crane transform --stage 30_ImagestreamPlugin
+crane transform 20_OpenshiftPlugin
+crane transform 30_ImagestreamPlugin
 
 # Add a manual editing stage
-crane transform --stage 40_CustomEdits
+crane transform 40_CustomEdits
 
 # Edit the manual stage (example: edit a specific deployment)
 vi transform/40_CustomEdits/resources/Deployment_apps_v1_default_wordpress.yaml
 
 # Run all stages sequentially
-# Note: requires --force for custom stages
-crane transform --force
+# Note: requires --overwrite for custom stages
+crane transform --overwrite
 
 # Apply all stages
 crane apply --transform-dir transform --output-dir output
@@ -392,11 +392,11 @@ crane transform
 # Creates: 10_KubernetesPlugin/
 
 # 3. Add OpenShift-specific transformations
-crane transform --stage 20_OpenshiftPlugin
+crane transform 20_OpenshiftPlugin
 # Creates: 20_OpenshiftPlugin/ using OpenshiftPlugin
 
 # 4. Add a manual customization stage
-crane transform --stage 50_CustomLabels
+crane transform 50_CustomLabels
 # Creates: 50_CustomLabels/ as pass-through (resources copied from previous stage)
 
 # 5. Manually add custom labels
@@ -411,8 +411,8 @@ vi transform/50_CustomLabels/kustomization.yaml
 
 # 6. Run the entire pipeline
 # Note: 10_KubernetesPlugin and 20_OpenshiftPlugin regenerate automatically
-# 50_CustomLabels will fail unless --force is used (protects manual edits)
-crane transform --force
+# 50_CustomLabels will fail unless --overwrite is used (protects manual edits)
+crane transform --overwrite
 
 # 7. Verify the output
 kubectl kustomize transform/50_CustomLabels/
@@ -460,23 +460,23 @@ git diff --staged transform/10_KubernetesPlugin/patches/
 
 ## Troubleshooting
 
-### "Stage directory is not empty (use --force to overwrite)"
+### "Stage directory is not empty (use --overwrite to overwrite)"
 
 **Problem**: Crane detects a custom stage already exists and refuses to overwrite to protect manual edits.
 
 **Solution**:
 ```bash
-# Option 1: Use force flag to overwrite
-crane transform --force
+# Option 1: Use overwrite flag to overwrite
+crane transform --overwrite
 
 # Option 2: Check what changed
 git diff transform/
 
 # Option 3: Only regenerate plugin stages (they auto-regenerate)
-crane transform --stage 10_KubernetesPlugin
+crane transform 10_KubernetesPlugin
 
-# Note: Plugin stages (ending with "Plugin") regenerate automatically without --force
-# Custom stages (not ending with "Plugin") require --force to protect manual edits
+# Note: Plugin stages (ending with "Plugin") regenerate automatically without --overwrite
+# Custom stages (not ending with "Plugin") require --overwrite to protect manual edits
 ```
 
 ### "kustomization.yaml validation failed"

--- a/e2e-tests/framework/crane.go
+++ b/e2e-tests/framework/crane.go
@@ -50,7 +50,7 @@ type TransformOptions struct {
 	IgnoredPatchesDir string
 	SkipPlugins       []string
 	OptionalFlags     string
-	Force             bool
+	Overwrite         bool
 	KustomizeArgs     string
 	InstructionsFile  string
 	Stages            []string
@@ -126,8 +126,8 @@ func (c CraneRunner) Transform(opts TransformOptions) error {
 	if opts.OptionalFlags != "" {
 		args = append(args, "--optional-flags", opts.OptionalFlags)
 	}
-	if opts.Force {
-		args = append(args, "--force")
+	if opts.Overwrite {
+		args = append(args, "--overwrite")
 	}
 	if opts.KustomizeArgs != "" {
 		args = append(args, "--kustomize-args", opts.KustomizeArgs)

--- a/e2e-tests/tests/tier0/mta_828_instructions_file_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_828_instructions_file_migration_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Instructions-file migration", func() {
 		instructionsFile, err := utils.TestdataFilePath("basic-instructions-file.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(runner.Transform(TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
-			InstructionsFile: instructionsFile, Force: false})).NotTo(HaveOccurred())
+			InstructionsFile: instructionsFile, Overwrite: false})).NotTo(HaveOccurred())
 
 		By("Assert instructions-file stages are present as stage-directories in transform dir")
 		stageDirectories := []string{"10_KubernetesPlugin", "20_CustomStage"}

--- a/e2e-tests/tests/tier1/mta_830_instructions_file_force_reconcile_test.go
+++ b/e2e-tests/tests/tier1/mta_830_instructions_file_force_reconcile_test.go
@@ -13,8 +13,8 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Instructions-file force reconcile migration", func() {
-	It("[MTA-830] should reconcile pre-existing transform stages with --force and complete end-to-end migration", Label("tier1"), func() {
+var _ = Describe("Instructions-file overwrite reconcile migration", func() {
+	It("[MTA-830] should reconcile pre-existing transform stages with --overwrite and complete end-to-end migration", Label("tier1"), func() {
 
 		appName := "simple-nginx-nopv"
 		namespace := "simple-nginx-force-reconcile"
@@ -71,15 +71,15 @@ var _ = Describe("Instructions-file force reconcile migration", func() {
 		By("Create transform dir with orphan stage and existing stage present in instructions-file")
 		err = os.MkdirAll(paths.TransformDir, 0o755)
 		Expect(err).NotTo(HaveOccurred())
-		//Create orphan stage directory for extra stage that should be deleted with --force
+		//Create orphan stage directory for extra stage that should be deleted with --overwrite
 		orphanStagePath := filepath.Join(paths.TransformDir, "99_OrphanStage")
 		err = os.MkdirAll(orphanStagePath, 0o755)
 		Expect(err).NotTo(HaveOccurred())
-		// Create orphan output directory within stage that should also be deleted with --force
+		// Create orphan output directory within stage that should also be deleted with --overwrite
 		orphanOutputPath := filepath.Join(paths.TransformDir, "99_OrphanStage", "output")
 		err = os.MkdirAll(orphanOutputPath, 0o755)
 		Expect(err).NotTo(HaveOccurred())
-		//Create path for CustomStage that should be overwritten with --force
+		//Create path for CustomStage that should be overwritten with --overwrite
 		customStagePath := filepath.Join(paths.TransformDir, "20_CustomStage")
 		err = os.MkdirAll(customStagePath, 0o755)
 		Expect(err).NotTo(HaveOccurred())
@@ -111,20 +111,20 @@ var _ = Describe("Instructions-file force reconcile migration", func() {
 		instructionsFile, err := utils.TestdataFilePath("basic-instructions-file.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(runner.Transform(TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
-			InstructionsFile: instructionsFile, Force: true})).NotTo(HaveOccurred())
+			InstructionsFile: instructionsFile, Overwrite: true})).NotTo(HaveOccurred())
 
 		By("Assert post transform orphan stage is removed and existing CustomStage is overwritten ")
-		By("Assert orphan stage dir is removed by --force")
+		By("Assert orphan stage dir is removed by --overwrite")
 		_, err = os.Stat(orphanStagePath)
-		Expect(os.IsNotExist(err)).To(BeTrue(), "expected orphan stage to be removed by --force")
+		Expect(os.IsNotExist(err)).To(BeTrue(), "expected orphan stage to be removed by --overwrite")
 
-		By("Assert orphan stage (including output dir) is removed by --force")
+		By("Assert orphan stage (including output dir) is removed by --overwrite")
 		_, err = os.Stat(orphanOutputPath)
-		Expect(os.IsNotExist(err)).To(BeTrue(), "expected orphan stage output dir to be removed by --force")
+		Expect(os.IsNotExist(err)).To(BeTrue(), "expected orphan stage output dir to be removed by --overwrite")
 
-		By("Assert preexisting custom stage file is removed by --force")
+		By("Assert preexisting custom stage file is removed by --overwrite")
 		_, err = os.Stat(customStageExistingFilePath)
-		Expect(os.IsNotExist(err)).To(BeTrue(), "expected preexisting custom stage file to be removed by --force")
+		Expect(os.IsNotExist(err)).To(BeTrue(), "expected preexisting custom stage file to be removed by --overwrite")
 
 		By("Assert instructions-file stages are present as stage-directories in transform dir")
 		stageDirectories := []string{"10_KubernetesPlugin", "20_CustomStage"}

--- a/internal/transform/orchestrator.go
+++ b/internal/transform/orchestrator.go
@@ -27,7 +27,7 @@ type Orchestrator struct {
 	PluginDir      string
 	SkipPlugins    []string
 	OptionalFlags  map[string]string
-	Force          bool
+	Overwrite      bool
 	CraneVersion   string
 	// NewlyCreatedStages tracks stages created in this run that can be overwritten
 	// This prevents double-write errors when creating a stage and then running it
@@ -159,25 +159,20 @@ func (o *Orchestrator) executeStage(stage Stage, inputResources []unstructured.U
 	}
 
 	// Determine write behavior based on stage type
-	// Plugin stages: always allow overwrite (auto-regenerate)
-	// Custom stages: require --force flag
-	// Newly created stages: always allow overwrite
+	// Newly created stages: always allow overwrite (just created, safe to populate)
+	// All other stages: respect --overwrite flag
 	var forceWrite bool
 	if o.NewlyCreatedStages != nil && o.NewlyCreatedStages[stage.DirName] {
 		// Stage was just created in this run: safe to populate
 		forceWrite = true
 		o.Log.Debugf("Stage %s: allowing write (newly created in this run)", stage.DirName)
-	} else if strings.HasSuffix(stage.PluginName, "Plugin") {
-		// Plugin-based stage: automatically regenerate
-		forceWrite = true
-		o.Log.Debugf("Stage %s: allowing write (plugin-based stage auto-regeneration)", stage.DirName)
 	} else {
-		// Custom stage: respect --force flag
-		forceWrite = o.Force
+		// All stages (plugin and custom): respect --overwrite flag
+		forceWrite = o.Overwrite
 		if forceWrite {
-			o.Log.Debugf("Stage %s: allowing write (--force flag for custom stage)", stage.DirName)
+			o.Log.Debugf("Stage %s: allowing write (--overwrite flag set)", stage.DirName)
 		} else {
-			o.Log.Debugf("Stage %s: checking for empty directory (custom stage without --force)", stage.DirName)
+			o.Log.Debugf("Stage %s: checking for empty directory (no --overwrite flag)", stage.DirName)
 		}
 	}
 

--- a/internal/transform/orchestrator_test.go
+++ b/internal/transform/orchestrator_test.go
@@ -162,7 +162,7 @@ resources: []
 		ExportDir:    exportDir,
 		TransformDir: transformDir,
 		PluginDir:    "/nonexistent", // Won't be used in this test
-		Force:        true,             // Use force to overwrite existing directories
+		Overwrite:        true,             // Use overwrite to overwrite existing directories
 	}
 
 	tests := []struct {
@@ -277,7 +277,7 @@ resources:
 		ExportDir:    exportDir,
 		TransformDir: transformDir,
 		PluginDir:    "/nonexistent",
-		Force:        false,
+		Overwrite:        false,
 	}
 
 	// Test: Try to run stage 20 which should depend on stage 10
@@ -702,7 +702,7 @@ resources: []
 		ExportDir:    exportDir,
 		TransformDir: transformDir,
 		PluginDir:    "/nonexistent", // No plugins
-		Force:        true,
+		Overwrite:        true,
 	}
 
 	// Execute multi-stage pipeline
@@ -1533,7 +1533,7 @@ data:
 		ExportDir:    exportDir,
 		TransformDir: transformDir,
 		PluginDir:    "/nonexistent",
-		Force:        true,
+		Overwrite:        true,
 	}
 
 	// Test 1: No stages found
@@ -1726,7 +1726,7 @@ resources:
 		ExportDir:    exportDir,
 		TransformDir: transformDir,
 		PluginDir:    "/nonexistent",
-		Force:        true,
+		Overwrite:        true,
 	}
 
 	selector := StageSelector{} // Run all stages

--- a/internal/transform/writer.go
+++ b/internal/transform/writer.go
@@ -402,7 +402,7 @@ func (w *KustomizeWriter) checkStageDirectory(stageDir string) error {
 	}
 
 	if len(entries) > 0 {
-		return fmt.Errorf("stage directory %s is not empty (use --force to overwrite)", stageDir)
+		return fmt.Errorf("stage directory %s is not empty (use --overwrite to overwrite)", stageDir)
 	}
 
 	return nil


### PR DESCRIPTION
  Changes the crane transform command to use --overwrite flag instead of --force, aligning it with other crane commands (export, apply, validate).

  Key changes:

  - Renamed --force flag to --overwrite for consistency across all crane commands
  - Removed silent auto-overwrite behavior for plugin stages - all stages now require --overwrite flag when rewriting non-empty directories
  - Updated error messages to reference --overwrite instead of --force
  - Updated all tests and comments to reflect the new flag name

  Behavior:

  - Without --overwrite: Command fails if stage directories are not empty (both plugin and custom stages)
  - With --overwrite: Overwrites existing stage directories
  - Newly created stages: Can be populated immediately in the same run without requiring --overwrite

  Fixes #613

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced the old overwrite option with `--overwrite` in the transform command, updating overwrite behavior consistently across stage processing.
  * Updated the documented stage selection examples to use positional stage arguments (instead of prior flag-based examples).

* **Bug Fixes**
  * Improved the “stage directory already exists and isn’t empty” guidance to point to `--overwrite`.
  * Updated overwrite/reconciliation behavior to match the new option, including removal of previous force-specific handling.

* **Tests**
  * Updated unit and end-to-end tests to validate overwrite semantics with `Overwrite`/`--overwrite` instead of the prior `Force`/`--force`.

* **Documentation**
  * Refreshed transform and migration guides to use `--overwrite` in overwrite/retry workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->