### PR TITLE
:test_tube: Add e2e test for Deployment with missing ConfigMap reference

### DIFF
--- a/e2e-tests/testdata/broken-ref-deployment.yaml
+++ b/e2e-tests/testdata/broken-ref-deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: broken-ref-deploy
+  namespace: mta-841-missing-cm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: broken-ref-deploy
+  template:
+    metadata:
+      labels:
+        app: broken-ref-deploy
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:alpine
+          envFrom:
+            - configMapRef:
+                name: missing-configmap

--- a/e2e-tests/testdata/broken-ref-deployment.yaml
+++ b/e2e-tests/testdata/broken-ref-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: broken-ref-deploy
-  namespace: mta-841-missing-cm
+  namespace: __NAMESPACE__
 spec:
   replicas: 1
   selector:

--- a/e2e-tests/tests/tier1/mta_841_missing_configmap_ref_test.go
+++ b/e2e-tests/tests/tier1/mta_841_missing_configmap_ref_test.go
@@ -1,0 +1,93 @@
+package e2e
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	"github.com/konveyor/crane/e2e-tests/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Missing ConfigMap reference migration", func() {
+	It("[MTA-841] crane migrates deployment with missing ConfigMap reference intact", Label("tier1"), func() {
+		namespace := "mta-841-missing-cm"
+		missingCMName := "missing-configmap"
+		scenario := NewMigrationScenario(
+			namespace,
+			namespace,
+			config.K8sDeployBin,
+			config.CraneBin,
+			config.SourceContext,
+			config.TargetContext,
+		)
+
+		kubectlSrc := scenario.KubectlSrc
+		kubectlTgt := scenario.KubectlTgt
+
+		paths, err := NewScenarioPaths("crane-export-*")
+		Expect(err).NotTo(HaveOccurred())
+		exportOpts := ExportOptions{Namespace: namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir, OutputDir: paths.OutputDir}
+		DeferCleanup(func() {
+			By("Delete source and target namespaces")
+			if _, err := kubectlSrc.Run("delete", "namespace", namespace, "--ignore-not-found=true", "--wait=true", "--timeout=60s"); err != nil {
+				log.Printf("cleanup: %v", err)
+			}
+			if _, err := kubectlTgt.Run("delete", "namespace", namespace, "--ignore-not-found=true", "--wait=true", "--timeout=60s"); err != nil {
+				log.Printf("cleanup: %v", err)
+			}
+
+			By("Cleanup namespace and temp dir")
+			Expect(os.RemoveAll(paths.TempDir)).To(Succeed())
+		})
+
+		By("Create source namespace")
+		_, err = kubectlSrc.Run("create", "namespace", namespace)
+		Expect(err).NotTo(HaveOccurred())
+		log.Printf("Created source namespace %s\n", namespace)
+
+		By("Apply Deployment with missing ConfigMap reference to source")
+		deploymentYAML, err := utils.ReadTestdataFile("broken-ref-deployment.yaml")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = kubectlSrc.RunWithStdin(deploymentYAML, "apply", "-f", "-")
+		Expect(err).NotTo(HaveOccurred())
+		log.Printf("Applied deployment with broken ConfigMap ref %s\n", missingCMName)
+
+		runner := scenario.Crane
+		runner.WorkDir = paths.TempDir
+
+		By("Run crane export/transform/apply pipeline")
+		log.Printf("Running crane pipeline for namespace %s\n", namespace)
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
+		log.Printf("Crane pipeline completed for namespace %s\n", namespace)
+
+		By("Verify Deployment manifest exists in output directory")
+		deploymentManifest := filepath.Join(paths.OutputDir, "resources", namespace, "*Deployment*.yaml")
+		matches, err := filepath.Glob(deploymentManifest)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(matches).NotTo(BeEmpty(), "Expected at least one Deployment manifest")
+		log.Printf("Deployment resource present in output dir: %s\n", matches[0])
+
+		By("Verify broken ConfigMap reference is preserved in output YAML")
+		content, err := os.ReadFile(matches[0])
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(content)).To(ContainSubstring(missingCMName))
+		log.Printf("Verified broken ConfigMap ref %s is preserved in output YAML\n", missingCMName)
+
+		By("Apply rendered manifests to target")
+		log.Printf("Applying rendered manifests on target namespace %s from %s\n", namespace, paths.OutputDir)
+		Expect(ApplyOutputToTarget(kubectlTgt, namespace, paths.OutputDir)).NotTo(HaveOccurred())
+
+		By("Verify broken ConfigMap reference is preserved on target cluster")
+		out, err := kubectlTgt.Run("get", "deployment", "broken-ref-deploy", "-n", namespace, "-o", "jsonpath={.spec.template.spec.containers[0].envFrom[0].configMapRef.name}")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(Equal(missingCMName))
+		log.Printf("Verified broken ConfigMap ref %s is present on target\n", missingCMName)
+
+	})
+})

