### PR TITLE
:test_tube:  [fix] mta_853 test logic so it will fit the test plan more accuratly

### DIFF
--- a/e2e-tests/framework/crane.go
+++ b/e2e-tests/framework/crane.go
@@ -41,6 +41,7 @@ type ExportOptions struct {
 	AsExtras         string
 	QPS              float32
 	Burst            int
+	Overwrite        bool
 }
 
 type TransformOptions struct {
@@ -64,6 +65,7 @@ type ApplyOptions struct {
 	SkipClusterScoped bool
 	Ordered           bool
 	Stages            []string
+	Overwrite         bool
 }
 
 // Export runs crane export for a namespace into the given export directory.
@@ -93,6 +95,9 @@ func (c CraneRunner) Export(opts ExportOptions) error {
 	}
 	if opts.Burst > 0 {
 		args = append(args, "--burst", fmt.Sprintf("%d", opts.Burst))
+	}
+	if opts.Overwrite {
+		args = append(args, "--overwrite")
 	}
 	logVerboseCommand(c.Bin, args)
 	cmd := exec.Command(c.Bin, args...)
@@ -170,6 +175,9 @@ func (c CraneRunner) Apply(opts ApplyOptions) error {
 	}
 	if opts.Ordered {
 		args = append(args, "--ordered")
+	}
+	if opts.Overwrite {
+		args = append(args, "--overwrite")
 	}
 	args = append(args, opts.Stages...)
 

--- a/e2e-tests/tests/tier0/mta_853_split_apply_test.go
+++ b/e2e-tests/tests/tier0/mta_853_split_apply_test.go
@@ -120,13 +120,17 @@ var _ = Describe("Namespace-admin cluster-level migration", func() {
 		By("Cluster admin phase: Verifying cluster resources in output _cluster directory after cluster Admin phase")
 		Expect(utils.AssertKindsInOutput(paths.OutputDir, []string{"ClusterRole", "ClusterRoleBinding"})).NotTo(HaveOccurred())
 
-		By("Cluster admin phase: Applying namespace resources to target as namespace-admin")
+		By("Cluster admin phase: Applying cluster resources to target")
 		Expect(kubectlTgt.ApplyDir(filepath.Join(paths.OutputDir, "resources", "_cluster"))).NotTo(HaveOccurred())
 
 		By("Scaling target deployment and validating app")
 		Expect(kubectlTgtNonAdmin.ScaleDeployment(namespace, appName, 1)).NotTo(HaveOccurred())
 		Eventually(tgtAppNonAdmin.Validate, "5m", "10s").Should(Succeed())
 
+		By("Verifying ClusterRoleBinding on target references correct ClusterRole and ServiceAccount")
+		Expect(ValidateClusterRBAC(kubectlTgt, []ExpectedClusterRoleBinding{
+			{ClusterRoleBindingName: clusterRoleBindingName, ClusterRoleName: clusterRoleName, SubjectName: sa.Name},
+		})).NotTo(HaveOccurred())
 	})
 
 })

