### PR TITLE
:bug: fix secret issue on pvc rename

### DIFF
--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -383,13 +383,7 @@ func (t *TransferPVCCommand) run() error {
 
 	for i := range secretList.Items {
 		destSecret := &secretList.Items[i]
-		secretName := destSecret.Name
-		// The server cert secret is named after destPVC, but the client
-		// expects one named after srcPVC. When names differ, copy with
-		// the client's expected name so both use the same CA.
-		if srcPVC.Name != destPVC.Name {
-			secretName = fmt.Sprintf("stunnel-creds-certs-%s", getValidatedResourceName(srcPVC.Name))
-		}
+		secretName := certificateSecretName(destSecret.Name, srcPVC.Name, destPVC.Name)
 		secretLabels := destSecret.Labels
 		if t.isIntraClusterSameNamespace() {
 			secretLabels = clientLabels
@@ -545,6 +539,13 @@ func (t *TransferPVCCommand) run() error {
 		return garbageCollect(srcClient, destClient, clientLabels, t.Endpoint.Type, t.PVC.Namespace)
 	}
 	return garbageCollect(srcClient, destClient, labels, t.Endpoint.Type, t.PVC.Namespace)
+}
+
+func certificateSecretName(serverSecret, srcPVCName, destPVCName string) string {
+	if srcPVCName != destPVCName {
+		return fmt.Sprintf("stunnel-creds-certs-%s", getValidatedResourceName(srcPVCName))
+	}
+	return serverSecret
 }
 
 // getValidatedResourceName returns a name for resources

--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -384,10 +384,10 @@ func (t *TransferPVCCommand) run() error {
 	for i := range secretList.Items {
 		destSecret := &secretList.Items[i]
 		secretName := destSecret.Name
-		// For intra-cluster: the server cert secret is named after destPVC,
-		// but the client expects one named after srcPVC. Copy with the
-		// client's expected name so both use the same CA.
-		if t.isIntraClusterSameNamespace() {
+		// The server cert secret is named after destPVC, but the client
+		// expects one named after srcPVC. When names differ, copy with
+		// the client's expected name so both use the same CA.
+		if srcPVC.Name != destPVC.Name {
 			secretName = fmt.Sprintf("stunnel-creds-certs-%s", getValidatedResourceName(srcPVC.Name))
 		}
 		secretLabels := destSecret.Labels

--- a/cmd/transfer-pvc/transfer-pvc_test.go
+++ b/cmd/transfer-pvc/transfer-pvc_test.go
@@ -958,10 +958,7 @@ func TestCertSecretNaming(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			secretName := tt.serverSecret
-			if tt.srcPVCName != tt.destPVCName {
-				secretName = fmt.Sprintf("stunnel-creds-certs-%s", getValidatedResourceName(tt.srcPVCName))
-			}
+			secretName := certificateSecretName(tt.serverSecret, tt.srcPVCName, tt.destPVCName)
 			if secretName != tt.wantCopyName {
 				t.Errorf("cert secret name = %q, want %q", secretName, tt.wantCopyName)
 			}

--- a/cmd/transfer-pvc/transfer-pvc_test.go
+++ b/cmd/transfer-pvc/transfer-pvc_test.go
@@ -918,3 +918,53 @@ func TestValidateRejectsSameNameIntraCluster(t *testing.T) {
 		})
 	}
 }
+
+func TestCertSecretNaming(t *testing.T) {
+	tests := []struct {
+		name           string
+		srcPVCName     string
+		destPVCName    string
+		serverSecret   string
+		wantCopyName   string
+	}{
+		{
+			name:         "same PVC name — keep original secret name",
+			srcPVCName:   "mydata",
+			destPVCName:  "mydata",
+			serverSecret: "stunnel-creds-certs-mydata",
+			wantCopyName: "stunnel-creds-certs-mydata",
+		},
+		{
+			name:         "different PVC name — rename to match client expectation",
+			srcPVCName:   "mydata",
+			destPVCName:  "mydata-renamed",
+			serverSecret: "stunnel-creds-certs-mydata-renamed",
+			wantCopyName: "stunnel-creds-certs-mydata",
+		},
+		{
+			name:         "intra-cluster SC conversion — rename to source PVC",
+			srcPVCName:   "redis-data",
+			destPVCName:  "redis-data-new",
+			serverSecret: "stunnel-creds-certs-redis-data-new",
+			wantCopyName: "stunnel-creds-certs-redis-data",
+		},
+		{
+			name:         "cross-cluster namespace mapping same name — keep original",
+			srcPVCName:   "data",
+			destPVCName:  "data",
+			serverSecret: "stunnel-creds-certs-data",
+			wantCopyName: "stunnel-creds-certs-data",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			secretName := tt.serverSecret
+			if tt.srcPVCName != tt.destPVCName {
+				secretName = fmt.Sprintf("stunnel-creds-certs-%s", getValidatedResourceName(tt.srcPVCName))
+			}
+			if secretName != tt.wantCopyName {
+				t.Errorf("cert secret name = %q, want %q", secretName, tt.wantCopyName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

  Fix TLS certificate mismatch when transferring PVCs with different source and destination names across clusters.

  ## Problem

  `crane transfer-pvc --pvc-name mydata:mydata-renamed` fails with rsync exit code 12 on cross-cluster transfers. The stunnel server cert secret is named after the destination PVC (`stunnel-creds-certs-mydata-renamed`),
  but the stunnel client looks for one named after the source PVC (`stunnel-creds-certs-mydata`). When not found, the library generates a new cert bundle with a different CA, causing a TLS handshake failure.

  ## Fix

  Changed the cert secret rename condition from `isIntraClusterSameNamespace()` to `srcPVC.Name != destPVC.Name`, so the rename applies to both cross-cluster and intra-cluster transfers whenever PVC names differ.
  
  
 ## Tests

  Added TestCertSecretNaming with 4 cases:
  - Same name cross-cluster — keep original name
  - Different name cross-cluster — rename to source PVC (the fix)
  - Different name intra-cluster (SC conversion) — rename to source PVC
  - Same name with namespace mapping — keep original name 

  Fixes #733

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved certificate secret naming during PVC transfers.
  * Ensured certificates are correctly copied and renamed whenever the source and destination PVC names differ, including cross-cluster and cross-namespace transfers.
  * Preserved the original certificate secret name when PVC names match.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->