### PR TITLE
:sparkles: Add support for intra cluster Storage class conversion in transfer-pvc

### DIFF
--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -402,7 +402,7 @@ func (t *TransferPVCCommand) run() error {
 		}
 		err = srcClient.Create(context.TODO(), srcSecret)
 		if err != nil && !errors.IsAlreadyExists(err) {
-			log.Fatal(err, "failed to create certificate secret on source cluster")
+			log.Fatalf("failed to create certificate Secret %q in namespace %q on source cluster: %v", secretName, srcPVC.Namespace, err)
 		}
 	}
 

--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -230,6 +230,10 @@ func (t *TransferPVCCommand) Validate() error {
 		return fmt.Errorf("cannot evaluate destination context")
 	}
 
+	if t.isIntraCluster() && t.PVC.Name.source == t.PVC.Name.destination {
+		return fmt.Errorf("source and destination PVC names must differ for same-cluster same-namespace transfers")
+	}
+
 	err := t.PVC.Validate()
 	if err != nil {
 		return err
@@ -401,7 +405,19 @@ func (t *TransferPVCCommand) run() error {
 			Data:       destSecret.Data,
 		}
 		err = srcClient.Create(context.TODO(), srcSecret)
-		if err != nil && !errors.IsAlreadyExists(err) {
+		if errors.IsAlreadyExists(err) {
+			existing := &corev1.Secret{}
+			if getErr := srcClient.Get(context.TODO(), client.ObjectKey{Name: secretName, Namespace: srcPVC.Namespace}, existing); getErr != nil {
+				log.Fatalf("failed to get existing certificate Secret %q in namespace %q: %v", secretName, srcPVC.Namespace, getErr)
+			}
+			existing.Data = destSecret.Data
+			existing.StringData = destSecret.StringData
+			existing.Labels = secretLabels
+			existing.Annotations = destSecret.Annotations
+			if updateErr := srcClient.Update(context.TODO(), existing); updateErr != nil {
+				log.Fatalf("failed to update certificate Secret %q in namespace %q: %v", secretName, srcPVC.Namespace, updateErr)
+			}
+		} else if err != nil {
 			log.Fatalf("failed to create certificate Secret %q in namespace %q on source cluster: %v", secretName, srcPVC.Namespace, err)
 		}
 	}

--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -230,7 +230,7 @@ func (t *TransferPVCCommand) Validate() error {
 		return fmt.Errorf("cannot evaluate destination context")
 	}
 
-	if t.isIntraCluster() && t.PVC.Name.source == t.PVC.Name.destination {
+	if t.isIntraClusterSameNamespace() && t.PVC.Name.source == t.PVC.Name.destination {
 		return fmt.Errorf("source and destination PVC names must differ for same-cluster same-namespace transfers")
 	}
 
@@ -251,10 +251,10 @@ func (t *TransferPVCCommand) Run() error {
 	return t.run()
 }
 
-// isIntraCluster returns true when source and destination are on the same
+// isIntraClusterSameNamespace returns true when source and destination are on the same
 // cluster AND the same namespace. This requires special handling for stunnel
 // cert secrets and pod labels to avoid collisions.
-func (t *TransferPVCCommand) isIntraCluster() bool {
+func (t *TransferPVCCommand) isIntraClusterSameNamespace() bool {
 	return t.sourceContext != nil && t.destinationContext != nil &&
 		t.sourceContext.Cluster == t.destinationContext.Cluster &&
 		t.PVC.Namespace.source == t.PVC.Namespace.destination
@@ -336,7 +336,7 @@ func (t *TransferPVCCommand) run() error {
 	// For intra-cluster (same namespace), split labels so the log reader
 	// can distinguish server and client pods.
 	clientLabels := labels
-	if t.isIntraCluster() {
+	if t.isIntraClusterSameNamespace() {
 		labels["app.konveyor.io/role"] = "server"
 		labels["app.konveyor.io/created-for-pvc"] = getValidatedResourceName(destPVC.Name)
 		clientLabels = map[string]string{
@@ -387,11 +387,11 @@ func (t *TransferPVCCommand) run() error {
 		// For intra-cluster: the server cert secret is named after destPVC,
 		// but the client expects one named after srcPVC. Copy with the
 		// client's expected name so both use the same CA.
-		if t.isIntraCluster() {
+		if t.isIntraClusterSameNamespace() {
 			secretName = fmt.Sprintf("stunnel-creds-certs-%s", getValidatedResourceName(srcPVC.Name))
 		}
 		secretLabels := destSecret.Labels
-		if t.isIntraCluster() {
+		if t.isIntraClusterSameNamespace() {
 			secretLabels = clientLabels
 		}
 		srcSecret := &corev1.Secret{
@@ -538,7 +538,7 @@ func (t *TransferPVCCommand) run() error {
 		log.Fatal(err, "error following rsync client logs")
 	}
 
-	if t.isIntraCluster() {
+	if t.isIntraClusterSameNamespace() {
 		if err := garbageCollect(srcClient, destClient, labels, t.Endpoint.Type, t.PVC.Namespace); err != nil {
 			log.Printf("WARN: server-side cleanup: %v", err)
 		}

--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -230,10 +230,6 @@ func (t *TransferPVCCommand) Validate() error {
 		return fmt.Errorf("cannot evaluate destination context")
 	}
 
-	if t.sourceContext.Cluster == t.destinationContext.Cluster {
-		return fmt.Errorf("both source and destination cluster are the same, this is not support right now, coming soon")
-	}
-
 	err := t.PVC.Validate()
 	if err != nil {
 		return err
@@ -249,6 +245,15 @@ func (t *TransferPVCCommand) Validate() error {
 
 func (t *TransferPVCCommand) Run() error {
 	return t.run()
+}
+
+// isIntraCluster returns true when source and destination are on the same
+// cluster AND the same namespace. This requires special handling for stunnel
+// cert secrets and pod labels to avoid collisions.
+func (t *TransferPVCCommand) isIntraCluster() bool {
+	return t.sourceContext != nil && t.destinationContext != nil &&
+		t.sourceContext.Cluster == t.destinationContext.Cluster &&
+		t.PVC.Namespace.source == t.PVC.Namespace.destination
 }
 
 func (t *TransferPVCCommand) getClientFromContext(ctx string) (client.Client, error) {
@@ -324,6 +329,20 @@ func (t *TransferPVCCommand) run() error {
 		"app.konveyor.io/created-for-pvc": getValidatedResourceName(srcPVC.Name),
 	}
 
+	// For intra-cluster (same namespace), split labels so the log reader
+	// can distinguish server and client pods.
+	clientLabels := labels
+	if t.isIntraCluster() {
+		labels["app.konveyor.io/role"] = "server"
+		labels["app.konveyor.io/created-for-pvc"] = getValidatedResourceName(destPVC.Name)
+		clientLabels = map[string]string{
+			"app.kubernetes.io/name":          "crane",
+			"app.kubernetes.io/component":     "transfer-pvc",
+			"app.konveyor.io/role":            "client",
+			"app.konveyor.io/created-for-pvc": getValidatedResourceName(srcPVC.Name),
+		}
+	}
+
 	e, err := createEndpoint(t.Endpoint, destPVC, labels, logger, destClient)
 	if err != nil {
 		log.Fatal(err, "failed creating endpoint")
@@ -360,18 +379,29 @@ func (t *TransferPVCCommand) run() error {
 
 	for i := range secretList.Items {
 		destSecret := &secretList.Items[i]
+		secretName := destSecret.Name
+		// For intra-cluster: the server cert secret is named after destPVC,
+		// but the client expects one named after srcPVC. Copy with the
+		// client's expected name so both use the same CA.
+		if t.isIntraCluster() {
+			secretName = fmt.Sprintf("stunnel-creds-certs-%s", getValidatedResourceName(srcPVC.Name))
+		}
+		secretLabels := destSecret.Labels
+		if t.isIntraCluster() {
+			secretLabels = clientLabels
+		}
 		srcSecret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        destSecret.Name,
+				Name:        secretName,
 				Namespace:   srcPVC.Namespace,
-				Labels:      destSecret.Labels,
+				Labels:      secretLabels,
 				Annotations: destSecret.Annotations,
 			},
 			StringData: destSecret.StringData,
 			Data:       destSecret.Data,
 		}
 		err = srcClient.Create(context.TODO(), srcSecret)
-		if err != nil {
+		if err != nil && !errors.IsAlreadyExists(err) {
 			log.Fatal(err, "failed to create certificate secret on source cluster")
 		}
 	}
@@ -384,7 +414,7 @@ func (t *TransferPVCCommand) run() error {
 			Name:      getValidatedResourceName(srcPVC.Name),
 			Namespace: srcPVC.Namespace,
 		}, e.Hostname(), e.IngressPort(), &transport.Options{
-			Labels: labels,
+			Labels: clientLabels,
 			Image:  t.Flags.DestinationImage,
 		},
 	)
@@ -458,7 +488,7 @@ func (t *TransferPVCCommand) run() error {
 
 	_, err = rsynctransfer.NewClient(
 		context.TODO(),
-		srcClient, srcPVCList, stunnelClient, logger, "rsync-client", labels, nil,
+		srcClient, srcPVCList, stunnelClient, logger, "rsync-client", clientLabels, nil,
 		transfer.PodOptions{
 			NodeName: nodeName,
 			CommandOptions: rsynctransfer.NewDefaultOptionsFrom(
@@ -487,11 +517,17 @@ func (t *TransferPVCCommand) run() error {
 	}
 
 	err = followClientLogs(
-		srcCfg, types.NamespacedName{Name: srcPVC.Name, Namespace: srcPVC.Namespace}, labels, t.ProgressOutput)
+		srcCfg, types.NamespacedName{Name: srcPVC.Name, Namespace: srcPVC.Namespace}, clientLabels, t.ProgressOutput)
 	if err != nil {
 		log.Fatal(err, "error following rsync client logs")
 	}
 
+	if t.isIntraCluster() {
+		if err := garbageCollect(srcClient, destClient, labels, t.Endpoint.Type, t.PVC.Namespace); err != nil {
+			log.Printf("WARN: server-side cleanup: %v", err)
+		}
+		return garbageCollect(srcClient, destClient, clientLabels, t.Endpoint.Type, t.PVC.Namespace)
+	}
 	return garbageCollect(srcClient, destClient, labels, t.Endpoint.Type, t.PVC.Namespace)
 }
 

--- a/cmd/transfer-pvc/transfer-pvc_test.go
+++ b/cmd/transfer-pvc/transfer-pvc_test.go
@@ -877,10 +877,13 @@ func TestValidateRejectsSameNameIntraCluster(t *testing.T) {
 			cmd: TransferPVCCommand{
 				sourceContext:      &clientcmdapi.Context{Cluster: "c1"},
 				destinationContext: &clientcmdapi.Context{Cluster: "c1"},
-				Flags: Flags{PVC: PvcFlags{
-					Name:      mappedNameVar{source: "mysql-data", destination: "mysql-data-new"},
-					Namespace: mappedNameVar{source: "ns1", destination: "ns1"},
-				}},
+				Flags: Flags{
+					PVC: PvcFlags{
+						Name:      mappedNameVar{source: "mysql-data", destination: "mysql-data-new"},
+						Namespace: mappedNameVar{source: "ns1", destination: "ns1"},
+					},
+					Endpoint: EndpointFlags{Subdomain: "test.example.com"},
+				},
 			},
 			wantErr: false,
 		},
@@ -889,10 +892,13 @@ func TestValidateRejectsSameNameIntraCluster(t *testing.T) {
 			cmd: TransferPVCCommand{
 				sourceContext:      &clientcmdapi.Context{Cluster: "c1"},
 				destinationContext: &clientcmdapi.Context{Cluster: "c2"},
-				Flags: Flags{PVC: PvcFlags{
-					Name:      mappedNameVar{source: "mysql-data", destination: "mysql-data"},
-					Namespace: mappedNameVar{source: "ns1", destination: "ns1"},
-				}},
+				Flags: Flags{
+					PVC: PvcFlags{
+						Name:      mappedNameVar{source: "mysql-data", destination: "mysql-data"},
+						Namespace: mappedNameVar{source: "ns1", destination: "ns1"},
+					},
+					Endpoint: EndpointFlags{Subdomain: "test.example.com"},
+				},
 			},
 			wantErr: false,
 		},
@@ -906,8 +912,8 @@ func TestValidateRejectsSameNameIntraCluster(t *testing.T) {
 			if tt.wantErr && err != nil && !strings.Contains(err.Error(), "must differ") {
 				t.Errorf("Validate() returned unexpected error: %v", err)
 			}
-			if !tt.wantErr && err != nil && strings.Contains(err.Error(), "must differ") {
-				t.Errorf("Validate() should not have rejected this case: %v", err)
+			if !tt.wantErr && err != nil {
+				t.Errorf("Validate() returned unexpected error: %v", err)
 			}
 		})
 	}

--- a/cmd/transfer-pvc/transfer-pvc_test.go
+++ b/cmd/transfer-pvc/transfer-pvc_test.go
@@ -835,8 +835,8 @@ func TestIsIntraCluster(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.cmd.isIntraCluster(); got != tt.want {
-				t.Errorf("isIntraCluster() = %v, want %v", got, tt.want)
+			if got := tt.cmd.isIntraClusterSameNamespace(); got != tt.want {
+				t.Errorf("isIntraClusterSameNamespace() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/cmd/transfer-pvc/transfer-pvc_test.go
+++ b/cmd/transfer-pvc/transfer-pvc_test.go
@@ -2,6 +2,7 @@ package transfer_pvc
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -836,6 +837,77 @@ func TestIsIntraCluster(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.cmd.isIntraCluster(); got != tt.want {
 				t.Errorf("isIntraCluster() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateRejectsSameNameIntraCluster(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmd     TransferPVCCommand
+		wantErr bool
+	}{
+		{
+			name: "same name same cluster same namespace is rejected",
+			cmd: TransferPVCCommand{
+				sourceContext:      &clientcmdapi.Context{Cluster: "c1"},
+				destinationContext: &clientcmdapi.Context{Cluster: "c1"},
+				Flags: Flags{PVC: PvcFlags{
+					Name:      mappedNameVar{source: "mysql-data", destination: "mysql-data"},
+					Namespace: mappedNameVar{source: "ns1", destination: "ns1"},
+				}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "no colon pvc-name same cluster same namespace is rejected",
+			cmd: TransferPVCCommand{
+				sourceContext:      &clientcmdapi.Context{Cluster: "c1"},
+				destinationContext: &clientcmdapi.Context{Cluster: "c1"},
+				Flags: Flags{PVC: PvcFlags{
+					Name:      mappedNameVar{source: "mysql-data", destination: "mysql-data"},
+					Namespace: mappedNameVar{source: "ns1", destination: "ns1"},
+				}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "different name same cluster same namespace is allowed",
+			cmd: TransferPVCCommand{
+				sourceContext:      &clientcmdapi.Context{Cluster: "c1"},
+				destinationContext: &clientcmdapi.Context{Cluster: "c1"},
+				Flags: Flags{PVC: PvcFlags{
+					Name:      mappedNameVar{source: "mysql-data", destination: "mysql-data-new"},
+					Namespace: mappedNameVar{source: "ns1", destination: "ns1"},
+				}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "same name cross cluster is allowed",
+			cmd: TransferPVCCommand{
+				sourceContext:      &clientcmdapi.Context{Cluster: "c1"},
+				destinationContext: &clientcmdapi.Context{Cluster: "c2"},
+				Flags: Flags{PVC: PvcFlags{
+					Name:      mappedNameVar{source: "mysql-data", destination: "mysql-data"},
+					Namespace: mappedNameVar{source: "ns1", destination: "ns1"},
+				}},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cmd.Validate()
+			if tt.wantErr && err == nil {
+				t.Error("Validate() should have returned error but didn't")
+			}
+			if tt.wantErr && err != nil && !strings.Contains(err.Error(), "must differ") {
+				t.Errorf("Validate() returned unexpected error: %v", err)
+			}
+			if !tt.wantErr && err != nil && strings.Contains(err.Error(), "must differ") {
+				t.Errorf("Validate() should not have rejected this case: %v", err)
 			}
 		})
 	}

--- a/cmd/transfer-pvc/transfer-pvc_test.go
+++ b/cmd/transfer-pvc/transfer-pvc_test.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -774,6 +775,67 @@ func TestTruncateWithHash(t *testing.T) {
 			again := truncateWithHash(tt.input)
 			if result != again {
 				t.Errorf("truncateWithHash() not deterministic: got %q then %q", result, again)
+			}
+		})
+	}
+}
+
+func TestIsIntraCluster(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  TransferPVCCommand
+		want bool
+	}{
+		{
+			name: "same cluster same namespace",
+			cmd: TransferPVCCommand{
+				sourceContext:      &clientcmdapi.Context{Cluster: "cluster-a"},
+				destinationContext: &clientcmdapi.Context{Cluster: "cluster-a"},
+				Flags:              Flags{PVC: PvcFlags{Namespace: mappedNameVar{source: "ns1", destination: "ns1"}}},
+			},
+			want: true,
+		},
+		{
+			name: "same cluster different namespace",
+			cmd: TransferPVCCommand{
+				sourceContext:      &clientcmdapi.Context{Cluster: "cluster-a"},
+				destinationContext: &clientcmdapi.Context{Cluster: "cluster-a"},
+				Flags:              Flags{PVC: PvcFlags{Namespace: mappedNameVar{source: "ns1", destination: "ns2"}}},
+			},
+			want: false,
+		},
+		{
+			name: "different cluster same namespace",
+			cmd: TransferPVCCommand{
+				sourceContext:      &clientcmdapi.Context{Cluster: "cluster-a"},
+				destinationContext: &clientcmdapi.Context{Cluster: "cluster-b"},
+				Flags:              Flags{PVC: PvcFlags{Namespace: mappedNameVar{source: "ns1", destination: "ns1"}}},
+			},
+			want: false,
+		},
+		{
+			name: "nil source context",
+			cmd: TransferPVCCommand{
+				sourceContext:      nil,
+				destinationContext: &clientcmdapi.Context{Cluster: "cluster-a"},
+				Flags:              Flags{PVC: PvcFlags{Namespace: mappedNameVar{source: "ns1", destination: "ns1"}}},
+			},
+			want: false,
+		},
+		{
+			name: "nil destination context",
+			cmd: TransferPVCCommand{
+				sourceContext:      &clientcmdapi.Context{Cluster: "cluster-a"},
+				destinationContext: nil,
+				Flags:              Flags{PVC: PvcFlags{Namespace: mappedNameVar{source: "ns1", destination: "ns1"}}},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cmd.isIntraCluster(); got != tt.want {
+				t.Errorf("isIntraCluster() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

  - Extends `transfer-pvc` to support same-cluster transfers by removing the same-cluster rejection and handling intra-cluster stunnel cert sharing and pod label collisions
  - Enables StorageClass conversion workflow: `transfer-pvc` (same context) + `export/transform` (pvc-rename-map) + `apply`

  ## Cross-cluster impact

  **Zero behavioral change.** `isIntraCluster()` returns false for cross-cluster — all new code paths are skipped. The only cross-cluster improvement is `AlreadyExists` tolerance on secret creation, which prevents crashes on re-runs.

  ## StorageClass conversion workflow

  ```bash
  # 1. Quiesce workloads
  kubectl scale deploy webapp --replicas=0 -n myapp

  # 2. Transfer data to new PVC with new StorageClass (same cluster)
  crane transfer-pvc \
    --source-context mycluster --destination-context mycluster \
    --pvc-name "mysql-data:mysql-data-new" \
    --pvc-namespace myapp \
    --dest-storage-class gp3 \
    --endpoint route

  # 3. Generate updated manifests with renamed PVC references
  crane export --context mycluster --namespace myapp --export-dir ./export
  crane transform --export-dir ./export --transform-dir ./transform \
    --optional-flags '{"pvc-rename-map": "mysql-data:mysql-data-new"}'
  crane apply --export-dir ./export --transform-dir ./transform --output-dir ./output

  # 4. Review and apply
  kubectl apply -f ./output/output.yaml -n myapp
  kubectl scale deploy webapp --replicas=1 -n myapp

```

##  Test plan

  - ✅ Unit tests pass (go test ./cmd/transfer-pvc/)
  - ✅ Tested intra-cluster on minikube as non-admin (Deployment with PVC, standard → standard-v2)
  - ✅ Verified cross-cluster path is unaffected (code trace, all isIntraCluster() checks skipped)
  - ⬜ E2E cross-cluster regression test
  - ⬜ OCP intra-cluster test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enabled intra-cluster, same-namespace transfers with stricter validation: transfers are rejected only when source and destination resolve to the same PVC name.
- **Bug Fixes**
  - Improved labeling for intra-cluster transfers to prevent collisions and ensure resources are correctly marked as server vs client.
  - Updated certificate secret copying/cleanup behavior for intra-cluster scenarios to match source/destination expectations.
- **Tests**
  - Added unit tests covering intra-cluster detection and the “must differ” validation message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->