### PR TITLE
:bug: Disable tranfer pvc

### DIFF
--- a/.github/workflows/e2e-pr-tester.yaml
+++ b/.github/workflows/e2e-pr-tester.yaml
@@ -202,7 +202,7 @@ jobs:
       - name: Run touched crane e2e tests
         run: |
           if [ "${{ needs.detect-changes.outputs.run_mode }}" = "all" ]; then
-            ginkgo run -v -r "$E2E_SUITE_DIR" -- $GINKGO_COMMON_ARGS
+            ginkgo run -v -r --label-filter='!pvc-transfer' "$E2E_SUITE_DIR" -- $GINKGO_COMMON_ARGS
           else
-            ginkgo run -v -r --focus-file="${{ needs.detect-changes.outputs.focus_file_regex }}" "$E2E_SUITE_DIR" -- $GINKGO_COMMON_ARGS
+            ginkgo run -v -r --label-filter='!pvc-transfer' --focus-file="${{ needs.detect-changes.outputs.focus_file_regex }}" "$E2E_SUITE_DIR" -- $GINKGO_COMMON_ARGS
           fi

--- a/.github/workflows/run-e2e-tier0-tests.yml
+++ b/.github/workflows/run-e2e-tier0-tests.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           cpus: max
           memory: "8192"
-          label_filter: tier0
+          label_filter: tier0 && !pvc-transfer
           create_users: "true"
           src_user: "dev"
           tgt_user: "dev"

--- a/.github/workflows/run-e2e-tier1-tests.yml
+++ b/.github/workflows/run-e2e-tier1-tests.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           cpus: max
           memory: "8192"
-          label_filter: tier1
+          label_filter: tier1 && !pvc-transfer
           create_users: "true"
           src_user: "dev"
           tgt_user: "dev"

