### PR TITLE
:bug: fix rsync exit code handling

### DIFF
--- a/cmd/transfer-pvc/progress.go
+++ b/cmd/transfer-pvc/progress.go
@@ -91,6 +91,11 @@ func (r *rsyncLogStream) Init() error {
 			// sometimes, a stream would end without returning an EOF gracefully
 			// we force exit the loop when we see null bytes on stream consecutively
 			if zeroBytes > 4 {
+				code, finalLogs, e := getFinalPodStatus(clientset, podName, r.pvc.Namespace)
+				if e == nil {
+					r.progress.ExitCode = code
+					logString = finalLogs
+				}
 				err = io.EOF
 			}
 			logString = fmt.Sprintf("%s%s", logString, string(buf[:n]))
@@ -98,11 +103,10 @@ func (r *rsyncLogStream) Init() error {
 				err = readErr
 				// attempt to get a final status of terminated pod
 				code, finalLogs, e := getFinalPodStatus(clientset, podName, r.pvc.Namespace)
-				if e != nil {
-					err = e
+				if e == nil {
+					r.progress.ExitCode = code
+					logString = finalLogs
 				}
-				r.progress.ExitCode = code
-				logString = finalLogs
 			}
 			parsedProgress, unparsed := parseRsyncLogs(logString)
 			r.progress.Merge(parsedProgress)
@@ -259,7 +263,7 @@ func (p *Progress) AsString() (out string, err string) {
 			}
 		}
 		if len(p.Errors) > 0 {
-			errors := "Errors: \n"
+			errors = "Errors: \n"
 			for _, e := range p.Errors {
 				errors = fmt.Sprintf("%s - %s\n", errors, e)
 			}
@@ -512,9 +516,7 @@ func waitForPodRunning(c *kubernetes.Clientset, namespace string, labels map[str
 
 func getFinalPodStatus(c *kubernetes.Clientset, name string, namespace string) (*int32, string, error) {
 	var exitCode *int32
-	count := 0
-	for {
-		count += 1
+	for i := 0; i < 10; i++ {
 		pod, err := c.CoreV1().Pods(namespace).Get(context.Background(), name, metav1.GetOptions{})
 		if err != nil {
 			return nil, "", err
@@ -527,9 +529,10 @@ func getFinalPodStatus(c *kubernetes.Clientset, name string, namespace string) (
 				}
 			}
 		}
-		if count > 5 || exitCode != nil {
+		if exitCode != nil {
 			break
 		}
+		time.Sleep(time.Second)
 	}
 
 	lastLines := int64(35)

--- a/cmd/transfer-pvc/progress.go
+++ b/cmd/transfer-pvc/progress.go
@@ -101,11 +101,12 @@ func (r *rsyncLogStream) Init() error {
 			logString = fmt.Sprintf("%s%s", logString, string(buf[:n]))
 			if readErr == io.EOF {
 				err = readErr
-				// attempt to get a final status of terminated pod
-				code, finalLogs, e := getFinalPodStatus(clientset, podName, r.pvc.Namespace)
-				if e == nil {
-					r.progress.ExitCode = code
-					logString = finalLogs
+				if r.progress.ExitCode == nil {
+					code, finalLogs, e := getFinalPodStatus(clientset, podName, r.pvc.Namespace)
+					if e == nil {
+						r.progress.ExitCode = code
+						logString = finalLogs
+					}
 				}
 			}
 			parsedProgress, unparsed := parseRsyncLogs(logString)
@@ -519,7 +520,7 @@ func getFinalPodStatus(c *kubernetes.Clientset, name string, namespace string) (
 	for i := 0; i < 10; i++ {
 		pod, err := c.CoreV1().Pods(namespace).Get(context.Background(), name, metav1.GetOptions{})
 		if err != nil {
-			return nil, "", err
+			return nil, "", fmt.Errorf("failed to get pod %s/%s for final status: %w", namespace, name, err)
 		}
 
 		for _, container := range pod.Status.ContainerStatuses {

--- a/cmd/transfer-pvc/progress_test.go
+++ b/cmd/transfer-pvc/progress_test.go
@@ -2,7 +2,9 @@ package transfer_pvc
 
 import (
 	"fmt"
+	"strings"
 	"testing"
+	"time"
 )
 
 func intEqual(a, b *int64) (string, string, bool) {
@@ -174,6 +176,145 @@ total size is 8.67G  speedup is 1.00`,
 			}
 			if unprocessed != tt.wantUnProcessed {
 				t.Errorf("parseRsyncLogs() unprocessed = %v, want %v", unprocessed, tt.wantUnProcessed)
+			}
+		})
+	}
+}
+
+func TestStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		progress   Progress
+		wantStatus status
+	}{
+		{
+			name: "exit code 0 returns succeeded",
+			progress: Progress{
+				ExitCode: func() *int32 { c := int32(0); return &c }(),
+			},
+			wantStatus: succeeded,
+		},
+		{
+			name: "exit code 23 with transferred files returns partially failed",
+			progress: Progress{
+				ExitCode:         func() *int32 { c := int32(23); return &c }(),
+				TransferredFiles: 1,
+				TransferredData:  &dataSize{val: 9, unit: "bytes"},
+				TotalFiles:       func() *int64 { v := int64(1); return &v }(),
+			},
+			wantStatus: partiallyFailed,
+		},
+		{
+			name: "exit code 23 with no data returns failed",
+			progress: Progress{
+				ExitCode:        func() *int32 { c := int32(23); return &c }(),
+				TransferredData: &dataSize{val: 0, unit: "bytes"},
+			},
+			wantStatus: failed,
+		},
+		{
+			name:       "nil exit code returns preparing",
+			progress:   Progress{},
+			wantStatus: preparing,
+		},
+		{
+			name: "nil exit code with 100% returns finishing up",
+			progress: Progress{
+				TransferPercentage: func() *int64 { v := int64(100); return &v }(),
+			},
+			wantStatus: finishingUp,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.progress.Status()
+			if got != tt.wantStatus {
+				t.Errorf("Status() = %q, want %q", got, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestAsString_ErrorsDisplayed(t *testing.T) {
+	tests := []struct {
+		name           string
+		progress       Progress
+		wantContains   []string
+		wantNotContain []string
+	}{
+		{
+			name: "succeeded with no errors shows no error section",
+			progress: Progress{
+				ExitCode:  func() *int32 { c := int32(0); return &c }(),
+				startedAt: time.Now(),
+			},
+			wantContains:   []string{"Succeeded"},
+			wantNotContain: []string{"Failed files", "Errors"},
+		},
+		{
+			name: "partially failed shows failed files",
+			progress: Progress{
+				ExitCode:         func() *int32 { c := int32(23); return &c }(),
+				TransferredFiles: 1,
+				TransferredData:  &dataSize{val: 9, unit: "bytes"},
+				TotalFiles:       func() *int64 { v := int64(1); return &v }(),
+				FailedFiles: []FailedFile{
+					{Name: "/mnt/data/secret", Err: "Permission denied (13)"},
+				},
+				startedAt: time.Now(),
+			},
+			wantContains: []string{"Partially failed", "Failed files", "/mnt/data/secret", "Permission denied (13)"},
+		},
+		{
+			name: "failed shows failed files",
+			progress: Progress{
+				ExitCode:        func() *int32 { c := int32(23); return &c }(),
+				TransferredData: &dataSize{val: 0, unit: "bytes"},
+				FailedFiles: []FailedFile{
+					{Name: "/mnt/data/dir1", Err: "Permission denied (13)"},
+					{Name: "/mnt/data/dir2", Err: "Permission denied (13)"},
+				},
+				startedAt: time.Now(),
+			},
+			wantContains: []string{"Failed", "Failed files", "/mnt/data/dir1", "/mnt/data/dir2"},
+		},
+		{
+			name: "errors field displayed when completed (regression test for #286 shadowing fix)",
+			progress: Progress{
+				ExitCode:        func() *int32 { c := int32(1); return &c }(),
+				TransferredData: &dataSize{val: 0, unit: "bytes"},
+				Errors:          []string{"connection reset by peer"},
+				startedAt:       time.Now(),
+			},
+			wantContains: []string{"Errors", "connection reset by peer"},
+		},
+		{
+			name: "preparing status hides errors",
+			progress: Progress{
+				FailedFiles: []FailedFile{
+					{Name: "/mnt/data/secret", Err: "Permission denied (13)"},
+				},
+				Errors:    []string{"some error"},
+				startedAt: time.Now(),
+			},
+			wantContains:   []string{"Preparing"},
+			wantNotContain: []string{"Failed files", "Errors"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outString, errString := tt.progress.AsString()
+			combined := outString + errString
+
+			for _, want := range tt.wantContains {
+				if !strings.Contains(combined, want) {
+					t.Errorf("output should contain %q, got:\n%s", want, combined)
+				}
+			}
+			for _, notWant := range tt.wantNotContain {
+				if strings.Contains(combined, notWant) {
+					t.Errorf("output should NOT contain %q, got:\n%s", notWant, combined)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
### Summary

  Fixes #621, fixes #286. Three layered bugs in `transfer-pvc` progress reporting that caused transfer errors (permission denied, partial failures) to be silently swallowed.

  When rsync encounters errors during PVC transfer, the errors are captured internally (`p.FailedFiles`) but never displayed to the user. The transfer reports `Status: Preparing` and exits with code 0, giving no indication that files were skipped.

  ### Root Cause

  1. **Exit code not captured on zero-byte stream end** (`progress.go:93-95`): When the pod log stream ends without a clean EOF (common case — 4 consecutive zero-byte reads), the code sets `err = io.EOF` but never calls
  `getFinalPodStatus()` to get the rsync exit code. Without the exit code, `Status()` returns `"Preparing"` instead of `"Partially failed"`, and `Completed()` returns `false`, so the error display block is never reached.

  2. **`getFinalPodStatus` polls too fast** (`progress.go:516-537`): The function polls the pod status 5 times with no delay between iterations. On fast completions, the container's `Terminated` state may not have
  propagated to the API server yet, so all 5 polls return nil exit code.

  3. **#286 — Error variable shadowing** (`progress.go:262`): `errors :=` creates a new local variable that shadows the outer `errors`, so even when the display code runs, errors go to a variable that's immediately
  discarded.

  ### Tested

  **Successful transfer:**
  Status:    Succeeded
  Progress:
    Percentage:    100%
    Transferred:   12.00 bytes
    Rate:          0.13 kB/s
    Files:
      Sent:    4
      Total:   2
  Elapsed:     0s

  **Partially failed (mixed UIDs, some files permission denied):**
  Status:    Partially failed
  Progress:
    Percentage:    <unavailable>
    Transferred:   3.00 bytes
    Rate:          <unavailable>
    Files:         
      Sent:    1
      Total:   1
  Elapsed:     32s
  Failed files:
  - /mnt/error-test/data/secret [Permission denied (13)]

  **Failed (all files 0700 root, nothing transferred):**
  Status:    Failed
  Progress:
    Percentage:    <unavailable>
    Transferred:   0.00 bytes
    Rate:          <unavailable>
    Files:
      Sent:    0
  Elapsed:     32s
  Failed files:
  - /mnt/error-test/data/dir1 [Permission denied (13)]
  - /mnt/error-test/data/dir2 [Permission denied (13)]

  | Scenario | Before | After |
  |---|---|---|
  | Mixed UIDs — partial permission denied | Status: "Preparing", no errors shown | Status: "Partially failed", failed files listed |
  | All files 0700 root — full failure | Status: "Preparing", 0 bytes, no errors | Status: "Failed", failed files listed |
  | Clean transfer — no errors | Status: "Succeeded" | Status: "Succeeded" (no regression) |
  | Non-existent PVC | Error message shown | Error message shown (no regression) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of stalled log streams during PVC transfers by detecting and recovering from connection stalls.
  * Fixed error handling in progress reporting to prevent variable shadowing issues.

* **Improvements**
  * Optimized status polling with a bounded iteration limit for more efficient resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->