### PR TITLE
:seedling: Add cherry-pick workflow for release branches

### DIFF
--- a/.github/workflows/pr-closed.yaml
+++ b/.github/workflows/pr-closed.yaml
@@ -1,0 +1,16 @@
+name: Cherry-pick to release branches
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - closed
+
+jobs:
+  cherry_pick_job:
+    if: github.event.pull_request.merged == true
+    permissions:
+      pull-requests: write
+      contents: write
+    uses: konveyor/release-tools/.github/workflows/cherry-pick.yml@main
+    secrets: inherit


### PR DESCRIPTION
Whenever a PR is merged to main, if the PR has a cherry-pick/release-0.x label, a backport PR gets created automatically for the release-0.x branch.