--- a/cmd/transform/completion_test.go
+++ b/cmd/transform/completion_test.go
@@ -43,7 +43,7 @@ func TestGetPluginCompletions(t *testing.T) {
 			args:          []string{},
 			toComplete:    "",
 			wantDirective: cobra.ShellCompDirectiveNoFileComp,
-			wantPlugins:   []string{"KubernetesPlugin"}, // Default plugin is always present
+			wantPlugins:   []string{"KubernetesPlugin", "OpenShiftPlugin"}, // Built-in plugins are always present
 			checkContains: true,
 		},
 		{
@@ -66,7 +66,7 @@ func TestGetPluginCompletions(t *testing.T) {
 			args:          []string{},
 			toComplete:    "",
 			wantDirective: cobra.ShellCompDirectiveNoFileComp,
-			wantPlugins:   []string{}, // KubernetesPlugin skipped, so empty
+			wantPlugins:   []string{"OpenShiftPlugin"}, // KubernetesPlugin skipped, OpenShiftPlugin remains
 		},
 		{
 			name: "error path - plugin-dir flag does not exist",

--- a/cmd/transform/listplugins/listplugins_test.go
+++ b/cmd/transform/listplugins/listplugins_test.go
@@ -21,59 +21,55 @@ func TestGetPluginNames(t *testing.T) {
 		wantErr      bool
 	}{
 		{
-			name: "empty plugin directory returns only default plugin",
+			name: "empty plugin directory returns built-in plugins",
 			setupPlugins: func(t *testing.T, pluginDir string) {
-				// Create empty plugin directory
 				if err := os.MkdirAll(pluginDir, 0755); err != nil {
 					t.Fatalf("failed to create plugin dir: %v", err)
 				}
 			},
 			skipPlugins: []string{},
-			wantNames:   []string{"KubernetesPlugin"}, // Default plugin is always included
+			wantNames:   []string{"KubernetesPlugin", "OpenShiftPlugin"},
 			wantErr:     false,
 		},
 		{
-			name: "skip default plugin",
+			name: "skip KubernetesPlugin leaves OpenShiftPlugin",
 			setupPlugins: func(t *testing.T, pluginDir string) {
 				if err := os.MkdirAll(pluginDir, 0755); err != nil {
 					t.Fatalf("failed to create plugin dir: %v", err)
 				}
 			},
 			skipPlugins: []string{"KubernetesPlugin"},
-			wantNames:   []string{},
+			wantNames:   []string{"OpenShiftPlugin"},
 			wantErr:     false,
 		},
 		{
-			name: "nonexistent plugin directory",
+			name: "nonexistent plugin directory returns built-in plugins",
 			setupPlugins: func(t *testing.T, pluginDir string) {
 				// Don't create the directory
 			},
 			skipPlugins: []string{},
-			wantNames:   []string{"KubernetesPlugin"}, // Default plugin is still included
+			wantNames:   []string{"KubernetesPlugin", "OpenShiftPlugin"},
 			wantErr:     false,
 		},
 		{
-			name: "plugin directory with mock plugins",
+			name: "plugin directory with no external plugins returns built-ins",
 			setupPlugins: func(t *testing.T, pluginDir string) {
 				if err := os.MkdirAll(pluginDir, 0755); err != nil {
 					t.Fatalf("failed to create plugin dir: %v", err)
 				}
-				// Note: We can't easily test with real plugin binaries in unit tests
-				// This test verifies the function works with an empty directory
-				// Integration tests would be needed for testing with actual plugin binaries
 			},
 			skipPlugins: []string{},
-			wantNames:   []string{"KubernetesPlugin"},
+			wantNames:   []string{"KubernetesPlugin", "OpenShiftPlugin"},
 			wantErr:     false,
 		},
 		{
-			name: "skip multiple plugins",
+			name: "skip both built-in plugins",
 			setupPlugins: func(t *testing.T, pluginDir string) {
 				if err := os.MkdirAll(pluginDir, 0755); err != nil {
 					t.Fatalf("failed to create plugin dir: %v", err)
 				}
 			},
-			skipPlugins: []string{"KubernetesPlugin", "NonExistentPlugin"},
+			skipPlugins: []string{"KubernetesPlugin", "OpenShiftPlugin"},
 			wantNames:   []string{},
 			wantErr:     false,
 		},

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/jarcoal/httpmock v1.2.0
 	github.com/konveyor/crane-lib v0.1.6-0.20260618130404-9791be7b44bd
+	github.com/migtools/crane-plugin-openshift v0.1.1
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.0

--- a/go.sum
+++ b/go.sum
@@ -378,8 +378,8 @@ github.com/maxatome/go-testdeep v1.11.0/go.mod h1:011SgQ6efzZYAen6fDn4BqQ+lUR72y
 github.com/mfridman/tparse v0.18.0 h1:wh6dzOKaIwkUGyKgOntDW4liXSo37qg5AXbIhkMV3vE=
 github.com/mfridman/tparse v0.18.0/go.mod h1:gEvqZTuCgEhPbYk/2lS3Kcxg1GmTxxU7kTC8DvP0i/A=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
-github.com/migtools/crane-plugin-openshift v0.1.0 h1:HLjKpUoS5Nw+al/H5iBkU+uVCvr2Kg00hkhv6djWVBE=
-github.com/migtools/crane-plugin-openshift v0.1.0/go.mod h1:wFdbjNnSn8tSen9oYy8769ivLmwAS3TFL34H1jfSeFw=
+github.com/migtools/crane-plugin-openshift v0.1.1 h1:67h9tND4GeRlsbADbVo7RvMz//Q+yKvGoyHjeTJal9w=
+github.com/migtools/crane-plugin-openshift v0.1.1/go.mod h1:wFdbjNnSn8tSen9oYy8769ivLmwAS3TFL34H1jfSeFw=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/go.sum
+++ b/go.sum
@@ -378,6 +378,8 @@ github.com/maxatome/go-testdeep v1.11.0/go.mod h1:011SgQ6efzZYAen6fDn4BqQ+lUR72y
 github.com/mfridman/tparse v0.18.0 h1:wh6dzOKaIwkUGyKgOntDW4liXSo37qg5AXbIhkMV3vE=
 github.com/mfridman/tparse v0.18.0/go.mod h1:gEvqZTuCgEhPbYk/2lS3Kcxg1GmTxxU7kTC8DvP0i/A=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
+github.com/migtools/crane-plugin-openshift v0.1.0 h1:HLjKpUoS5Nw+al/H5iBkU+uVCvr2Kg00hkhv6djWVBE=
+github.com/migtools/crane-plugin-openshift v0.1.0/go.mod h1:wFdbjNnSn8tSen9oYy8769ivLmwAS3TFL34H1jfSeFw=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/internal/plugin/plugin_helper.go
+++ b/internal/plugin/plugin_helper.go
@@ -9,6 +9,7 @@ import (
 	"github.com/konveyor/crane-lib/transform"
 	binary_plugin "github.com/konveyor/crane-lib/transform/binary-plugin"
 	"github.com/konveyor/crane-lib/transform/kubernetes"
+	"github.com/migtools/crane-plugin-openshift/openshift"
 	"github.com/sirupsen/logrus"
 )
 
@@ -73,6 +74,7 @@ func GetFilteredPlugins(pluginDir string, skipPlugins []string, logger *logrus.L
 
 	// Start with built-in plugins
 	unfilteredPlugins = append(unfilteredPlugins, &kubernetes.KubernetesTransformPlugin{})
+	unfilteredPlugins = append(unfilteredPlugins, &openshift.OpenShiftTransformPlugin{Log: logger})
 
 	paths := []string{absPathPluginDir, pluginDir, GlobalPluginDir, PkgPluginDir}
 

--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -21,7 +21,7 @@ RUN set -e && \
         fi && \
         echo "Building standalone binary $output (version=${MTA_OPS_VERSION}, commit=${MTA_OPS_GIT_COMMIT})..." && \
         CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" go build -trimpath -mod=readonly \
-            -ldflags="-X github.com/konveyor/crane/internal/buildinfo.Version=${MTA_OPS_VERSION}" \
+            -ldflags="-X github.com/konveyor/crane/internal/buildinfo.Version=${MTA_OPS_VERSION} -X github.com/konveyor/crane/internal/buildinfo.BuildCommit=${MTA_OPS_GIT_COMMIT}" \
             -o "/tmp/archives/$output" ./main.go && \
         (cd /tmp/archives && sha256sum "$output" > "$output.sha256"); \
     done && \

--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -1,0 +1,54 @@
+FROM registry.redhat.io/ubi9/go-toolset:1.25 AS builder
+
+COPY . /workspace
+WORKDIR /workspace
+
+ARG BUILD_VERSION=v0.0.0
+ARG SOURCE_GIT_COMMIT=unknown
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+
+RUN set -e && \
+    MTA_OPS_VERSION="${BUILD_VERSION:-dev}" && \
+    mkdir -p /tmp/archives /tmp/bin && \
+    for platform in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64; do \
+        os=$(echo "$platform" | cut -d'/' -f1) && \
+        arch=$(echo "$platform" | cut -d'/' -f2) && \
+        if [ "$os" = "windows" ]; then \
+            output="mta-ops_${os}_${arch}.exe"; \
+        else \
+            output="mta-ops_${os}_${arch}"; \
+        fi && \
+        echo "Building standalone binary $output (version=${MTA_OPS_VERSION})..." && \
+        CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" go build -trimpath -mod=readonly \
+            -ldflags="-X github.com/konveyor/crane/internal/buildinfo.Version=${CRANE_VERSION}" \
+            -o "/tmp/archives/$output" ./main.go && \
+        (cd /tmp/archives && sha256sum "$output" > "$output.sha256"); \
+    done && \
+    cp LICENSE /tmp/archives/LICENSE && \
+    go clean -cache -modcache -testcache && \
+    rm -rf /opt/app-root/src/.cache /opt/app-root/src/go/pkg /tmp/go /tmp/.cache
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath -mod=readonly \
+    -ldflags="-X github.com/konveyor/crane/internal/buildinfo.Version=${BUILD_VERSION}" \
+    -o /tmp/bin/mta-ops ./main.go
+
+FROM registry.access.redhat.com/ubi9:latest
+
+RUN dnf -y install openssl && dnf -y reinstall tzdata && dnf clean all
+
+COPY --from=builder /tmp/archives /archives
+COPY --from=builder /tmp/bin/mta-ops /usr/local/bin/mta-ops
+COPY LICENSE /licenses/
+
+USER 1001
+
+ENTRYPOINT ["/usr/local/bin/mta-ops"]
+
+LABEL \
+    description="MTA-OPS CLI for Kubernetes migration workflows" \
+    io.k8s.description="MTA-Ops CLI for Kubernetes migration workflows" \
+    io.k8s.display-name="MTA-Ops CLI" \
+    io.openshift.maintainer.project="MTA-Ops" \
+    io.openshift.tags="migration,modernization,konveyor,mta-ops" \
+    summary="MTA-Ops CLI"

--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -35,7 +35,7 @@ RUN set -e && \
     go clean -cache -modcache -testcache && \
     rm -rf /opt/app-root/src/.cache /opt/app-root/src/go/pkg /tmp/go /tmp/.cache
 
-FROM registry.access.redhat.com/ubi9:latest
+FROM registry.redhat.io/ubi9/ubi:latest
 
 RUN dnf -y install openssl && dnf -y reinstall tzdata && dnf clean all
 

--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -25,14 +25,15 @@ RUN set -e && \
             -o "/tmp/archives/$output" ./main.go && \
         (cd /tmp/archives && sha256sum "$output" > "$output.sha256"); \
     done && \
+    if [ "${TARGETOS}" = "windows" ]; then \
+        runtime_output="mta-ops_${TARGETOS}_${TARGETARCH}.exe"; \
+    else \
+        runtime_output="mta-ops_${TARGETOS}_${TARGETARCH}"; \
+    fi && \
+    cp "/tmp/archives/${runtime_output}" /tmp/bin/mta-ops && \
     cp LICENSE /tmp/archives/LICENSE && \
     go clean -cache -modcache -testcache && \
     rm -rf /opt/app-root/src/.cache /opt/app-root/src/go/pkg /tmp/go /tmp/.cache
-
-RUN MTA_OPS_VERSION="${BUILD_VERSION:-dev}" && \
-    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath -mod=readonly \
-    -ldflags="-X github.com/konveyor/crane/internal/buildinfo.Version=${MTA_OPS_VERSION}" \
-    -o /tmp/bin/mta-ops ./main.go
 
 FROM registry.access.redhat.com/ubi9:latest
 

--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -51,6 +51,6 @@ LABEL \
     description="MTA-Ops CLI for Kubernetes migration workflows" \
     io.k8s.description="MTA-Ops CLI for Kubernetes migration workflows" \
     io.k8s.display-name="MTA-Ops CLI" \
-    io.openshift.maintainer.project="MTA-Ops" \
+    io.openshift.maintainer.project="MTA" \
     io.openshift.tags="migration,modernization,konveyor,mta-ops" \
     summary="MTA-Ops CLI"

--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -47,7 +47,7 @@ USER 1001
 ENTRYPOINT ["/usr/local/bin/mta-ops"]
 
 LABEL \
-    description="MTA-OPS CLI for Kubernetes migration workflows" \
+    description="MTA-Ops CLI for Kubernetes migration workflows" \
     io.k8s.description="MTA-Ops CLI for Kubernetes migration workflows" \
     io.k8s.display-name="MTA-Ops CLI" \
     io.openshift.maintainer.project="MTA-Ops" \

--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -3,13 +3,13 @@ FROM registry.redhat.io/ubi9/go-toolset:1.25 AS builder
 COPY . /workspace
 WORKDIR /workspace
 
-ARG BUILD_VERSION=v0.0.0
-ARG SOURCE_GIT_COMMIT=unknown
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
 
 RUN set -e && \
+    # Prefer ART/Konflux injected env vars; fall back for local builds.
     MTA_OPS_VERSION="${BUILD_VERSION:-dev}" && \
+    MTA_OPS_GIT_COMMIT="${SOURCE_GIT_COMMIT:-unknown}" && \
     mkdir -p /tmp/archives /tmp/bin && \
     for platform in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64; do \
         os=$(echo "$platform" | cut -d'/' -f1) && \
@@ -19,9 +19,9 @@ RUN set -e && \
         else \
             output="mta-ops_${os}_${arch}"; \
         fi && \
-        echo "Building standalone binary $output (version=${MTA_OPS_VERSION})..." && \
+        echo "Building standalone binary $output (version=${MTA_OPS_VERSION}, commit=${MTA_OPS_GIT_COMMIT})..." && \
         CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" go build -trimpath -mod=readonly \
-            -ldflags="-X github.com/konveyor/crane/internal/buildinfo.Version=${CRANE_VERSION}" \
+            -ldflags="-X github.com/konveyor/crane/internal/buildinfo.Version=${MTA_OPS_VERSION}" \
             -o "/tmp/archives/$output" ./main.go && \
         (cd /tmp/archives && sha256sum "$output" > "$output.sha256"); \
     done && \
@@ -29,8 +29,9 @@ RUN set -e && \
     go clean -cache -modcache -testcache && \
     rm -rf /opt/app-root/src/.cache /opt/app-root/src/go/pkg /tmp/go /tmp/.cache
 
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath -mod=readonly \
-    -ldflags="-X github.com/konveyor/crane/internal/buildinfo.Version=${BUILD_VERSION}" \
+RUN MTA_OPS_VERSION="${BUILD_VERSION:-dev}" && \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath -mod=readonly \
+    -ldflags="-X github.com/konveyor/crane/internal/buildinfo.Version=${MTA_OPS_VERSION}" \
     -o /tmp/bin/mta-ops ./main.go
 
 FROM registry.access.redhat.com/ubi9:latest

--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -37,8 +37,6 @@ RUN set -e && \
 
 FROM registry.redhat.io/ubi9/ubi:latest
 
-RUN dnf -y install openssl && dnf -y reinstall tzdata && dnf clean all
-
 COPY --from=builder /tmp/archives /archives
 COPY --from=builder /tmp/bin/mta-ops /usr/local/bin/mta-ops
 COPY LICENSE /licenses/

--- a/main.go
+++ b/main.go
@@ -5,13 +5,8 @@ import (
 	"path/filepath"
 
 	"github.com/konveyor/crane/cmd/apply"
-	"github.com/konveyor/crane/cmd/convert"
 	export "github.com/konveyor/crane/cmd/export"
-	plugin_manager "github.com/konveyor/crane/cmd/plugin-manager"
-	skopeo_sync_gen "github.com/konveyor/crane/cmd/skopeo-sync-gen"
-	transfer_pvc "github.com/konveyor/crane/cmd/transfer-pvc"
 	"github.com/konveyor/crane/cmd/transform"
-	tunnel_api "github.com/konveyor/crane/cmd/tunnel-api"
 	"github.com/konveyor/crane/cmd/validate"
 	"github.com/konveyor/crane/cmd/version"
 	"github.com/konveyor/crane/internal/flags"
@@ -26,13 +21,8 @@ func main() {
 	}
 	f.ApplyFlags(&root)
 	root.AddCommand(export.NewExportCommand(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}, f))
-	root.AddCommand(transfer_pvc.NewTransferPVCCommand(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}))
-	root.AddCommand(tunnel_api.NewTunnelAPIOptions(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}))
-	root.AddCommand(convert.NewConvertOptions(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}))
 	root.AddCommand(transform.NewTransformCommand(f))
-	root.AddCommand(skopeo_sync_gen.NewSkopeoSyncGenCommand(f))
 	root.AddCommand(apply.NewApplyCommand(f))
-	root.AddCommand(plugin_manager.NewPluginManagerCommand(f))
 	root.AddCommand(version.NewVersionCommand(f))
 	root.AddCommand(validate.NewValidateCommand(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}, f))
 	if err := root.Execute(); err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added built-in OpenShift transformation plugin support alongside Kubernetes.
  - Added a UBI9-based container image with cross-platform build artifacts and checksum files.
  - Containerized application runs as a non-root user with `mta-ops` as the entry point.

- **Changes**
  - Removed the `convert`, `plugin-manager`, `skopeo-sync-gen`, `transfer-pvc`, and `tunnel-api` CLI commands.
  - End-to-end test runs now exclude PVC transfer scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->