### PR TITLE
:test_tube: Add e2e test for migrate namespace with multiple secret types

### DIFF
--- a/e2e-tests/framework/test_helpers.go
+++ b/e2e-tests/framework/test_helpers.go
@@ -1,6 +1,7 @@
 package framework
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"regexp"
@@ -83,5 +84,35 @@ func ValidateClusterRBAC(kubectl KubectlRunner, bindings []ExpectedClusterRoleBi
 		}
 		log.Printf("CRB %s -> CR %s (subject: %s) verified", b.ClusterRoleBindingName, b.ClusterRoleName, b.SubjectName)
 	}
+	return nil
+}
+
+// Fetches a secret by name from the given namespace and cluster, parses the JSON response, and verifies the type
+// field matches the expected value. Returns a descriptive error if the secret cannot be fetched, the JSON cannot
+// be parsed, or the type does not match.
+func VerifySecret(kubectl KubectlRunner, namespace, secretName, expectedType string) error {
+	secretJson, err := kubectl.Run("get", "secret", secretName, "-n", namespace, "-o", "json")
+	if err != nil {
+		return fmt.Errorf("failed to get secret %s: %w", secretName, err)
+	}
+
+	var secretObj map[string]any
+	if err := json.Unmarshal([]byte(secretJson), &secretObj); err != nil {
+		return fmt.Errorf("failed to parse secret %s JSON: %w", secretName, err)
+	}
+
+	actualType, ok := secretObj["type"].(string)
+	if !ok {
+		return fmt.Errorf("secret %s has no type field", secretName)
+	}
+	if actualType != expectedType {
+		return fmt.Errorf("secret %s: expected type %q but got %q", secretName, expectedType, actualType)
+	}
+	data, ok := secretObj["data"].(map[string]any)
+	if !ok || len(data) == 0 {
+		return fmt.Errorf("secret %s has missing or empty data field", secretName)
+	}
+
+	log.Printf("Secret verified: name=%s type=%s\n", secretName, actualType)
 	return nil
 }

--- a/e2e-tests/framework/test_helpers.go
+++ b/e2e-tests/framework/test_helpers.go
@@ -87,20 +87,19 @@ func ValidateClusterRBAC(kubectl KubectlRunner, bindings []ExpectedClusterRoleBi
 	return nil
 }
 
