### PR TITLE
:seedling: Remove defunct --ignored-patches-dir flag from transform command

### DIFF
--- a/cmd/transform/transform.go
+++ b/cmd/transform/transform.go
@@ -43,7 +43,6 @@ type Flags struct {
 	ExportDir         string   `mapstructure:"export-dir"`
 	PluginDir         string   `mapstructure:"plugin-dir"`
 	TransformDir      string   `mapstructure:"transform-dir"`
-	IgnoredPatchesDir string   `mapstructure:"ignored-patches-dir"`
 	SkipPlugins       []string `mapstructure:"skip-plugins"`
 	OptionalFlags     string   `mapstructure:"optional-flags"`
 	Overwrite         bool     `mapstructure:"overwrite"`
@@ -157,7 +156,6 @@ func addFlagsForOptions(o *Flags, cmd *cobra.Command) {
 	defaultPluginDir := home + plugin.DefaultLocalPluginDir
 	cmd.Flags().StringVarP(&o.ExportDir, "export-dir", "e", "export", "The path where the kubernetes resources are saved")
 	cmd.Flags().StringVarP(&o.TransformDir, "transform-dir", "t", "transform", "The path where files that contain the transformations are saved")
-	cmd.Flags().StringVar(&o.IgnoredPatchesDir, "ignored-patches-dir", "", "The path where files that contain transformations that were discarded due to conflicts are saved. If left blank, these files will not be saved.")
 	cmd.Flags().StringVar(&o.InstructionsFile, "instructions-file", "", "Path to the transform instructions file")
 	cmd.Flags().BoolVar(&o.Overwrite, "overwrite", false, "Overwrite existing stage directories even if they contain user modifications")
 

--- a/e2e-tests/framework/crane.go
+++ b/e2e-tests/framework/crane.go
@@ -47,7 +47,6 @@ type TransformOptions struct {
 	ExportDir         string
 	TransformDir      string
 	PluginDir         string
-	IgnoredPatchesDir string
 	SkipPlugins       []string
 	OptionalFlags     string
 	Overwrite         bool
@@ -117,9 +116,6 @@ func (c CraneRunner) Transform(opts TransformOptions) error {
 	}
 	if opts.PluginDir != "" {
 		args = append(args, "--plugin-dir", opts.PluginDir)
-	}
-	if opts.IgnoredPatchesDir != "" {
-		args = append(args, "--ignored-patches-dir", opts.IgnoredPatchesDir)
 	}
 	for _, p := range opts.SkipPlugins {
 		args = append(args, "--skip-plugins", p)

--- a/internal/file/file_helper.go
+++ b/internal/file/file_helper.go
@@ -85,7 +85,6 @@ type PathOpts struct {
 	TransformDir      string
 	ExportDir         string
 	OutputDir         string
-	IgnoredPatchesDir string
 }
 
 func (opts *PathOpts) GetWhiteOutFilePath(filePath string) string {
@@ -96,19 +95,8 @@ func (opts *PathOpts) GetTransformPath(filePath string) string {
 	return opts.updateTransformDirPath("transform-", filePath)
 }
 
-func (opts *PathOpts) GetIgnoredPatchesPath(filePath string) string {
-	return opts.updateIgnoredPatchesDirPath("ignored-", filePath)
-}
-
 func (opts *PathOpts) updateTransformDirPath(prefix, filePath string) string {
 	return opts.updatePath(opts.TransformDir, prefix, filePath)
-}
-
-func (opts *PathOpts) updateIgnoredPatchesDirPath(prefix, filePath string) string {
-	if len(opts.IgnoredPatchesDir) == 0 {
-		return ""
-	}
-	return opts.updatePath(opts.IgnoredPatchesDir, prefix, filePath)
 }
 
 func (opts *PathOpts) updatePath(updateDir, prefix, filePath string) string {


### PR DESCRIPTION
## Summary
  
  Removes the `--ignored-patches-dir` flag from the `transform` command - the flag is no longer functional or
  needed.
  
  - Remove `IgnoredPatchesDir` field from `Flags` struct and flag registration in `cmd/transform/transform.go`
  - Remove `IgnoredPatchesDir` field, `GetIgnoredPatchesPath`, and `updateIgnoredPatchesDirPath` from
  `internal/file/file_helper.go`
  - Remove `IgnoredPatchesDir` field and args injection from `e2e-tests/framework/crane.go`

  No existing tests referenced this flag.
  https://github.com/migtools/crane/issues/666

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Removed support for the `--ignored-patches-dir` option from the transform command.
  - Previously ignored or discarded patch outputs can no longer be written to a configured directory.

- **New Features**
  - Added support for configuring a plugin directory with the `--plugin-dir` option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->