### PR TITLE
:seedling: Code quality improvements for resource ordering

### DIFF
--- a/internal/file/ordering.go
+++ b/internal/file/ordering.go
@@ -26,6 +26,8 @@ var resourceOrder = map[string]int{
 	"VolumeSnapshotClass":         100,
 	"CSIDriver":                   110,
 	"CSINode":                     120,
+	"SecurityContextConstraints":  130,
+
 
 	// Namespace-scoped configuration resources
 	"ResourceQuota":      200,
@@ -34,7 +36,6 @@ var resourceOrder = map[string]int{
 	"Secret":             230,
 	"ConfigMap":          240,
 	"PersistentVolumeClaim": 250,
-	"SecurityContextConstraints": 260,
 
 	// RBAC resources (must come after ServiceAccount)
 	"Role":        300,

--- a/internal/file/ordering.go
+++ b/internal/file/ordering.go
@@ -5,12 +5,14 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-// ResourceOrder defines the application order for Kubernetes resources.
+const defaultResourceOrder = 999
+
+// resourceOrder defines the application order for Kubernetes resources.
 // Lower numbers are applied first to ensure dependencies exist before dependents.
 // All order values must be ≤ 999 to maintain 3-digit padding in ordered filenames.
 // Unknown resource kinds use order 999 to ensure they are applied last.
 // This ordering follows kubectl's resource ordering for apply operations.
-var ResourceOrder = map[string]int{
+var resourceOrder = map[string]int{
 	// Cluster-wide resources
 	"Namespace":                   10,
 	"CustomResourceDefinition":    20,
@@ -32,6 +34,7 @@ var ResourceOrder = map[string]int{
 	"Secret":             230,
 	"ConfigMap":          240,
 	"PersistentVolumeClaim": 250,
+	"SecurityContextConstraints": 260,
 
 	// RBAC resources (must come after ServiceAccount)
 	"Role":        300,
@@ -63,27 +66,23 @@ var ResourceOrder = map[string]int{
 	"Route":              600,
 	"BuildConfig":        610,
 	"Build":              620,
-	"DeploymentConfig":   630,
-	"ImageStream":        640,
-	"ImageStreamTag":     650,
+	"ImageStream":        630,
+	"ImageStreamTag":     640,
+	"DeploymentConfig":   650,
 	"Template":           660,
-	"SecurityContextConstraints": 670,
 
 	// Admission webhooks (must come after workload resources to avoid bootstrap deadlock)
 	"ValidatingWebhookConfiguration": 800,
 	"MutatingWebhookConfiguration":   810,
-
-	// Default for unknown types
-	"_default": 999,
 }
 
 // GetResourceOrder returns the application order for a given resource kind.
 // Resources with lower order values should be applied before those with higher values.
 func GetResourceOrder(kind string) int {
-	if order, exists := ResourceOrder[kind]; exists {
+	if order, exists := resourceOrder[kind]; exists {
 		return order
 	}
-	return ResourceOrder["_default"]
+	return defaultResourceOrder
 }
 
 // GetOrderedResourceFilename returns a filename with an order prefix for dependency-aware application.

--- a/internal/file/ordering_test.go
+++ b/internal/file/ordering_test.go
@@ -53,6 +53,24 @@ func TestGetResourceOrder_ConfigMapBeforeDeployment(t *testing.T) {
 	}
 }
 
+func TestGetResourceOrder_ImageStreamBeforeDeploymentConfig(t *testing.T) {
+	imageStreamOrder := GetResourceOrder("ImageStream")
+	deploymentConfigOrder := GetResourceOrder("DeploymentConfig")
+
+	if imageStreamOrder >= deploymentConfigOrder {
+		t.Errorf("ImageStream order (%d) should be less than DeploymentConfig order (%d)", imageStreamOrder, deploymentConfigOrder)
+	}
+}
+
+func TestGetResourceOrder_SCCBeforeWorkloads(t *testing.T) {
+	securityContextConstraintsOrder := GetResourceOrder("SecurityContextConstraints")
+	podOrder := GetResourceOrder("Pod")
+
+	if securityContextConstraintsOrder >= podOrder {
+		t.Errorf("SecurityContextConstraints order (%d) should be less than Pod order (%d) — SCCs must exist before pods are scheduled", securityContextConstraintsOrder, podOrder)
+	}
+}
+
 func TestGetResourceOrder_WebhooksAfterWorkloads(t *testing.T) {
 	// Webhooks must come after workloads to avoid bootstrap deadlock
 	deploymentOrder := GetResourceOrder("Deployment")
@@ -145,11 +163,14 @@ func TestOrderValues_MaxThreeDigits(t *testing.T) {
 	// Ensure all order values are ≤ 999 to maintain 3-digit padding
 	// This prevents the sorting bug where 4-digit values (e.g., 1000) sort
 	// lexicographically before 3-digit values (e.g., 240)
-	for kind, order := range ResourceOrder {
+	for kind, order := range resourceOrder {
 		if order > 999 {
 			t.Errorf("Order value for %s is %d, but must be ≤ 999 to maintain 3-digit padding. "+
 				"Either reduce the order value or switch to 4-digit padding (%%04d)", kind, order)
 		}
+	}
+	if defaultResourceOrder > 999 {
+		t.Errorf("Default order value is %d, but must be ≤ 999 to maintain 3-digit padding", defaultResourceOrder)
 	}
 }
 
@@ -157,9 +178,9 @@ func TestOrderedFilenames_LexicographicSorting(t *testing.T) {
 	// Verify that ordered filenames sort lexicographically in the same order as numeric ordering
 	// This is critical for tools that apply resources in sorted filename order
 	testResources := []struct {
-		kind     string
-		name     string
-		order    int
+		kind  string
+		name  string
+		order int
 	}{
 		{"Namespace", "ns1", 10},
 		{"ConfigMap", "cm1", 240},


### PR DESCRIPTION
## Summary
  Post-merge code quality improvements identified after [PR #525.](https://github.com/migtools/crane/pull/525)
  
  - **Remove `_default` sentinel**: `"_default": 999` was a non-Kubernetes key mixed into the resource map.
  Replaced with `const defaultResourceOrder = 999` - separates control logic from data.
  - **Unexport `resourceOrder`**: The map was exported but only `GetResourceOrder()` is the intended public API.
  Renaming prevents accidental mutation from outside the package.
  - **Fix OpenShift ordering**: `ImageStream` now applies before `DeploymentConfig` (DC image triggers reference
  ImageStream at apply time). `SecurityContextConstraints` moved to order 260, before workloads - SCCs must exist
  before OpenShift admission control checks pods.

  ## Test plan
  - [ ] `go test ./internal/file/...` passes
  - [ ] New tests verify: `ImageStream < DeploymentConfig`, `SecurityContextConstraints < Pod`
  - [ ] `defaultResourceOrder` is validated by `TestOrderValues_MaxThreeDigits`

  Closes [#619](https://github.com/migtools/crane/issues/619)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the ordering of resource types in generated output, including placing security constraints before workload resources.
  * Added consistent fallback ordering for resource types that are not explicitly recognized.
  * Refined ordering behavior for image streams and deployment configurations to produce more predictable results.

* **Tests**
  * Expanded coverage to verify resource ordering and ensure generated filenames remain consistently sorted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->