### PR TITLE
:test_tube: validate scanner: Verify resourcePlural for core group resources

### DIFF
--- a/e2e-tests/testdata/test-897/test-897-namespace.yaml
+++ b/e2e-tests/testdata/test-897/test-897-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: validate-core-v1-plural

--- a/e2e-tests/testdata/test-897/test-897-pod.yaml
+++ b/e2e-tests/testdata/test-897/test-897-pod.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: validate-core-v1-plural-pod
+  namespace: validate-core-v1-plural
+spec:
+  containers:
+    - name: busybox
+      image: busybox:latest
+      command: ["sh", "-c", "exit 0"]
+  restartPolicy: Never

--- a/e2e-tests/testdata/test-897/test-897-pvc.yaml
+++ b/e2e-tests/testdata/test-897/test-897-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: validate-core-v1-plural-pvc
+  namespace: validate-core-v1-plural
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Mi

--- a/e2e-tests/testdata/test-897/test-897-serviceaccount.yaml
+++ b/e2e-tests/testdata/test-897/test-897-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: validate-core-v1-plural-sa
+  namespace: validate-core-v1-plural

--- a/e2e-tests/tests/tier1/mta_897_validate_core_group_resource_plural_live_test.go
+++ b/e2e-tests/tests/tier1/mta_897_validate_core_group_resource_plural_live_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Crane validate: resourcePlural for core group resources (v1) [Live Mode]", func() {
+var _ = Describe("Crane validate: verify resourcePlural for core group resources (v1) [Live Mode]", func() {
 	It("[MTA-897] should report correct resourcePlural for Pod, Namespace, PVC, and ServiceAccount",
 		Label("tier1", "validate"), func() {
 			testName := "validate-core-v1-plural"
@@ -38,25 +38,34 @@ var _ = Describe("Crane validate: resourcePlural for core group resources (v1) [
 			})
 			runner.WorkDir = paths.TempDir
 
+			type resourceCase struct {
+				testdataFile   string
+				kind           string
+				apiVersion     string
+				resourcePlural string
+				namespace      string
+			}
+			namespace := testName
+			resources := []resourceCase{
+				{"test-897-pod.yaml", "Pod", "v1", "pods", namespace},
+				{"test-897-namespace.yaml", "Namespace", "v1", "namespaces", ""},
+				{"test-897-pvc.yaml", "PersistentVolumeClaim", "v1", "persistentvolumeclaims", namespace},
+				{"test-897-serviceaccount.yaml", "ServiceAccount", "v1", "serviceaccounts", namespace},
+			}
+
 			inputDir := filepath.Join(paths.TempDir, "input")
 			Expect(os.MkdirAll(inputDir, 0o755)).NotTo(HaveOccurred())
 
 			By("Copy testdata manifests to input directory")
-			testdataFiles := []string{
-				"test-897-pod.yaml",
-				"test-897-namespace.yaml",
-				"test-897-pvc.yaml",
-				"test-897-serviceaccount.yaml",
-			}
-			for _, filename := range testdataFiles {
-				sourcePath, err := filepath.Abs(filepath.Join("../../testdata/test-897", filename))
+			for _, rc := range resources {
+				sourcePath, err := filepath.Abs(filepath.Join("../../testdata/test-897", rc.testdataFile))
 				Expect(err).NotTo(HaveOccurred())
-				Expect(sourcePath).To(BeAnExistingFile(), "%s should exist in testdata/test-897", filename)
+				Expect(sourcePath).To(BeAnExistingFile(), "%s should exist in testdata/test-897", rc.testdataFile)
 
 				data, err := os.ReadFile(sourcePath)
 				Expect(err).NotTo(HaveOccurred())
 
-				destPath := filepath.Join(inputDir, filename)
+				destPath := filepath.Join(inputDir, rc.testdataFile)
 				Expect(os.WriteFile(destPath, data, 0o644)).NotTo(HaveOccurred())
 			}
 
@@ -74,42 +83,38 @@ var _ = Describe("Crane validate: resourcePlural for core group resources (v1) [
 			err = utils.ParseValidationReport(paths.ValidateDir, "json", &report)
 			Expect(err).NotTo(HaveOccurred(), "should parse JSON report")
 
+			expectedResources := make(map[string]string, len(resources))
+			expectedPlurals := make(map[string]string, len(resources))
+			for _, rc := range resources {
+				expectedResources[rc.kind] = rc.apiVersion
+				expectedPlurals[rc.kind] = rc.resourcePlural
+			}
+
 			By("Verify report using VerifyValidateResults")
 			expectations := utils.ValidationExpectations{
 				ValidationReport: cranevalidate.ValidationReport{
 					Mode:           "live",
 					ClusterContext: scenario.KubectlTgt.Context,
-					TotalScanned:   4,
-					Compatible:     4,
+					TotalScanned:   len(resources),
+					Compatible:     len(resources),
 					Incompatible:   0,
 				},
-				ExpectedResources: map[string]string{
-					"Pod":                   "v1",
-					"Namespace":             "v1",
-					"PersistentVolumeClaim": "v1",
-					"ServiceAccount":        "v1",
-				},
-				ExpectedResourcePlurals: map[string]string{
-					"Pod":                   "pods",
-					"Namespace":             "namespaces",
-					"PersistentVolumeClaim": "persistentvolumeclaims",
-					"ServiceAccount":        "serviceaccounts",
-				},
-				ExpectedStatus:    cranevalidate.StatusOK,
-				ExpectFailuresDir: false,
+				ExpectedResources:       expectedResources,
+				ExpectedResourcePlurals: expectedPlurals,
+				ExpectedStatus:          cranevalidate.StatusOK,
+				ExpectFailuresDir:       false,
 			}
 			utils.VerifyValidateResults(report, paths.ValidateDir, "JSON", expectations)
 
-			By("Verify namespace: empty for cluster-scoped Namespace, set for namespaced resources")
-			namespace := testName
+			By("Verify namespace: empty for cluster-scoped, set for namespaced resources")
+			expectedNamespaces := make(map[string]string, len(resources))
+			for _, rc := range resources {
+				expectedNamespaces[rc.kind] = rc.namespace
+			}
 			for _, result := range report.Results {
-				switch result.Kind {
-				case "Namespace":
-					Expect(result.Namespace).To(BeEmpty(),
-						"expected Namespace to have empty namespace (cluster-scoped)")
-				case "Pod", "PersistentVolumeClaim", "ServiceAccount":
-					Expect(result.Namespace).To(Equal(namespace),
-						"expected %s to be in namespace %s", result.Kind, namespace)
+				if expectedNs, ok := expectedNamespaces[result.Kind]; ok {
+					Expect(result.Namespace).To(Equal(expectedNs),
+						"expected %s to have namespace %q", result.Kind, expectedNs)
 				}
 			}
 		})

--- a/e2e-tests/tests/tier1/mta_897_validate_core_group_resource_plural_live_test.go
+++ b/e2e-tests/tests/tier1/mta_897_validate_core_group_resource_plural_live_test.go
@@ -1,0 +1,116 @@
+package e2e
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	"github.com/konveyor/crane/e2e-tests/utils"
+	cranevalidate "github.com/konveyor/crane/internal/validate"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Crane validate: resourcePlural for core group resources (v1) [Live Mode]", func() {
+	It("[MTA-897] should report correct resourcePlural for Pod, Namespace, PVC, and ServiceAccount",
+		Label("tier1", "validate"), func() {
+			testName := "validate-core-v1-plural"
+			scenario := NewMigrationScenario(
+				"core-v1-plural",
+				testName,
+				config.K8sDeployBin,
+				config.CraneBin,
+				config.SourceContext,
+				config.TargetContext,
+			)
+
+			if scenario.KubectlTgt.Context == "" {
+				Skip("target-context is required")
+			}
+
+			runner := scenario.Crane
+			paths, err := NewScenarioPaths("crane-validate-core-v1-plural-*")
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(func() {
+				Expect(os.RemoveAll(paths.TempDir)).To(Succeed())
+			})
+			runner.WorkDir = paths.TempDir
+
+			inputDir := filepath.Join(paths.TempDir, "input")
+			Expect(os.MkdirAll(inputDir, 0o755)).NotTo(HaveOccurred())
+
+			By("Copy testdata manifests to input directory")
+			testdataFiles := []string{
+				"test-897-pod.yaml",
+				"test-897-namespace.yaml",
+				"test-897-pvc.yaml",
+				"test-897-serviceaccount.yaml",
+			}
+			for _, filename := range testdataFiles {
+				sourcePath, err := filepath.Abs(filepath.Join("../../testdata/test-897", filename))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(sourcePath).To(BeAnExistingFile(), "%s should exist in testdata/test-897", filename)
+
+				data, err := os.ReadFile(sourcePath)
+				Expect(err).NotTo(HaveOccurred())
+
+				destPath := filepath.Join(inputDir, filename)
+				Expect(os.WriteFile(destPath, data, 0o644)).NotTo(HaveOccurred())
+			}
+
+			By("Run crane validate in live mode")
+			stdout, err := runner.Validate(ValidateOptions{
+				Context:     scenario.KubectlTgt.Context,
+				InputDir:    inputDir,
+				ValidateDir: paths.ValidateDir,
+			})
+			Expect(err).NotTo(HaveOccurred(), "crane validate should succeed for core v1 resources")
+			log.Printf("Validate stdout: %s", stdout)
+
+			By("Parse validation report")
+			var report cranevalidate.ValidationReport
+			err = utils.ParseValidationReport(paths.ValidateDir, "json", &report)
+			Expect(err).NotTo(HaveOccurred(), "should parse JSON report")
+
+			By("Verify report using VerifyValidateResults")
+			expectations := utils.ValidationExpectations{
+				ValidationReport: cranevalidate.ValidationReport{
+					Mode:           "live",
+					ClusterContext: scenario.KubectlTgt.Context,
+					TotalScanned:   4,
+					Compatible:     4,
+					Incompatible:   0,
+				},
+				ExpectedResources: map[string]string{
+					"Pod":                   "v1",
+					"Namespace":             "v1",
+					"PersistentVolumeClaim": "v1",
+					"ServiceAccount":        "v1",
+				},
+				ExpectedResourcePlurals: map[string]string{
+					"Pod":                   "pods",
+					"Namespace":             "namespaces",
+					"PersistentVolumeClaim": "persistentvolumeclaims",
+					"ServiceAccount":        "serviceaccounts",
+				},
+				ExpectedStatus:    cranevalidate.StatusOK,
+				ExpectFailuresDir: false,
+			}
+			utils.VerifyValidateResults(report, paths.ValidateDir, "JSON", expectations)
+
+			By("Verify namespace: empty for cluster-scoped Namespace, set for namespaced resources")
+			namespace := testName
+			for _, result := range report.Results {
+				switch result.Kind {
+				case "Namespace":
+					Expect(result.Namespace).To(BeEmpty(),
+						"expected Namespace to have empty namespace (cluster-scoped)")
+				case "Pod", "PersistentVolumeClaim", "ServiceAccount":
+					Expect(result.Namespace).To(Equal(namespace),
+						"expected %s to be in namespace %s", result.Kind, namespace)
+				}
+			}
+		})
+})

--- a/e2e-tests/utils/utils_validate.go
+++ b/e2e-tests/utils/utils_validate.go
@@ -18,8 +18,9 @@ import (
 
 type ValidationExpectations struct {
 	validate.ValidationReport                           // Embedded: Mode, APIResourcesSource, TotalScanned, Compatible, Incompatible
-	ExpectedResources         map[string]string         // Map of Kind -> APIVersion for expected resources (simpler than Results)
-	ExpectedStatus            validate.ValidationStatus // Expected status for resources (e.g., StatusOK)
+	ExpectedResources       map[string]string         // Map of Kind -> APIVersion for expected resources
+	ExpectedResourcePlurals map[string]string         // Map of Kind -> ResourcePlural (e.g., "Deployment" -> "deployments")
+	ExpectedStatus          validate.ValidationStatus // Expected status for resources (e.g., StatusOK)
 	Namespace                 string                    // Expected namespace for resources
 	ExpectFailuresDir         bool                      // Whether to expect a failures/ directory
 }
@@ -76,9 +77,13 @@ func VerifyValidateResults(report validate.ValidationReport, validateDir string,
 					Expect(result.Namespace).To(Equal(expectations.Namespace),
 						"expected %s to be in namespace %s in %s report", result.Kind, expectations.Namespace, outputFormat)
 				}
+				if expectedPlural, ok := expectations.ExpectedResourcePlurals[result.Kind]; ok {
+					Expect(result.ResourcePlural).To(Equal(expectedPlural),
+						"expected %s to have resourcePlural %s in %s report", result.Kind, expectedPlural, outputFormat)
+				}
 			}
-			log.Printf("✓ %s report: Found %s with apiVersion %s in namespace %s with status %s",
-				outputFormat, result.Kind, result.APIVersion, result.Namespace, result.Status)
+			log.Printf("✓ %s report: Found %s with apiVersion %s in namespace %s with resourcePlural %s with status %s",
+				outputFormat, result.Kind, result.APIVersion, result.Namespace, result.ResourcePlural, result.Status)
 		}
 
 		By(outputFormat + " report: Verify all expected resources were found")


### PR DESCRIPTION
Fixes [390](https://github.com/migtools/crane/issues/390)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new live-mode end-to-end test validating core Kubernetes resource handling (Pods, Namespaces, PersistentVolumeClaims, ServiceAccounts) via `crane validate`.
  * Test assertions now include compatibility totals, per-kind API versions, per-kind `resourcePlural` expectations, and correct namespace scoping per resource kind.
* **Bug Fixes**
  * Enhanced validation result checking to conditionally verify `resourcePlural` when expected values are provided, and improved success logging to include `resourcePlural`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->