### PR TITLE
:test_tube: mta_812: adopt --ordered apply now that crane#266 is fixed

### DIFF
--- a/e2e-tests/tests/tier0/mta_812_role_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_812_role_migration_test.go
@@ -92,7 +92,8 @@ var _ = Describe("Role and RoleBinding migration", func() {
 		exportOpts := ExportOptions{Namespace: namespace, ExportDir: paths.ExportDir}
 		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
 		applyOpts := ApplyOptions{TransformDir: paths.TransformDir,
-			OutputDir: paths.OutputDir}
+			OutputDir: paths.OutputDir,
+			Ordered:   true}
 		DeferCleanup(func() {
 			By("Cleanup source and target resources")
 			if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
@@ -108,31 +109,23 @@ var _ = Describe("Role and RoleBinding migration", func() {
 		log.Printf("Crane pipeline completed for namespace %s\n", namespace)
 
 		By("Verify Role manifest is present in output directory")
-		rolePattern := filepath.Join(paths.OutputDir, "resources", namespace, "Role_*.yaml")
+		// Ordered: true prefixes filenames with a dependency-aware order number (e.g.
+		// 300_Role_*.yaml), so match on the resource-kind segment rather than the prefix.
+		rolePattern := filepath.Join(paths.OutputDir, "resources", namespace, "*Role_*.yaml")
 		roleMatches, err := filepath.Glob(rolePattern)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(roleMatches).NotTo(BeEmpty(), "expected Role manifest in output dir")
 		log.Printf("Role manifests in output: %v\n", roleMatches)
 
 		By("Verify RoleBinding manifest is present in output directory")
-		rbPattern := filepath.Join(paths.OutputDir, "resources", namespace, "RoleBinding_*.yaml")
+		rbPattern := filepath.Join(paths.OutputDir, "resources", namespace, "*RoleBinding_*.yaml")
 		rbMatches, err := filepath.Glob(rbPattern)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rbMatches).NotTo(BeEmpty(), "expected RoleBinding manifest in output dir")
 		log.Printf("RoleBinding manifests in output: %v\n", rbMatches)
 
-		// TODO: remove once https://github.com/migtools/crane/issues/266 is fixed
-		// NOTE: kubectl apply -f processes files alphabetically. RoleBinding sorts before
-		// Role, so pod-reader-binding fails on a fresh namespace because pod-reader does
-		// not yet exist. We skip the dry-run validation on the first pass and call ApplyDir
-		// directly so the Role lands before the second pass retries the RoleBinding.
-		// See: https://github.com/migtools/crane/issues/266
-		By("Apply rendered manifests to target (first pass)")
-		log.Printf("First apply pass — skipping dry-run, ordering failure for RoleBinding expected\n")
-		_ = kubectlTgtNonAdmin.ApplyDir(paths.OutputDir)
-
-		By("Apply rendered manifests to target (second pass — resolves ordering issue)")
-		log.Printf("Second apply pass for namespace %s\n", namespace)
+		By("Apply rendered manifests to target")
+		log.Printf("Applying manifests for namespace %s\n", namespace)
 		Expect(ApplyOutputToTargetNonAdmin(kubectlTgtNonAdmin, paths.OutputDir)).NotTo(HaveOccurred())
 
 		By("Scale target deployment and validate app is running")


### PR DESCRIPTION
## Summary
- `mta_812_role_migration_test.go` had a two-pass `kubectl apply` workaround for crane#266 (RoleBinding sorting alphabetically before its Role on a fresh namespace apply). #266 is now fixed via the opt-in `--ordered` apply flag, which prefixes output filenames with a dependency-aware order number (e.g. `300_Role_*`, `310_RoleBinding_*`).
- This test now sets `Ordered: true` and does a single apply pass instead of the old skip-dry-run-then-retry workaround.
- Updated the Role/RoleBinding manifest-presence glob assertions to match regardless of the ordering prefix (`*Role_*.yaml` / `*RoleBinding_*.yaml`), since the old exact-prefix globs would've silently stopped matching once ordering was enabled.
- Kept the `BUG #266` title/label tag on the test for historical traceability, per team convention, even though the workaround itself is gone.

Other `BUG #NNN`-tagged tests were audited as part of this pass:
- `mta_807`, `mta_811` (crane#213): already fully fixed upstream (PR #603) with no remaining workaround — no changes needed.
- `mta_813` (crane#330 fixed / crane#408 still open): crane#330's workaround was already removed (PR #637). The PVC-content-integrity assertion tied to crane#408 stays commented out — verified by temporarily re-enabling and running it locally, which reproduced the bug (crane's own output showed `Status: Failed`, `Files Sent: 0`, rsync exit code 12, yet `crane transfer-pvc` still reported `"PVC data copy: succeeded"` and exited 0). Reverted back to the commented-out state since crane#408 is not fixed yet.
- `mta_862`: no change needed — it's already the dedicated regression test for the `--ordered` fix.

## Test plan
- [x] `go build ./...` and `go vet ./...` pass in `e2e-tests/`
- [x] Ran `mta_812` locally against `src`/`tgt` minikube clusters — passes with a single ordered apply pass (verified ordered filenames `300_Role_*`/`310_RoleBinding_*` in output, single dry-run + apply, no first-pass/second-pass workaround)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment ordering so dependent resources are applied in the correct sequence.
  * Updated manifest validation to reliably accept correctly ordered resource filenames.
  * Simplified target application to use a single standard apply step, improving consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->