--- a/e2e-tests/tests/tier1/mta_841_missing_configmap_ref_test.go
+++ b/e2e-tests/tests/tier1/mta_841_missing_configmap_ref_test.go
@@ -56,6 +56,7 @@ var _ = Describe("Missing ConfigMap reference migration", func() {
 		By("Apply Deployment with missing ConfigMap reference to source")
 		deploymentYAML, err := utils.ReadTestdataFile("broken-ref-deployment.yaml")
 		Expect(err).NotTo(HaveOccurred())
+		deploymentYAML = strings.ReplaceAll(deploymentYAML, "__NAMESPACE__", namespace)
 		_, err = kubectlSrc.RunWithStdin(deploymentYAML, "apply", "-f", "-")
 		Expect(err).NotTo(HaveOccurred())
 		log.Printf("Applied deployment with broken ConfigMap ref %s\n", missingCMName)

--- a/e2e-tests/tests/tier1/mta_841_missing_configmap_ref_test.go
+++ b/e2e-tests/tests/tier1/mta_841_missing_configmap_ref_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"log"
+	"strings"
 	"os"
 	"path/filepath"
 

--- a/e2e-tests/tests/tier1/mta_841_missing_configmap_ref_test.go
+++ b/e2e-tests/tests/tier1/mta_841_missing_configmap_ref_test.go
@@ -43,7 +43,9 @@ var _ = Describe("Missing ConfigMap reference migration", func() {
 			}
 
 			By("Cleanup namespace and temp dir")
-			Expect(os.RemoveAll(paths.TempDir)).To(Succeed())
+			if err := os.RemoveAll(paths.TempDir); err != nil {
+				log.Printf("cleanup: failed to remove temp dir: %v", err)
+			}
 		})
 
 		By("Create source namespace")
@@ -66,6 +68,12 @@ var _ = Describe("Missing ConfigMap reference migration", func() {
 		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 		log.Printf("Crane pipeline completed for namespace %s\n", namespace)
 
+		By("Verify no export failures")
+		failuresDir := filepath.Join(paths.ExportDir, "failures", namespace)
+		hasFiles, _, err := utils.HasFilesRecursively(failuresDir)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(hasFiles).To(BeFalse(), "unexpected files in export failures directory")
+
 		By("Verify Deployment manifest exists in output directory")
 		deploymentManifest := filepath.Join(paths.OutputDir, "resources", namespace, "*Deployment*.yaml")
 		matches, err := filepath.Glob(deploymentManifest)
@@ -76,8 +84,12 @@ var _ = Describe("Missing ConfigMap reference migration", func() {
 		By("Verify broken ConfigMap reference is preserved in output YAML")
 		content, err := os.ReadFile(matches[0])
 		Expect(err).NotTo(HaveOccurred())
-		Expect(string(content)).To(ContainSubstring(missingCMName))
+		Expect(string(content)).To(ContainSubstring("name: " + missingCMName))
 		log.Printf("Verified broken ConfigMap ref %s is preserved in output YAML\n", missingCMName)
+
+		By("Dry-run apply output manifests on target")
+		Expect(kubectlTgt.CreateNamespace(namespace)).NotTo(HaveOccurred())
+		Expect(kubectlTgt.ValidateApplyDir(paths.OutputDir)).NotTo(HaveOccurred())
 
 		By("Apply rendered manifests to target")
 		log.Printf("Applying rendered manifests on target namespace %s from %s\n", namespace, paths.OutputDir)

--- a/e2e-tests/tests/tier1/mta_841_missing_configmap_ref_test.go
+++ b/e2e-tests/tests/tier1/mta_841_missing_configmap_ref_test.go
@@ -49,8 +49,7 @@ var _ = Describe("Missing ConfigMap reference migration", func() {
 		})
 
 		By("Create source namespace")
-		_, err = kubectlSrc.Run("create", "namespace", namespace)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(kubectlSrc.CreateNamespace(namespace)).NotTo(HaveOccurred())
 		log.Printf("Created source namespace %s\n", namespace)
 
 		By("Apply Deployment with missing ConfigMap reference to source")


### PR DESCRIPTION
[#501](https://github.com/migtools/crane/issues/501)

## Summary
  Adds a tier1 E2E test to verify that Crane correctly migrates a namespace
  containing a Deployment that references a non-existent ConfigMap.

  #### How it works
  - Creates a source namespace with a Deployment that references `missing-configmap` via `envFrom` - a ConfigMap that does not exist on the
  cluster
  - Runs the full crane `export` → `transform` → `apply` pipeline
  - Verifies the pipeline completes without errors
  - Verifies the broken reference is preserved in the output YAML (no silent modification by transform plugins)
  - Applies the output to the target cluster and verifies the Deployment landed with the same broken reference intact

  #### Verification Logic
  - **Pipeline:** `RunCranePipelineWithChecks` - fails if any stage errors or produces empty output
  - **Output YAML:** `os.ReadFile` + `ContainSubstring` - ensures the broken ConfigMap reference was not dropped or modified during transform
  - **Target cluster:** `kubectl get deployment -o jsonpath= {.spec.template.spec.containers[0].envFrom[0].configMapRef.name}` - verifies the reference landed unchanged on target


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new end-to-end coverage for a Deployment that references a missing ConfigMap.
  * Verified that migration keeps the broken/missing ConfigMap reference in the rendered output and after applying to the target cluster.
  * Added supporting Kubernetes test manifest and ensured temporary namespaces/resources are cleaned up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->