### PR TITLE
:seedling: Enable build release binaries for release-* branches

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release-0.*
     tags:
       - "*"
   schedule:
@@ -15,70 +16,9 @@ permissions:
 
 jobs:
   build:
-    name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - goos: linux
-            goarch: amd64
-          - goos: linux
-            goarch: arm64
-          - goos: darwin
-            goarch: amd64
-          - goos: darwin
-            goarch: arm64
-          - goos: windows
-            goarch: amd64
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Go 1.25
-        uses: actions/setup-go@v6
-        with:
-          go-version: "1.25"
-
-      - name: Build binary
-        env:
-          GOOS: ${{ matrix.goos }}
-          GOARCH: ${{ matrix.goarch }}
-          CGO_ENABLED: "0"
-          BUILD_VERSION: ${{ github.ref_type == 'tag' && github.ref_name || format('main-{0}', github.sha) }}
-          BUILD_COMMIT: ${{ github.sha }}
-        run: |
-          mkdir -p dist
-
-          ext=""
-          if [ "$GOOS" = "windows" ]; then
-            ext=".exe"
-          fi
-
-          binary="crane_${GOOS}_${GOARCH}${ext}"
-          go build -trimpath \
-            -ldflags "-X github.com/konveyor/crane/internal/buildinfo.Version=${BUILD_VERSION} -X github.com/konveyor/crane/internal/buildinfo.BuildCommit=${BUILD_COMMIT}" \
-            -o "dist/${binary}" .
-
-          # Validate version injection for each built artifact.
-          if ! strings "dist/${binary}" | grep -Fq "${BUILD_VERSION}"; then
-            echo "Injected version ${BUILD_VERSION} not found in ${binary}"
-            exit 1
-          fi
-
-          (
-            cd dist
-            sha256sum "${binary}" > "${binary}.sha256"
-          )
-
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: crane-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: |
-            dist/crane_${{ matrix.goos }}_${{ matrix.goarch }}*
-          retention-days: 30
+    uses: ./.github/workflows/reusable-build-release-binaries.yml
+    with:
+      checkout_ref: ${{ github.ref }}
 
   release:
     name: Draft release for tag

--- a/.github/workflows/nightly-release-0.10-build-binaries.yml
+++ b/.github/workflows/nightly-release-0.10-build-binaries.yml
@@ -1,0 +1,15 @@
+name: Nightly Build Crane Binaries (release-0.10)
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-release-0-10:
+    uses: ./.github/workflows/reusable-build-release-binaries.yml
+    with:
+      checkout_ref: refs/heads/release-0.10

--- a/.github/workflows/nightly-release-0.10-build-binaries.yml
+++ b/.github/workflows/nightly-release-0.10-build-binaries.yml
@@ -12,4 +12,4 @@ jobs:
   build-release-0-10:
     uses: ./.github/workflows/reusable-build-release-binaries.yml
     with:
-      checkout_ref: refs/heads/release-0.10
+      checkout_ref: release-0.10

--- a/.github/workflows/reusable-build-release-binaries.yml
+++ b/.github/workflows/reusable-build-release-binaries.yml
@@ -1,0 +1,99 @@
+name: Reusable Build Crane Binaries
+
+on:
+  workflow_call:
+    inputs:
+      checkout_ref:
+        description: Git ref to checkout before building binaries
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+          - goos: windows
+            goarch: amd64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.checkout_ref }}
+
+      - name: Set up Go 1.25
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.25"
+
+      - name: Resolve build metadata
+        id: buildmeta
+        shell: bash
+        run: |
+          BUILD_COMMIT="$(git rev-parse HEAD)"
+          if TAG_NAME="$(git describe --tags --exact-match 2>/dev/null)"; then
+            BUILD_VERSION="${TAG_NAME}"
+          else
+            REF_NAME="${{ inputs.checkout_ref }}"
+            REF_NAME="${REF_NAME#refs/heads/}"
+            REF_NAME="${REF_NAME#refs/tags/}"
+            REF_NAME="${REF_NAME//\//-}"
+            BUILD_VERSION="${REF_NAME}-${BUILD_COMMIT}"
+          fi
+
+          echo "build_version=${BUILD_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "build_commit=${BUILD_COMMIT}" >> "$GITHUB_OUTPUT"
+
+      - name: Build binary
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: "0"
+          BUILD_VERSION: ${{ steps.buildmeta.outputs.build_version }}
+          BUILD_COMMIT: ${{ steps.buildmeta.outputs.build_commit }}
+        run: |
+          mkdir -p dist
+
+          ext=""
+          if [ "$GOOS" = "windows" ]; then
+            ext=".exe"
+          fi
+
+          binary="crane_${GOOS}_${GOARCH}${ext}"
+          go build -trimpath \
+            -ldflags "-X github.com/konveyor/crane/internal/buildinfo.Version=${BUILD_VERSION} -X github.com/konveyor/crane/internal/buildinfo.BuildCommit=${BUILD_COMMIT}" \
+            -o "dist/${binary}" .
+
+          # Validate version injection for each built artifact.
+          if ! strings "dist/${binary}" | grep -Fq "${BUILD_VERSION}"; then
+            echo "Injected version ${BUILD_VERSION} not found in ${binary}"
+            exit 1
+          fi
+
+          (
+            cd dist
+            sha256sum "${binary}" > "${binary}.sha256"
+          )
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: crane-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: |
+            dist/crane_${{ matrix.goos }}_${{ matrix.goarch }}*
+          retention-days: 30

--- a/.github/workflows/reusable-build-release-binaries.yml
+++ b/.github/workflows/reusable-build-release-binaries.yml
@@ -44,12 +44,14 @@ jobs:
       - name: Resolve build metadata
         id: buildmeta
         shell: bash
+        env:
+          CHECKOUT_REF: ${{ inputs.checkout_ref }}
         run: |
           BUILD_COMMIT="$(git rev-parse HEAD)"
           if TAG_NAME="$(git describe --tags --exact-match 2>/dev/null)"; then
             BUILD_VERSION="${TAG_NAME}"
           else
-            REF_NAME="${{ inputs.checkout_ref }}"
+            REF_NAME="${CHECKOUT_REF}"
             REF_NAME="${REF_NAME#refs/heads/}"
             REF_NAME="${REF_NAME#refs/tags/}"
             REF_NAME="${REF_NAME//\//-}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated nightly builds for the release-0.10 line.
  * Expanded release build coverage to include multiple Linux, macOS, and Windows architectures.
  * Release artifacts now include version metadata and SHA256 checksum files.

* **Improvements**
  * Standardized release binary creation through a reusable build process.
  * Added validation to confirm version information is embedded in generated binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->