### PR TITLE
:sparkles: Improve observability for pvc-transfer command output

### DIFF
--- a/cmd/transfer-pvc/progress.go
+++ b/cmd/transfer-pvc/progress.go
@@ -160,6 +160,13 @@ func (r *rsyncLogStream) Streams() (stdout chan string, stderr chan string, err 
 	return r.stdout, r.stderr, r.err
 }
 
+func (r *rsyncLogStream) ExitCode() *int32 {
+	if r.progress != nil {
+		return r.progress.ExitCode
+	}
+	return nil
+}
+
 // Progress defines transfer Progress
 type Progress struct {
 	PVC                types.NamespacedName `json:"pvc"`

--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -35,6 +35,8 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/konveyor/crane/internal/cli"
+
 	"github.com/backube/pvc-transfer/endpoint"
 	ingressendpoint "github.com/backube/pvc-transfer/endpoint/ingress"
 	routeendpoint "github.com/backube/pvc-transfer/endpoint/route"
@@ -293,21 +295,34 @@ func (t *TransferPVCCommand) run() error {
 	logrusLog.SetFormatter(&logrus.JSONFormatter{})
 	logger := logrusr.New(logrusLog).WithName("transfer-pvc")
 
+	totalPhases := 7
+	if t.isIntraClusterSameNamespace() {
+		totalPhases = 8
+	}
+	phases := cli.NewPhaseTracker(t.ErrOut, totalPhases)
+
+	cli.PrintTransferBanner(t.ErrOut,
+		t.Flags.SourceContext, t.Flags.DestinationContext,
+		fmt.Sprintf("%s/%s → %s/%s",
+			t.PVC.Namespace.source, t.PVC.Name.source,
+			t.PVC.Namespace.destination, t.PVC.Name.destination),
+		string(t.Endpoint.Type), t.Endpoint.Subdomain,
+	)
+
+	// ---- Phase 1: Reading source PVC ----
+	phases.Start("Reading source PVC")
 	srcCfg, err := t.getRestConfigFromContext(t.Flags.SourceContext)
 	if err != nil {
-		log.Fatal(err, "unable to get source rest config")
+		return phases.Fail(err, "unable to get source rest config")
 	}
-
 	srcClient, err := t.getClientFromContext(t.Flags.SourceContext)
 	if err != nil {
-		log.Fatal(err, "unable to get source client")
+		return phases.Fail(err, "unable to get source client")
 	}
 	destClient, err := t.getClientFromContext(t.Flags.DestinationContext)
 	if err != nil {
-		log.Fatal(err, "unable to get destination client")
+		return phases.Fail(err, "unable to get destination client")
 	}
-
-	// set up the PVC on destination to receive the data
 	srcPVC := &corev1.PersistentVolumeClaim{}
 	err = srcClient.Get(
 		context.TODO(),
@@ -318,14 +333,18 @@ func (t *TransferPVCCommand) run() error {
 		srcPVC,
 	)
 	if err != nil {
-		log.Fatal(err, "unable to get source PVC")
+		return phases.Fail(err, "unable to get source PVC")
 	}
+	phases.End("ok", "")
 
+	// ---- Phase 2: Creating destination PVC ----
+	phases.Start("Creating destination PVC")
 	destPVC := t.buildDestinationPVC(srcPVC)
 	err = destClient.Create(context.TODO(), destPVC, &client.CreateOptions{})
 	if err != nil && !errors.IsAlreadyExists(err) {
-		log.Fatal(err, "unable to create destination PVC")
+		return phases.Fail(err, "unable to create destination PVC")
 	}
+	phases.End("ok", "")
 
 	labels := map[string]string{
 		"app.kubernetes.io/name":          "crane",
@@ -333,8 +352,6 @@ func (t *TransferPVCCommand) run() error {
 		"app.konveyor.io/created-for-pvc": getValidatedResourceName(srcPVC.Name),
 	}
 
-	// For intra-cluster (same namespace), split labels so the log reader
-	// can distinguish server and client pods.
 	clientLabels := labels
 	if t.isIntraClusterSameNamespace() {
 		labels["app.konveyor.io/role"] = "server"
@@ -347,15 +364,23 @@ func (t *TransferPVCCommand) run() error {
 		}
 	}
 
+	// ---- Phase 3: Creating endpoint ----
+	phases.Start(fmt.Sprintf("Creating endpoint (%s)", t.Endpoint.Type))
 	e, err := createEndpoint(t.Endpoint, destPVC, labels, logger, destClient)
 	if err != nil {
-		log.Fatal(err, "failed creating endpoint")
+		return phases.Fail(err, "failed creating endpoint")
 	}
+	phases.End("ok", "")
 
+	// ---- Phase 4: Waiting for endpoint healthy ----
+	phases.Start("Waiting for endpoint healthy")
 	if err := waitForEndpoint(e, destClient); err != nil {
-		log.Fatal("endpoint not healthy")
+		return phases.Fail(err, "endpoint not healthy")
 	}
+	phases.End("ok", "")
 
+	// ---- Phase 5: Setting up secure tunnel and server ----
+	phases.Start("Setting up secure tunnel and server")
 	stunnelServer, err := stunneltransport.NewServer(
 		context.TODO(),
 		destClient,
@@ -368,7 +393,7 @@ func (t *TransferPVCCommand) run() error {
 			Image:  t.Flags.DestinationImage,
 		})
 	if err != nil {
-		log.Fatal(err, "error creating stunnel server")
+		return phases.Fail(err, "error creating stunnel server")
 	}
 
 	secretList := &corev1.SecretList{}
@@ -378,7 +403,7 @@ func (t *TransferPVCCommand) run() error {
 		client.InNamespace(destPVC.Namespace),
 		client.MatchingLabels(labels))
 	if err != nil {
-		log.Fatal(err, "failed to find certificate secrets")
+		return phases.Fail(err, "failed to find certificate secrets")
 	}
 
 	for i := range secretList.Items {
@@ -402,17 +427,17 @@ func (t *TransferPVCCommand) run() error {
 		if errors.IsAlreadyExists(err) {
 			existing := &corev1.Secret{}
 			if getErr := srcClient.Get(context.TODO(), client.ObjectKey{Name: secretName, Namespace: srcPVC.Namespace}, existing); getErr != nil {
-				log.Fatalf("failed to get existing certificate Secret %q in namespace %q: %v", secretName, srcPVC.Namespace, getErr)
+				return phases.Fail(getErr, fmt.Sprintf("failed to get existing certificate Secret %q", secretName))
 			}
 			existing.Data = destSecret.Data
 			existing.StringData = destSecret.StringData
 			existing.Labels = secretLabels
 			existing.Annotations = destSecret.Annotations
 			if updateErr := srcClient.Update(context.TODO(), existing); updateErr != nil {
-				log.Fatalf("failed to update certificate Secret %q in namespace %q: %v", secretName, srcPVC.Namespace, updateErr)
+				return phases.Fail(updateErr, fmt.Sprintf("failed to update certificate Secret %q", secretName))
 			}
 		} else if err != nil {
-			log.Fatalf("failed to create certificate Secret %q in namespace %q on source cluster: %v", secretName, srcPVC.Namespace, err)
+			return phases.Fail(err, fmt.Sprintf("failed to create certificate Secret %q", secretName))
 		}
 	}
 
@@ -429,26 +454,21 @@ func (t *TransferPVCCommand) run() error {
 		},
 	)
 	if err != nil {
-		log.Fatal(err, "error creating stunnel server")
+		return phases.Fail(err, "error creating stunnel client")
 	}
 
 	destPVCList := transfer.NewSingletonPVC(destPVC)
 	srcPVCList := transfer.NewSingletonPVC(srcPVC)
 
-	// Compute source security context first — used for rsync client, and
-	// as fallback for rsync server on K8s (where target may not have the
-	// workload deployed yet).
 	clientPodSecCtx, err := getRsyncClientPodSecurityContext(srcClient, srcPVC.Namespace, srcPVC.Name)
 	if err != nil {
-		log.Fatal(err, "error creating security context for rsync client")
+		return phases.Fail(err, "error creating security context for rsync client")
 	}
 
 	serverPodSecContext, err := getRsyncServerPodSecurityContext(destClient, destPVC.Namespace, destPVC.Name)
 	if err != nil {
-		log.Fatal(err, "error creating security context for rsync server")
+		return phases.Fail(err, "error creating security context for rsync server")
 	}
-	// On K8s, if the target has no OCP annotation and no workload deployed
-	// yet, fall back to the source-discovered UID.
 	if serverPodSecContext.RunAsUser == nil && clientPodSecCtx.RunAsUser != nil {
 		serverPodSecContext = clientPodSecCtx
 	}
@@ -479,21 +499,24 @@ func (t *TransferPVCCommand) run() error {
 		},
 	)
 	if err != nil {
-		log.Fatal(err, "error creating rsync transfer server")
+		return phases.Fail(err, "error creating rsync transfer server")
 	}
 
 	_ = wait.PollUntil(time.Second*5, func() (done bool, err error) {
 		ready, err := rsyncServer.IsHealthy(context.TODO(), destClient)
 		if err != nil {
-			log.Println(err, "unable to check rsync server health, retrying...")
+			fmt.Fprintf(t.ErrOut, "  rsync server not ready, retrying...\n")
 			return false, nil
 		}
 		return ready, nil
 	}, make(<-chan struct{}))
+	phases.End("ok", "")
 
+	// ---- Phase 6: Copying data (rsync) ----
+	phases.Start("Copying data (rsync)")
 	nodeName, err := getNodeNameForPVC(srcClient, srcPVC.Namespace, srcPVC.Name)
 	if err != nil {
-		log.Fatal(err, "failed to find node name")
+		return phases.Fail(err, "failed to find node name")
 	}
 
 	_, err = rsynctransfer.NewClient(
@@ -523,22 +546,47 @@ func (t *TransferPVCCommand) run() error {
 		},
 	)
 	if err != nil {
-		log.Fatal(err, "failed to create rsync client")
+		return phases.Fail(err, "failed to create rsync client")
 	}
 
-	err = followClientLogs(
+	exitCode, err := followClientLogs(
 		srcCfg, types.NamespacedName{Name: srcPVC.Name, Namespace: srcPVC.Namespace}, clientLabels, t.ProgressOutput)
 	if err != nil {
-		log.Fatal(err, "error following rsync client logs")
+		return phases.Fail(err, "error following rsync client logs")
+	}
+	detail := ""
+	if exitCode != nil {
+		detail = fmt.Sprintf("exit=%d", *exitCode)
+	}
+	phases.End("finished", detail)
+
+	// ---- Phase 7/8: Cleanup ----
+	if t.isIntraClusterSameNamespace() {
+		phases.Start("Cleaning up server resources")
+		if err := garbageCollect(srcClient, destClient, labels, t.Endpoint.Type, t.PVC.Namespace); err != nil {
+			fmt.Fprintf(t.ErrOut, "  WARN: %v\n", err)
+		}
+		phases.End("ok", "")
+
+		phases.Start("Cleaning up client resources")
+		if err := garbageCollect(srcClient, destClient, clientLabels, t.Endpoint.Type, t.PVC.Namespace); err != nil {
+			return phases.Fail(err, "client-side cleanup failed")
+		}
+		phases.End("ok", "")
+	} else {
+		phases.Start("Cleaning up temporary resources")
+		if err := garbageCollect(srcClient, destClient, labels, t.Endpoint.Type, t.PVC.Namespace); err != nil {
+			return phases.Fail(err, "cleanup failed")
+		}
+		phases.End("ok", "")
 	}
 
-	if t.isIntraClusterSameNamespace() {
-		if err := garbageCollect(srcClient, destClient, labels, t.Endpoint.Type, t.PVC.Namespace); err != nil {
-			log.Printf("WARN: server-side cleanup: %v", err)
-		}
-		return garbageCollect(srcClient, destClient, clientLabels, t.Endpoint.Type, t.PVC.Namespace)
-	}
-	return garbageCollect(srcClient, destClient, labels, t.Endpoint.Type, t.PVC.Namespace)
+	cli.PrintTransferSummary(t.ErrOut, &cli.TransferSummary{
+		Status:   "succeeded",
+		Duration: phases.Elapsed(),
+	})
+
+	return nil
 }
 
 func certificateSecretName(serverSecret, srcPVCName, destPVCName string) string {
@@ -996,13 +1044,15 @@ type LogStreams interface {
 	Streams() (stdout chan string, stderr chan string, err chan error)
 	// Close closes log streams
 	Close()
+	// ExitCode returns the rsync process exit code, if available
+	ExitCode() *int32
 }
 
-func followClientLogs(srcConfig *rest.Config, pvc types.NamespacedName, labels map[string]string, outputFile string) error {
+func followClientLogs(srcConfig *rest.Config, pvc types.NamespacedName, labels map[string]string, outputFile string) (*int32, error) {
 	logReader := NewRsyncLogStream(srcConfig, pvc, labels, outputFile)
 	err := logReader.Init()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer logReader.Close()
 	stdout, stderr, errChan := logReader.Streams()
@@ -1023,7 +1073,7 @@ func followClientLogs(srcConfig *rest.Config, pvc types.NamespacedName, labels m
 			break
 		}
 	}
-	return err
+	return logReader.ExitCode(), err
 }
 
 // waitForEndpoint waits for endpoint to become ready

--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -313,7 +313,7 @@ func (t *TransferPVCCommand) run() (retErr error) {
 
 	cli.PrintTransferBanner(t.ErrOut,
 		t.Flags.SourceContext, t.Flags.DestinationContext,
-		fmt.Sprintf("%s/%s → %s/%s",
+		fmt.Sprintf("%s/%s -> %s/%s",
 			t.PVC.Namespace.source, t.PVC.Name.source,
 			t.PVC.Namespace.destination, t.PVC.Name.destination),
 		string(t.Endpoint.Type), t.Endpoint.Subdomain,
@@ -567,9 +567,6 @@ func (t *TransferPVCCommand) run() (retErr error) {
 	detail := ""
 	if exitCode != nil {
 		detail = fmt.Sprintf("exit=%d", *exitCode)
-		if *exitCode != 0 {
-			return phases.Fail(fmt.Errorf("rsync exited with code %d", *exitCode), "data copy failed")
-		}
 	}
 	phases.End("finished", detail)
 

--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -290,7 +290,7 @@ func (t *TransferPVCCommand) getRestConfigFromContext(ctx string) (*rest.Config,
 	return t.configFlags.ToRESTConfig()
 }
 
-func (t *TransferPVCCommand) run() error {
+func (t *TransferPVCCommand) run() (retErr error) {
 	logrusLog := logrus.New()
 	logrusLog.SetFormatter(&logrus.JSONFormatter{})
 	logger := logrusr.New(logrusLog).WithName("transfer-pvc")
@@ -300,6 +300,16 @@ func (t *TransferPVCCommand) run() error {
 		totalPhases = 8
 	}
 	phases := cli.NewPhaseTracker(t.ErrOut, totalPhases)
+	defer func() {
+		status := "succeeded"
+		if retErr != nil {
+			status = "failed"
+		}
+		cli.PrintTransferSummary(t.ErrOut, &cli.TransferSummary{
+			Status:   status,
+			Duration: phases.Elapsed(),
+		})
+	}()
 
 	cli.PrintTransferBanner(t.ErrOut,
 		t.Flags.SourceContext, t.Flags.DestinationContext,
@@ -557,6 +567,9 @@ func (t *TransferPVCCommand) run() error {
 	detail := ""
 	if exitCode != nil {
 		detail = fmt.Sprintf("exit=%d", *exitCode)
+		if *exitCode != 0 {
+			return phases.Fail(fmt.Errorf("rsync exited with code %d", *exitCode), "data copy failed")
+		}
 	}
 	phases.End("finished", detail)
 
@@ -580,11 +593,6 @@ func (t *TransferPVCCommand) run() error {
 		}
 		phases.End("ok", "")
 	}
-
-	cli.PrintTransferSummary(t.ErrOut, &cli.TransferSummary{
-		Status:   "succeeded",
-		Duration: phases.Elapsed(),
-	})
 
 	return nil
 }

--- a/internal/cli/banner.go
+++ b/internal/cli/banner.go
@@ -1,0 +1,19 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+)
+
+func PrintTransferBanner(w io.Writer, sourceCtx, destCtx, pvcMapping, endpoint, subdomain string) {
+	fmt.Fprintf(w, "\ncrane transfer-pvc\n")
+	fmt.Fprintf(w, "source context:      %s\n", sourceCtx)
+	fmt.Fprintf(w, "destination context: %s\n", destCtx)
+	fmt.Fprintf(w, "PVC:                 %s\n", pvcMapping)
+	if subdomain != "" {
+		fmt.Fprintf(w, "endpoint:            %s  (subdomain: %s)\n", endpoint, subdomain)
+	} else {
+		fmt.Fprintf(w, "endpoint:            %s\n", endpoint)
+	}
+	fmt.Fprintln(w)
+}

--- a/internal/cli/phase.go
+++ b/internal/cli/phase.go
@@ -33,7 +33,7 @@ func (p *PhaseTracker) End(status string, detail string) {
 	if detail != "" {
 		line += "  " + detail
 	}
-	fmt.Fprintf(p.w, "\x1b[1A\x1b[2K%s\n", line)
+	fmt.Fprintf(p.w, "%s\n", line)
 }
 
 func (p *PhaseTracker) Fail(err error, msg string) error {

--- a/internal/cli/phase.go
+++ b/internal/cli/phase.go
@@ -1,0 +1,47 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"time"
+)
+
+type PhaseTracker struct {
+	w        io.Writer
+	total    int
+	current  int
+	name     string
+	runStart time.Time
+}
+
+func NewPhaseTracker(w io.Writer, totalPhases int) *PhaseTracker {
+	return &PhaseTracker{
+		w:        w,
+		total:    totalPhases,
+		runStart: time.Now(),
+	}
+}
+
+func (p *PhaseTracker) Start(name string) {
+	p.current++
+	p.name = name
+	fmt.Fprintf(p.w, "[%d/%d] %s ...\n", p.current, p.total, name)
+}
+
+func (p *PhaseTracker) End(status string, detail string) {
+	line := fmt.Sprintf("[%d/%d] %s ... %s", p.current, p.total, p.name, status)
+	if detail != "" {
+		line += "  " + detail
+	}
+	fmt.Fprintf(p.w, "\x1b[1A\x1b[2K%s\n", line)
+}
+
+func (p *PhaseTracker) Fail(err error, msg string) error {
+	p.End("FAILED", "")
+	fmt.Fprintf(p.w, "  error: %v\n", err)
+	return fmt.Errorf("%s: %w", msg, err)
+}
+
+func (p *PhaseTracker) Elapsed() time.Duration {
+	return time.Since(p.runStart)
+}

--- a/internal/cli/phase_test.go
+++ b/internal/cli/phase_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestPhaseStartEnd(t *testing.T) {
@@ -40,8 +41,9 @@ func TestPhaseFail(t *testing.T) {
 	var buf bytes.Buffer
 	p := NewPhaseTracker(&buf, 1)
 
+	origErr := errors.New("not found")
 	p.Start("Reading source PVC")
-	err := p.Fail(errors.New("not found"), "unable to get source PVC")
+	err := p.Fail(origErr, "unable to get source PVC")
 
 	output := buf.String()
 	if !strings.Contains(output, "FAILED") {
@@ -56,11 +58,8 @@ func TestPhaseFail(t *testing.T) {
 	if !strings.Contains(err.Error(), "unable to get source PVC") {
 		t.Errorf("Error should contain message, got: %v", err)
 	}
-	if !errors.Is(err, errors.New("not found")) {
-		// unwrap check
-		if !strings.Contains(err.Error(), "not found") {
-			t.Errorf("Error should wrap original, got: %v", err)
-		}
+	if !errors.Is(err, origErr) {
+		t.Errorf("Error should wrap original, got: %v", err)
 	}
 }
 
@@ -94,5 +93,65 @@ func TestElapsed(t *testing.T) {
 	elapsed := p.Elapsed()
 	if elapsed < 0 {
 		t.Errorf("Elapsed should be non-negative, got: %v", elapsed)
+	}
+}
+
+func TestPrintTransferBannerWithSubdomain(t *testing.T) {
+	var buf bytes.Buffer
+	PrintTransferBanner(&buf, "src", "tgt", "app/data → app/data", "nginx-ingress", "data.app.example.com")
+
+	output := buf.String()
+	for _, want := range []string{"crane transfer-pvc", "source context:      src", "destination context: tgt", "app/data → app/data", "nginx-ingress", "data.app.example.com"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("Banner missing %q, got: %q", want, output)
+		}
+	}
+}
+
+func TestPrintTransferBannerWithoutSubdomain(t *testing.T) {
+	var buf bytes.Buffer
+	PrintTransferBanner(&buf, "src", "tgt", "app/data → app/data", "route", "")
+
+	output := buf.String()
+	if strings.Contains(output, "subdomain") {
+		t.Errorf("Banner should not show subdomain when empty, got: %q", output)
+	}
+	if !strings.Contains(output, "route") {
+		t.Errorf("Banner missing endpoint, got: %q", output)
+	}
+}
+
+func TestPrintTransferSummarySucceeded(t *testing.T) {
+	var buf bytes.Buffer
+	PrintTransferSummary(&buf, &TransferSummary{Status: "succeeded", Duration: 45 * time.Second})
+
+	output := buf.String()
+	if !strings.Contains(output, "Summary") {
+		t.Errorf("Summary header missing, got: %q", output)
+	}
+	if !strings.Contains(output, "succeeded") {
+		t.Errorf("Status missing, got: %q", output)
+	}
+	if !strings.Contains(output, "45s") {
+		t.Errorf("Duration missing, got: %q", output)
+	}
+	if !strings.Contains(output, "Done.") {
+		t.Errorf("Done missing for succeeded, got: %q", output)
+	}
+}
+
+func TestPrintTransferSummaryFailed(t *testing.T) {
+	var buf bytes.Buffer
+	PrintTransferSummary(&buf, &TransferSummary{Status: "failed", Duration: 4 * time.Second})
+
+	output := buf.String()
+	if !strings.Contains(output, "failed") {
+		t.Errorf("Status missing, got: %q", output)
+	}
+	if !strings.Contains(output, "4s") {
+		t.Errorf("Duration missing, got: %q", output)
+	}
+	if strings.Contains(output, "Done.") {
+		t.Errorf("Done should not appear for failed, got: %q", output)
 	}
 }

--- a/internal/cli/phase_test.go
+++ b/internal/cli/phase_test.go
@@ -1,0 +1,98 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestPhaseStartEnd(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewPhaseTracker(&buf, 3)
+
+	p.Start("Reading source PVC")
+	p.End("ok", "")
+
+	output := buf.String()
+	if !strings.Contains(output, "[1/3] Reading source PVC ...") {
+		t.Errorf("Start output missing, got: %q", output)
+	}
+	if !strings.Contains(output, "[1/3] Reading source PVC ... ok") {
+		t.Errorf("End output missing, got: %q", output)
+	}
+}
+
+func TestPhaseEndWithDetail(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewPhaseTracker(&buf, 1)
+
+	p.Start("Copying data")
+	p.End("finished", "exit=0")
+
+	output := buf.String()
+	if !strings.Contains(output, "finished  exit=0") {
+		t.Errorf("Detail not shown, got: %q", output)
+	}
+}
+
+func TestPhaseFail(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewPhaseTracker(&buf, 1)
+
+	p.Start("Reading source PVC")
+	err := p.Fail(errors.New("not found"), "unable to get source PVC")
+
+	output := buf.String()
+	if !strings.Contains(output, "FAILED") {
+		t.Errorf("FAILED not shown, got: %q", output)
+	}
+	if !strings.Contains(output, "error: not found") {
+		t.Errorf("Error message not shown, got: %q", output)
+	}
+	if err == nil {
+		t.Error("Fail should return an error")
+	}
+	if !strings.Contains(err.Error(), "unable to get source PVC") {
+		t.Errorf("Error should contain message, got: %v", err)
+	}
+	if !errors.Is(err, errors.New("not found")) {
+		// unwrap check
+		if !strings.Contains(err.Error(), "not found") {
+			t.Errorf("Error should wrap original, got: %v", err)
+		}
+	}
+}
+
+func TestSequentialPhases(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewPhaseTracker(&buf, 3)
+
+	p.Start("Phase A")
+	p.End("ok", "")
+	p.Start("Phase B")
+	p.End("ok", "")
+	p.Start("Phase C")
+	p.End("ok", "")
+
+	output := buf.String()
+	if !strings.Contains(output, "[1/3] Phase A") {
+		t.Errorf("Phase 1 missing, got: %q", output)
+	}
+	if !strings.Contains(output, "[2/3] Phase B") {
+		t.Errorf("Phase 2 missing, got: %q", output)
+	}
+	if !strings.Contains(output, "[3/3] Phase C") {
+		t.Errorf("Phase 3 missing, got: %q", output)
+	}
+}
+
+func TestElapsed(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewPhaseTracker(&buf, 1)
+
+	elapsed := p.Elapsed()
+	if elapsed < 0 {
+		t.Errorf("Elapsed should be non-negative, got: %v", elapsed)
+	}
+}

--- a/internal/cli/summary.go
+++ b/internal/cli/summary.go
@@ -1,0 +1,23 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"time"
+)
+
+type TransferSummary struct {
+	Status   string
+	Duration time.Duration
+}
+
+func PrintTransferSummary(w io.Writer, s *TransferSummary) {
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Summary")
+	fmt.Fprintln(w, "-------")
+	fmt.Fprintf(w, "PVC data copy: %s\n", s.Status)
+	fmt.Fprintf(w, "duration:      %s\n", s.Duration.Round(time.Second))
+	if s.Status == "succeeded" {
+		fmt.Fprintln(w, "Done.")
+	}
+}


### PR DESCRIPTION
## Summary

  Add numbered phase banners (`[i/N]`), an opening banner, and an end-of-run summary to `crane transfer-pvc` so users always know which step is running.

  ### Before

  {"ingress":"{...}","level":"info","logger":"transfer-pvc","msg":"endpoint is unhealthy","time":"..."}
  {"ingress":"{...}","level":"info","logger":"transfer-pvc","msg":"endpoint is unhealthy","time":"..."}
  {"level":"info","logger":"transfer-pvc","msg":"generating new certificate bundle","time":"..."}
  2026/07/28 13:17:59 container rsync in pod phase-test/rsync-client-... is not ready
  Status: Succeeded
  Progress:
    Percentage: 100%
    Transferred: 63.43 M

  No indication of which step is running. Mixed JSON and plain-text logs. No summary. On failure, `log.Fatal` exits immediately with no cleanup.

  ### After

  crane transfer-pvc
  source context:      src
  destination context: tgt
  PVC:                 big-test/big-data → big-test/big-data
  endpoint:            nginx-ingress  (subdomain: big-data.big-test.172.19.0.3.nip.io)

  [1/7] Reading source PVC ... ok
  [2/7] Creating destination PVC ... ok
  [3/7] Creating endpoint (nginx-ingress) ... ok
  [4/7] Waiting for endpoint healthy ... ok
  [5/7] Setting up secure tunnel and server ... ok
  [6/7] Copying data (rsync) ... finished  exit=0
  [7/7] Cleaning up temporary resources ... ok

  Summary

  PVC data copy: succeeded
  duration:      40s
  Done.

  On failure:
  [1/7] Reading source PVC ... FAILED
    error: persistentvolumeclaims "does-not-exist" not found

  Intra-cluster same-namespace shows 8 phases (separate server/client cleanup).

  ### Extensibility

  `internal/cli/` is designed as the foundation for observability across all crane commands. Future PRs for `export`, `transform`, and `apply` reuse the same `PhaseTracker`:

  ```go
  phases := cli.NewPhaseTracker(o.IOStreams.ErrOut, 5)
  phases.Start("Discovery")
  // ...
  phases.End("ok", "38 API types")
  ```
  
  Fixes #691 & #688


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added phase-based progress tracking for PVC transfers.
  * Added formatted transfer banner and end-of-transfer summary (duration + success/failure).
  * Rsync log streaming can now report an optional rsync process exit code.
* **Bug Fixes**
  * Improved phase-scoped error handling and messaging; transfers no longer terminate abruptly on failures.
* **Tests**
  * Added coverage for phase reporting, banner rendering, summary output, and elapsed time behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->