### PR TITLE
:seedling: inline cherry-pick workflow

### DIFF
--- a/.github/workflows/pr-closed.yaml
+++ b/.github/workflows/pr-closed.yaml
@@ -7,10 +7,93 @@ on:
       - closed
 
 jobs:
-  cherry_pick_job:
+  branches:
     if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    outputs:
+      branches: ${{ steps.cherry_pick_branches.outputs.result }}
+    steps:
+      - name: Check for cherry-pick labels
+        id: cherry_pick_branches
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: issue } = await github.rest.issues.get({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            const labels = issue.labels.map(label => label.name);
+            console.log(`Labels: ${labels}`);
+
+            const branches = labels.filter(label => label.startsWith('cherry-pick/'))
+              .map(label => label.substr(12));
+            console.log(`Branches: ${branches}`);
+
+            return branches
+
+  cherry-pick:
+    runs-on: ubuntu-latest
+    needs: branches
+    if: ${{ needs.branches.outputs.branches != '[]' && needs.branches.outputs.branches != '' }}
     permissions:
       pull-requests: write
       contents: write
-    uses: konveyor/release-tools/.github/workflows/cherry-pick.yml@main
-    secrets: inherit
+    strategy:
+      matrix:
+        branch: ${{ fromJson(needs.branches.outputs.branches) }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
+          fetch-depth: 0
+
+      - name: Get Token
+        id: get_workflow_token
+        uses: peter-murray/workflow-application-token-action@v3
+        with:
+          application_id: ${{ vars.MIGTOOLS_BOT_ID }}
+          application_private_key: ${{ secrets.MIGTOOLS_BOT_KEY }}
+
+      - name: Cherry-pick
+        id: cherry_pick
+        env:
+          GH_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
+          BRANCH_NAME: "cherry-pick-pr${{ github.event.number }}-${{ matrix.branch }}"
+        run: |
+          git config --global user.email "noreply@github.com"
+          git config --global user.name "Cherry Picker"
+          git checkout -b "${BRANCH_NAME}"
+          git cherry-pick -s ${{ github.sha }}
+          git push origin "${BRANCH_NAME}"
+          PR_URL=$(gh pr create --base "${{ matrix.branch }}" --fill)
+          echo "pr_url=${PR_URL}" >> "$GITHUB_OUTPUT"
+
+      - name: Post success comment
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.get_workflow_token.outputs.token }}
+          script: |
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `PR cherry-picked to branch __${{ matrix.branch }}__. Backport PR: ${{ steps.cherry_pick.outputs.pr_url }}`
+            });
+
+      - name: Post failure comment
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.get_workflow_token.outputs.token }}
+          script: |
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Failed to cherry-pick this PR to branch __${{ matrix.branch }}__. [View failed action](${runUrl})`
+            });


### PR DESCRIPTION
## Summary

The `pr-closed` workflow calls `konveyor/release-tools/.github/workflows/cherry-pick.yml`, which authenticates using the **konveyor-ci-bot** GitHub App via `vars.KONVEYOR_BOT_ID` and `secrets.KONVEYOR_BOT_KEY`. This fails in migtools/crane because:

1. **konveyor-ci-bot is not installed on the migtools org** -- the app is only installed on the konveyor org
2. **The required variable and secret do not exist** in migtools (org or repo level)

This produces the errors:
```
Error: Input required and not supplied: application_private_key
Error: Failed to initialize GitHub Application connection using provided id and private key
Error: Unhandled error: Error: Input required and not supplied: github-token
```

### What this PR does

Inlines the cherry-pick logic from `konveyor/release-tools` directly into `pr-closed.yaml` and uses the **migtools-sync-app** GitHub App (via `vars.MIGTOOLS_BOT_ID` / `secrets.MIGTOOLS_BOT_KEY`) instead of the konveyor-ci-bot. This removes the cross-org dependency on konveyor entirely.

The workflow behavior is identical to the upstream version:
- Scans PR labels for `cherry-pick/<branch>` patterns
- Cherry-picks the merged commit onto each target branch
- Creates a backport PR
- Comments on the original PR with success/failure status

### Prerequisites

The `MIGTOOLS_BOT_ID` org variable and `MIGTOOLS_BOT_KEY` org secret must be configured and accessible to the crane repository.

## Impact

- **Severity:** Fixes a broken workflow -- cherry-picks to release branches have been failing
- **Affected components:** `.github/workflows/pr-closed.yaml` only
- **Backward compatible:** Yes -- same label-based cherry-pick behavior

## Test plan

Merge a PR to `main` with a `cherry-pick/release-0.10` label and verify:
1. The cherry-pick branch is created
2. A backport PR is opened against the target release branch
3. A comment is posted on the original PR