-// Fetches a secret by name from the given namespace and cluster, parses the JSON response, and verifies the type
-// field matches the expected value. Returns a descriptive error if the secret cannot be fetched, the JSON cannot
-// be parsed, or the type does not match.
-func VerifySecret(kubectl KubectlRunner, namespace, secretName, expectedType string) error {
+// VerifySecret fetches a secret by name from the given namespace and cluster, parses the JSON response,
+// and verifies the type field matches the expected value and, when expectedData is non-nil, that every
+// key's base64-encoded value matches exactly. Returns a descriptive error if the secret cannot be fetched,
+// the JSON cannot be parsed, the type does not match, or any data key is missing/mismatched.
+func VerifySecret(kubectl KubectlRunner, namespace, secretName, expectedType string, expectedData map[string]string) error {
 	secretJson, err := kubectl.Run("get", "secret", secretName, "-n", namespace, "-o", "json")
 	if err != nil {
 		return fmt.Errorf("failed to get secret %s: %w", secretName, err)
 	}
-
 	var secretObj map[string]any
 	if err := json.Unmarshal([]byte(secretJson), &secretObj); err != nil {
 		return fmt.Errorf("failed to parse secret %s JSON: %w", secretName, err)
 	}
-
 	actualType, ok := secretObj["type"].(string)
 	if !ok {
 		return fmt.Errorf("secret %s/%s: type field is not a string, got %T", namespace, secretName, secretObj["type"])
@@ -112,7 +111,32 @@ func VerifySecret(kubectl KubectlRunner, namespace, secretName, expectedType str
 	if !ok || len(data) == 0 {
 		return fmt.Errorf("secret %s/%s: data field is missing or empty, got %T", namespace, secretName, secretObj["data"])
 	}
-
+	for key, expectedValue := range expectedData {
+		actualValue, ok := data[key].(string)
+		if !ok {
+			return fmt.Errorf("secret %s/%s: expected data key %q not found or not a string", namespace, secretName, key)
+		}
+		if actualValue != expectedValue {
+			return fmt.Errorf("secret %s/%s: data key %q does not match source value", namespace, secretName, key)
+		}
+	}
 	log.Printf("Secret verified: name=%s type=%s\n", secretName, actualType)
 	return nil
+}
+
+// GetSecretData fetches a secret by name and returns its data map with values left base64-encoded,
+// exactly as returned by the Kubernetes API, suitable for direct comparison via VerifySecret's
+// expectedData parameter without needing to decode/re-encode.
+func GetSecretData(kubectl KubectlRunner, namespace, secretName string) (map[string]string, error) {
+	secretJson, err := kubectl.Run("get", "secret", secretName, "-n", namespace, "-o", "json")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get secret %s: %w", secretName, err)
+	}
+	var secretObj struct {
+		Data map[string]string `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(secretJson), &secretObj); err != nil {
+		return nil, fmt.Errorf("failed to parse secret %s JSON: %w", secretName, err)
+	}
+	return secretObj.Data, nil
 }

--- a/e2e-tests/framework/test_helpers.go
+++ b/e2e-tests/framework/test_helpers.go
@@ -106,11 +106,11 @@ func VerifySecret(kubectl KubectlRunner, namespace, secretName, expectedType str
 		return fmt.Errorf("secret %s/%s: type field is not a string, got %T", namespace, secretName, secretObj["type"])
 	}
 	if actualType != expectedType {
-      return fmt.Errorf("secret %s/%s: expected type %q but got %q", namespace, secretName, expectedType, actualType)
+		return fmt.Errorf("secret %s/%s: expected type %q but got %q", namespace, secretName, expectedType, actualType)
 	}
 	data, ok := secretObj["data"].(map[string]any)
 	if !ok || len(data) == 0 {
-      return fmt.Errorf("secret %s/%s: data field is missing or empty, got %T", namespace, secretName, secretObj["data"])
+		return fmt.Errorf("secret %s/%s: data field is missing or empty, got %T", namespace, secretName, secretObj["data"])
 	}
 
 	log.Printf("Secret verified: name=%s type=%s\n", secretName, actualType)

--- a/e2e-tests/framework/test_helpers.go
+++ b/e2e-tests/framework/test_helpers.go
@@ -103,14 +103,14 @@ func VerifySecret(kubectl KubectlRunner, namespace, secretName, expectedType str
 
 	actualType, ok := secretObj["type"].(string)
 	if !ok {
-		return fmt.Errorf("secret %s has no type field", secretName)
+		return fmt.Errorf("secret %s/%s: type field is not a string, got %T", namespace, secretName, secretObj["type"])
 	}
 	if actualType != expectedType {
-		return fmt.Errorf("secret %s: expected type %q but got %q", secretName, expectedType, actualType)
+      return fmt.Errorf("secret %s/%s: expected type %q but got %q", namespace, secretName, expectedType, actualType)
 	}
 	data, ok := secretObj["data"].(map[string]any)
 	if !ok || len(data) == 0 {
-		return fmt.Errorf("secret %s has missing or empty data field", secretName)
+      return fmt.Errorf("secret %s/%s: data field is missing or empty, got %T", namespace, secretName, secretObj["data"])
 	}
 
 	log.Printf("Secret verified: name=%s type=%s\n", secretName, actualType)

--- a/e2e-tests/tests/tier1/mta_842_secrets_migration_test.go
+++ b/e2e-tests/tests/tier1/mta_842_secrets_migration_test.go
@@ -76,6 +76,14 @@ var _ = Describe("Migrate namespace with multiple secret types", func() {
 		_, err = kubectlSrc.Run("create", "secret", "docker-registry", "docker-secret", "--docker-server=quay.io", "--docker-username=user", "--docker-password=pass", "-n", namespace)
 		Expect(err).NotTo(HaveOccurred())
 
+		By("Capture source secret data for exact comparison on target")
+		srcOpaqueData, err := GetSecretData(kubectlSrc, namespace, "opaque-secret")
+		Expect(err).NotTo(HaveOccurred())
+		srcTLSData, err := GetSecretData(kubectlSrc, namespace, "tls-secret")
+		Expect(err).NotTo(HaveOccurred())
+		srcDockerData, err := GetSecretData(kubectlSrc, namespace, "docker-secret")
+		Expect(err).NotTo(HaveOccurred())
+
 		runner := scenario.Crane
 		runner.WorkDir = paths.TempDir
 
@@ -93,18 +101,22 @@ var _ = Describe("Migrate namespace with multiple secret types", func() {
 			log.Printf("Secret manifest found in output: %s\n", matches)
 		}
 
+		By("Verify default SA token secret is excluded from output")
+		matches, _ := filepath.Glob(filepath.Join(paths.OutputDir, "resources", namespace, "Secret__*default-token*"))
+		Expect(matches).To(BeEmpty(), "default SA token secret should be whited out")
+
 		By("Apply rendered manifests to target")
 		log.Printf("Applying rendered manifests on target namespace %s from %s\n", namespace, paths.OutputDir)
 		Expect(ApplyOutputToTarget(kubectlTgt, namespace, paths.OutputDir)).NotTo(HaveOccurred())
 
-		By("Verify Opaque secret is present on target with correct type")
-		Expect(VerifySecret(kubectlTgt, namespace, "opaque-secret", "Opaque")).NotTo(HaveOccurred())
+		By("Verify Opaque secret is present on target with correct type and data")
+		Expect(VerifySecret(kubectlTgt, namespace, "opaque-secret", "Opaque", srcOpaqueData)).NotTo(HaveOccurred())
 
-		By("Verify tls secret is present on target with correct type")
-		Expect(VerifySecret(kubectlTgt, namespace, "tls-secret", "kubernetes.io/tls")).NotTo(HaveOccurred())
+		By("Verify tls secret is present on target with correct type and data")
+		Expect(VerifySecret(kubectlTgt, namespace, "tls-secret", "kubernetes.io/tls", srcTLSData)).NotTo(HaveOccurred())
 
-		By("Verify docker secret is present on target with correct type")
-		Expect(VerifySecret(kubectlTgt, namespace, "docker-secret", "kubernetes.io/dockerconfigjson")).NotTo(HaveOccurred())
+		By("Verify docker secret is present on target with correct type and data")
+		Expect(VerifySecret(kubectlTgt, namespace, "docker-secret", "kubernetes.io/dockerconfigjson", srcDockerData)).NotTo(HaveOccurred())
 
 	})
 })

--- a/e2e-tests/tests/tier1/mta_842_secrets_migration_test.go
+++ b/e2e-tests/tests/tier1/mta_842_secrets_migration_test.go
@@ -1,0 +1,104 @@
+package e2e
+
+import (
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Migrate namespace with multiple secret types", func() {
+	It("[MTA-842] all secret types are exported, transformed, and applied to target cluster", Label("tier1"), func() {
+		namespace := "crane-secrets-test"
+
+		scenario := NewMigrationScenario(
+			namespace,
+			namespace,
+			config.K8sDeployBin,
+			config.CraneBin,
+			config.SourceContext,
+			config.TargetContext,
+		)
+		kubectlSrc := scenario.KubectlSrc
+		kubectlTgt := scenario.KubectlTgt
+
+		paths, err := NewScenarioPaths("crane-export-*")
+		Expect(err).NotTo(HaveOccurred())
+		exportOpts := ExportOptions{Namespace: namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
+		DeferCleanup(func() {
+			By("Cleanup temp directory")
+			if paths.TempDir != "" {
+				log.Printf("Removing temp dir: %s\n", paths.TempDir)
+				if err := os.RemoveAll(paths.TempDir); err != nil {
+					log.Printf("cleanup: failed to remove temp dir %q: %v", paths.TempDir, err)
+				}
+			}
+			By("Cleanup source namespace and temp dir")
+			if _, err := kubectlSrc.Run("delete", "namespace", namespace, "--ignore-not-found=true"); err != nil {
+				log.Printf("cleanup: failed to delete source namespace: %v", err)
+			}
+			By("Cleanup target namespace and temp dir")
+			if _, err := kubectlTgt.Run("delete", "namespace", namespace, "--ignore-not-found=true"); err != nil {
+				log.Printf("cleanup: failed to delete target namespace: %v", err)
+			}
+		})
+
+		By("Create namespace on source")
+		Expect(kubectlSrc.CreateNamespace(namespace)).NotTo(HaveOccurred())
+
+		By("Create Opaque secret on source")
+		Expect(kubectlSrc.Run("create", "secret", "generic", "opaque-secret", "--from-literal=key=value", "-n", namespace)).Error().NotTo(HaveOccurred())
+
+		By("Generate TLS certificate and key")
+		certFile := filepath.Join(paths.TempDir, "tls.crt")
+		keyFile := filepath.Join(paths.TempDir, "tls.key")
+		cmd := exec.Command("openssl", "req", "-x509", "-newkey", "rsa:2048", "-keyout", keyFile, "-out", certFile, "-days", "1", "-nodes", "-subj", "/CN=test")
+		out, err := cmd.CombinedOutput()
+		Expect(err).NotTo(HaveOccurred(), "openssl output: %s", out)
+
+		By("Create TLS secret on source")
+		Expect(kubectlSrc.Run("create", "secret", "tls", "tls-secret", "--cert="+certFile, "--key="+keyFile, "-n", namespace)).Error().NotTo(HaveOccurred())
+
+		By("Create docker-registry secret on source")
+		Expect(kubectlSrc.Run("create", "secret", "docker-registry", "docker-secret", "--docker-server=quay.io", "--docker-username=user", "--docker-password=pass", "-n", namespace)).Error().NotTo(HaveOccurred())
+
+		runner := scenario.Crane
+		runner.WorkDir = paths.TempDir
+
+		By("Run crane export/transform/apply pipeline")
+		log.Printf("Running crane pipeline for namespace %s\n", namespace)
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
+		log.Printf("Crane pipeline completed for namespace %s\n", namespace)
+
+		By("Verify all secret manifests are present in output directory")
+		for _, secretName := range []string{"opaque-secret", "tls-secret", "docker-secret"} {
+			glob := filepath.Join(paths.OutputDir, "resources", namespace, "Secret__*_"+secretName+".yaml")
+			matches, err := filepath.Glob(glob)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(matches).NotTo(BeEmpty(), "expected manifest for secret "+secretName+" in output directory")
+			log.Printf("Secret manifest found in output: %s\n", matches)
+		}
+
+		By("Apply rendered manifests to target")
+		log.Printf("Applying rendered manifests on target namespace %s from %s\n", namespace, paths.OutputDir)
+		Expect(ApplyOutputToTarget(kubectlTgt, namespace, paths.OutputDir)).NotTo(HaveOccurred())
+
+		By("Verify Opaque secret is present on target with correct type")
+		Expect(VerifySecret(kubectlTgt, namespace, "opaque-secret", "Opaque")).NotTo(HaveOccurred())
+
+		By("Verify tls secret is present on target with correct type")
+		Expect(VerifySecret(kubectlTgt, namespace, "tls-secret", "kubernetes.io/tls")).NotTo(HaveOccurred())
+
+		By("Verify docker secret is present on target with correct type")
+		Expect(VerifySecret(kubectlTgt, namespace, "docker-secret", "kubernetes.io/dockerconfigjson")).NotTo(HaveOccurred())
+
+	})
+})

--- a/e2e-tests/tests/tier1/mta_842_secrets_migration_test.go
+++ b/e2e-tests/tests/tier1/mta_842_secrets_migration_test.go
@@ -41,11 +41,11 @@ var _ = Describe("Migrate namespace with multiple secret types", func() {
 					log.Printf("cleanup: failed to remove temp dir %q: %v", paths.TempDir, err)
 				}
 			}
-			By("Cleanup source namespace and temp dir")
+			By("Cleanup source namespace")
 			if _, err := kubectlSrc.Run("delete", "namespace", namespace, "--ignore-not-found=true"); err != nil {
 				log.Printf("cleanup: failed to delete source namespace: %v", err)
 			}
-			By("Cleanup target namespace and temp dir")
+			By("Cleanup target namespace")
 			if _, err := kubectlTgt.Run("delete", "namespace", namespace, "--ignore-not-found=true"); err != nil {
 				log.Printf("cleanup: failed to delete target namespace: %v", err)
 			}
@@ -55,9 +55,13 @@ var _ = Describe("Migrate namespace with multiple secret types", func() {
 		Expect(kubectlSrc.CreateNamespace(namespace)).NotTo(HaveOccurred())
 
 		By("Create Opaque secret on source")
-		Expect(kubectlSrc.Run("create", "secret", "generic", "opaque-secret", "--from-literal=key=value", "-n", namespace)).Error().NotTo(HaveOccurred())
+		_, err = kubectlSrc.Run("create", "secret", "generic", "opaque-secret", "--from-literal=key=value", "-n", namespace)
+		Expect(err).NotTo(HaveOccurred())
 
 		By("Generate TLS certificate and key")
+		if _, lookErr := exec.LookPath("openssl"); lookErr != nil {
+			Skip("openssl not found in PATH — skipping TLS secret creation")
+		}
 		certFile := filepath.Join(paths.TempDir, "tls.crt")
 		keyFile := filepath.Join(paths.TempDir, "tls.key")
 		cmd := exec.Command("openssl", "req", "-x509", "-newkey", "rsa:2048", "-keyout", keyFile, "-out", certFile, "-days", "1", "-nodes", "-subj", "/CN=test")
@@ -65,10 +69,12 @@ var _ = Describe("Migrate namespace with multiple secret types", func() {
 		Expect(err).NotTo(HaveOccurred(), "openssl output: %s", out)
 
 		By("Create TLS secret on source")
-		Expect(kubectlSrc.Run("create", "secret", "tls", "tls-secret", "--cert="+certFile, "--key="+keyFile, "-n", namespace)).Error().NotTo(HaveOccurred())
+		_, err = kubectlSrc.Run("create", "secret", "tls", "tls-secret", "--cert="+certFile, "--key="+keyFile, "-n", namespace)
+		Expect(err).NotTo(HaveOccurred())
 
 		By("Create docker-registry secret on source")
-		Expect(kubectlSrc.Run("create", "secret", "docker-registry", "docker-secret", "--docker-server=quay.io", "--docker-username=user", "--docker-password=pass", "-n", namespace)).Error().NotTo(HaveOccurred())
+		_, err = kubectlSrc.Run("create", "secret", "docker-registry", "docker-secret", "--docker-server=quay.io", "--docker-username=user", "--docker-password=pass", "-n", namespace)
+		Expect(err).NotTo(HaveOccurred())
 
 		runner := scenario.Crane
 		runner.WorkDir = paths.TempDir


### PR DESCRIPTION
## Summary

  - Add e2e test for MTA-842: stateless migration of Kubernetes secrets with
  multiple types (Opaque, TLS, dockerconfigjson)
  - Verifies that crane export/transform/apply pipeline preserves all secret
  types intact
  - Validates secret type and data fields match source after migration to target
  cluster

 ## Test plan

  - [ ] Create 3 secrets (Opaque, TLS, dockerconfigjson) on source namespace
  - [ ] Run crane export/transform/apply pipeline - expect no errors
  - [ ] Verify all 3 secret manifests are present in output directory
  - [ ] Apply rendered manifests to target cluster
  - [ ] Verify each secret on target has correct type and non-empty data field

 ## Framework changes

  - Add VerifySecret() helper to test_helpers.go - fetches a secret by name,
  verifies type and data fields

  Polarion: [MTA-842](https://polarion.engineering.redhat.com/polarion/#/project/MTAPathfinder/workitem?id=MTA-842)
 [#502](https://github.com/migtools/crane/issues/502)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of migrated Kubernetes secrets, including secret type and required data.
  * Added coverage for exporting, transforming, and applying Opaque, TLS, and Docker registry secrets.
  * Confirmed migrated secrets retain their expected types in the target cluster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->