### PR TITLE
:bug: Fix Route hostname collision for long PVC names on OCP

### DIFF
--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -1037,13 +1037,15 @@ func getRouteHostName(client client.Client, namespacedName types.NamespacedName)
 	if len(routeNamePrefix) <= 62 {
 		return nil, nil
 	}
-	// if route prefix exceeds limits, a custom hostname will be provided
+	// if route prefix exceeds limits, truncate and append a hash suffix for uniqueness
 	ingressConfig := &configv1.Ingress{}
 	err := client.Get(context.TODO(), types.NamespacedName{Name: "cluster"}, ingressConfig)
 	if err != nil {
 		return nil, err
 	}
-	hostname := fmt.Sprintf("%s.%s", routeNamePrefix[:62], ingressConfig.Spec.Domain)
+	hash := fmt.Sprintf("%x", md5.Sum([]byte(routeNamePrefix)))[:8]
+	truncated := routeNamePrefix[:62-9] + "-" + hash
+	hostname := fmt.Sprintf("%s.%s", truncated, ingressConfig.Spec.Domain)
 	return &hostname, nil
 }
 

--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -1043,10 +1043,14 @@ func getRouteHostName(client client.Client, namespacedName types.NamespacedName)
 	if err != nil {
 		return nil, err
 	}
-	hash := fmt.Sprintf("%x", md5.Sum([]byte(routeNamePrefix)))[:8]
-	truncated := routeNamePrefix[:62-9] + "-" + hash
+	truncated := truncateWithHash(routeNamePrefix)
 	hostname := fmt.Sprintf("%s.%s", truncated, ingressConfig.Spec.Domain)
 	return &hostname, nil
+}
+
+func truncateWithHash(name string) string {
+	hash := fmt.Sprintf("%x", md5.Sum([]byte(name)))[:8]
+	return name[:62-9] + "-" + hash
 }
 
 // buildDestinationPVC given a source PVC, returns a PVC to be created in the destination cluster

--- a/cmd/transfer-pvc/transfer-pvc_test.go
+++ b/cmd/transfer-pvc/transfer-pvc_test.go
@@ -723,3 +723,58 @@ func TestServerFallbackToSourceUID(t *testing.T) {
 		t.Errorf("server should fallback to source UID: got %v, want 27", fmtInt64Ptr(serverCtx.RunAsUser))
 	}
 }
+
+func TestTruncateWithHash(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantLen    int
+		wantUnique bool
+		otherInput string
+	}{
+		{
+			name:    "result is exactly 62 chars",
+			input:   "my-very-long-pvc-name-that-exceeds-sixty-two-characters-in-the-namespace-production",
+			wantLen: 62,
+		},
+		{
+			name:       "different long names produce different results",
+			input:      "my-very-long-application-name-with-lots-of-details-pvc-data-volume1-production",
+			otherInput: "my-very-long-application-name-with-lots-of-details-pvc-data-volume2-production",
+			wantUnique: true,
+		},
+		{
+			name:       "names sharing first 62 chars produce different results",
+			input:      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-suffix1",
+			otherInput: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-suffix2",
+			wantUnique: true,
+		},
+		{
+			name:    "same input produces same result (deterministic)",
+			input:   "my-very-long-pvc-name-that-exceeds-sixty-two-characters-in-the-namespace-production",
+			wantLen: 62,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := truncateWithHash(tt.input)
+
+			if tt.wantLen > 0 && len(result) != tt.wantLen {
+				t.Errorf("truncateWithHash() length = %d, want %d, result = %q", len(result), tt.wantLen, result)
+			}
+
+			if tt.wantUnique {
+				other := truncateWithHash(tt.otherInput)
+				if result == other {
+					t.Errorf("truncateWithHash() collision: %q and %q both produced %q", tt.input, tt.otherInput, result)
+				}
+			}
+
+			// Verify deterministic
+			again := truncateWithHash(tt.input)
+			if result != again {
+				t.Errorf("truncateWithHash() not deterministic: got %q then %q", result, again)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #287

  ### Summary
  
  When transferring PVCs with long names on OCP, `getRouteHostName()` truncates the Route hostname prefix to 62 characters. Two PVCs whose names share the same first 62 characters get identical hostnames, causing a Route conflict and transfer failure.
Fixed by truncating to 53 characters and appending an 8-character MD5 hash suffix, keeping the hostname human-readable while guaranteeing uniqueness within the DNS label limit of 63 characters.

  ### Example

  Before (collision):
  my-very-long-app-name-with-details-pvc-data-volume-producti.apps.example.com  ← PVC volume1
  my-very-long-app-name-with-details-pvc-data-volume-producti.apps.example.com  ← PVC volume2 (same!)

  After (unique):
  my-very-long-app-name-with-details-pvc-data-volum-a1b2c3d4.apps.example.com  ← PVC volume1
  my-very-long-app-name-with-details-pvc-data-volum-f9e8d7c6.apps.example.com  ← PVC volume2 (unique)