### PR TITLE
:bug: fix nil pointer issue when no transferred data

### DIFF
--- a/cmd/transfer-pvc/progress.go
+++ b/cmd/transfer-pvc/progress.go
@@ -306,7 +306,7 @@ func (p *Progress) Status() status {
 			return succeeded
 		}
 		if p.TransferredFiles == 0 &&
-			p.TransferredData.val == 0 &&
+			(p.TransferredData == nil || p.TransferredData.val == 0) &&
 			p.TotalFiles == nil {
 			return failed
 		}

--- a/cmd/transfer-pvc/progress_test.go
+++ b/cmd/transfer-pvc/progress_test.go
@@ -319,3 +319,25 @@ func TestAsString_ErrorsDisplayed(t *testing.T) {
 		})
 	}
 }
+
+func TestStatus_NilTransferredData(t *testing.T) {
+	exitCode := int32(1)
+	p := Progress{
+		ExitCode:         &exitCode,
+		TransferredData:  nil,
+		TransferredFiles: 0,
+		TotalFiles:       nil,
+		startedAt:        time.Now(),
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Status() panicked with nil TransferredData: %v", r)
+		}
+	}()
+
+	s := p.Status()
+	if s != failed {
+		t.Errorf("Status() = %q, want %q", s, failed)
+	}
+}


### PR DESCRIPTION
 Fixes #178

  ### Summary
  
  When rsync fails completely before transferring any data (e.g., DNS resolution failure, connection refused, endpoint unreachable), `transfer-pvc` panics with a nil pointer dereference in `progress.go` instead of reporting a clean `Status: Failed`. This happens because `TransferredData` is never initialized when rsync exits without sending any bytes, but `Status()` unconditionally accesses `TransferredData.val`.

  ### Changes

  - Added nil check for `TransferredData` in `Status()` — returns `Failed` status instead of panicking
  - Added `TestStatus_NilTransferredData` unit test — verifies no panic and correct `Failed` status when `TransferredData` is nil with non-zero exit code

  ### Test plan

  - [x] Unit test: `TestStatus_NilTransferredData` passes
  - [x] All existing `progress_test.go` tests pass
  - [x] `go build ./...` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transfer status handling to prevent a crash when transfer data is missing.
  * Corrected failure classification for completed transfers when no transferred file data is recorded.
  * Added a test to ensure status evaluation remains stable and returns the expected “failed” result when transfer data is nil.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->