--- a/e2e-tests/tests/tier0/mta_853_split_apply_test.go
+++ b/e2e-tests/tests/tier0/mta_853_split_apply_test.go
@@ -45,6 +45,7 @@ var _ = Describe("Namespace-admin cluster-level migration", func() {
 		paths, err := NewScenarioPaths("crane-na1-*")
 		Expect(err).NotTo(HaveOccurred())
 		runner := scenario.CraneNonAdmin
+		adminRunner := scenario.Crane
 
 		exportOpts := ExportOptions{Namespace: srcAppNonAdmin.Namespace, ExportDir: paths.ExportDir}
 		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
@@ -53,6 +54,7 @@ var _ = Describe("Namespace-admin cluster-level migration", func() {
 
 		crb := ClusterRoleBinding{Name: clusterRoleBindingName, ClusterRoleName: clusterRoleName}
 		cr := ClusterRole{Name: clusterRoleName, Verb: "get,list,watch", Resource: "pods"}
+		sa := ServiceAccount{Name: "nginx-sa", Namespace: namespace}
 
 		By("Granting namespace-admin permissions to non-admin user on source and target")
 		kubectlSrcNonAdmin, kubectlTgtNonAdmin, rbacCleanup, err := SetupActiveKubectlRunners(scenario, namespace)
@@ -68,7 +70,7 @@ var _ = Describe("Namespace-admin cluster-level migration", func() {
 		})
 		DeferCleanup(rbacCleanup)
 		DeferCleanup(func() {
-			if err := ResourceCleanup([]KubectlRunner{kubectlSrc, kubectlTgt}, []Resource{crb, cr}); err != nil {
+			if err := ResourceCleanup([]KubectlRunner{kubectlSrc, kubectlTgt}, []Resource{crb, cr, sa}); err != nil {
 				log.Printf("Resources cleanup: %v", err)
 			}
 			if err := CleanupScenario(paths.TempDir, srcAppNonAdmin, tgtAppNonAdmin); err != nil {
@@ -81,26 +83,45 @@ var _ = Describe("Namespace-admin cluster-level migration", func() {
 		err = PrepareSourceApp(srcAppNonAdmin, kubectlSrcNonAdmin)
 		Expect(err).NotTo(HaveOccurred())
 
+		By("Creating Service-Account on namespace")
+		Expect(sa.Create(kubectlSrc)).NotTo(HaveOccurred())
+
 		By("Creating ClusterRole")
 		Expect(cr.Create(kubectlSrc)).NotTo(HaveOccurred())
 
 		By("Creating ClusterRoleBinding")
 		Expect(crb.Create(kubectlSrc)).NotTo(HaveOccurred())
 
+		By("Bind Relevent Service-Account to cluster role")
+		Expect(crb.AddSubject(kubectlSrc, sa)).NotTo(HaveOccurred())
+
 		By("Waiting for source pods and endpoints to drain")
 		WaitForSourceQuiesce(kubectlSrcNonAdmin, namespace, "app="+appName, serviceName)
 
-		By("Running crane export, transform, apply as namespace-admin")
+		By("Namespace admin phase: Running crane export, transform, apply as namespace-admin")
 		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 
-		By("Verifying expected cluster-resource failures for the current platform")
+		By("Namespace admin phase: Verifying expected cluster-resource failures for the current platform")
 		Expect(utils.AssertFilesExist(filepath.Join(paths.ExportDir, "failures", namespace), deniedResources)).NotTo(HaveOccurred())
 
-		By("Verifying no cluster resources in output _cluster directory")
+		By("Namespace admin phase: Verifying no cluster resources in output _cluster directory")
 		Expect(utils.AssertNoKindsInOutput(paths.OutputDir, []string{"ClusterRole", "ClusterRoleBinding"})).NotTo(HaveOccurred())
 
-		By("Applying namespace resources to target as namespace-admin")
+		By("Namespace admin phase: Applying namespace resources to target as namespace-admin")
 		Expect(kubectlTgtNonAdmin.ApplyDir(filepath.Join(paths.OutputDir, "resources", namespace))).NotTo(HaveOccurred())
+
+		By("Cluster admin phase: Running crane export, transform, apply as namespace-admin")
+		//we reuse the same setup so we need to override for the second pipeline run
+		exportOpts.Overwrite = true
+		transformOpts.Overwrite = true
+		applyOpts.Overwrite = true
+		Expect(RunCranePipelineWithChecks(adminRunner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
+
+		By("Cluster admin phase: Verifying cluster resources in output _cluster directory after cluster Admin phase")
+		Expect(utils.AssertKindsInOutput(paths.OutputDir, []string{"ClusterRole", "ClusterRoleBinding"})).NotTo(HaveOccurred())
+
+		By("Cluster admin phase: Applying namespace resources to target as namespace-admin")
+		Expect(kubectlTgt.ApplyDir(filepath.Join(paths.OutputDir, "resources", "_cluster"))).NotTo(HaveOccurred())
 
 		By("Scaling target deployment and validating app")
 		Expect(kubectlTgtNonAdmin.ScaleDeployment(namespace, appName, 1)).NotTo(HaveOccurred())

--- a/e2e-tests/tests/tier0/mta_853_split_apply_test.go
+++ b/e2e-tests/tests/tier0/mta_853_split_apply_test.go
@@ -92,7 +92,7 @@ var _ = Describe("Namespace-admin cluster-level migration", func() {
 		By("Creating ClusterRoleBinding")
 		Expect(crb.Create(kubectlSrc)).NotTo(HaveOccurred())
 
-		By("Bind Relevent Service-Account to cluster role")
+		By("Bind Relevant Service-Account to cluster role")
 		Expect(crb.AddSubject(kubectlSrc, sa)).NotTo(HaveOccurred())
 
 		By("Waiting for source pods and endpoints to drain")
@@ -110,7 +110,7 @@ var _ = Describe("Namespace-admin cluster-level migration", func() {
 		By("Namespace admin phase: Applying namespace resources to target as namespace-admin")
 		Expect(kubectlTgtNonAdmin.ApplyDir(filepath.Join(paths.OutputDir, "resources", namespace))).NotTo(HaveOccurred())
 
-		By("Cluster admin phase: Running crane export, transform, apply as namespace-admin")
+		By("Cluster admin phase: Running crane export, transform, apply as cluster-admin")
 		//we reuse the same setup so we need to override for the second pipeline run
 		exportOpts.Overwrite = true
 		transformOpts.Overwrite = true


### PR DESCRIPTION
## Summary
- Add cluster-admin phase to MTA-853 test to complete the split-apply workflow per test plan NA-1
- Add `Overwrite` field to `ExportOptions` and `ApplyOptions` so the pipeline can re-run with `--overwrite`
- Create ServiceAccount and bind it to ClusterRoleBinding to properly test RBAC discovery

## Why
The previous MTA-853 test only ran the namespace-admin phase — it verified that cluster resources failed for non-admin and applied namespace resources, but never completed the workflow by having a cluster-admin apply the `_cluster/` resources. This didn't match test plan NA-1 which requires both phases with Pod Ready at the end.

## Test plan
- [x] Namespace-admin phase: export/transform/apply, verify cluster resources fail, apply namespace resources
- [x] Cluster-admin phase: re-run pipeline with --overwrite, verify cluster resources in `_cluster/`, apply them
- [x] Pod Ready after both phases


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated the split-apply e2e test to run the export/transform/apply pipeline twice: once with namespace-admin permissions and again with cluster-admin permissions, with dedicated ServiceAccount creation and expanded RBAC cleanup.
  * Added overwrite capability to the e2e export/apply pipeline helpers so the pipeline can be re-run across phases, including assertions that namespace-scoped vs cluster-scoped outputs match expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->