### PR TITLE
:test_tube: mta-875 add tier1 e2e test for skipping PV migration with pre-migrated PVC data

### DIFF
--- a/e2e-tests/tests/tier1/mta_875_skip_premigrated_pvc_data_test.go
+++ b/e2e-tests/tests/tier1/mta_875_skip_premigrated_pvc_data_test.go
@@ -1,0 +1,154 @@
+package e2e
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	"github.com/konveyor/crane/e2e-tests/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func getPodName(k KubectlRunner, namespace, label string) (string, error) {
+	out, err := k.Run("get", "pods", "-n", namespace, "-l", "app="+label, "-o", "jsonpath={.items[0].metadata.name}")
+	if err != nil {
+		return "", err
+	}
+	name := strings.TrimSpace(out)
+	if name == "" {
+		return "", fmt.Errorf("no pod found in namespace %q with label app=%s", namespace, label)
+	}
+	return name, nil
+}
+
+func readPodFile(k KubectlRunner, namespace, pod, path string) (string, error) {
+	return k.Run("exec", pod, "-n", namespace, "--", "cat", path)
+}
+
+func writePodFile(k KubectlRunner, namespace, pod, path, content string) error {
+	_, err := k.RunWithStdin(content, "exec", pod, "-n", namespace, "-i", "--", "sh", "-c", "cat > "+path)
+	return err
+}
+
+func curlStatusCode(k KubectlRunner, namespace, pod string) (string, error) {
+	return k.Run("exec", pod, "-n", namespace, "--", "sh", "-c", "curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8080/")
+}
+
+var _ = Describe("Skip PV migration when PV data was already migrated ahead of time", func() {
+	It("[MTA-875] Skip PV migration when PV data was already migrated ahead of time", Label("tier1", "pvc-transfer"), func() {
+		const podLabel = "nginx"
+		appName := "nginxpv"
+		namespace := "mta-875-skip-pv"
+		scenario := NewMigrationScenario(
+			appName,
+			namespace,
+			config.K8sDeployBin,
+			config.CraneBin,
+			config.SourceContext,
+			config.TargetContext,
+		)
+		srcApp := scenario.SrcApp
+		tgtApp := scenario.TgtApp
+		kubectlSrc := scenario.KubectlSrc
+		kubectlTgt := scenario.KubectlTgt
+
+		paths, err := NewScenarioPaths("crane-export-*")
+		Expect(err).NotTo(HaveOccurred())
+		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{TransformDir: paths.TransformDir, OutputDir: paths.OutputDir}
+		DeferCleanup(func() {
+			By("Cleanup source and target resources")
+			if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
+				log.Printf("cleanup: %v", err)
+			}
+		})
+
+		By("Deploy nginx app with two PVCs (html, logs)")
+		Expect(PrepareSourceAppNoQuiesce(srcApp)).NotTo(HaveOccurred())
+		srcPod, err := getPodName(kubectlSrc, srcApp.Namespace, podLabel)
+		Expect(err).NotTo(HaveOccurred())
+		log.Printf("pod %s is ready\n", srcPod)
+
+		By("Generate traffic/data (a 403 on empty html dir, then a real page)")
+		firstCode, err := curlStatusCode(kubectlSrc, srcApp.Namespace, srcPod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(firstCode).To(Equal("403"), "expected a 403 for the empty html dir")
+		Expect(writePodFile(kubectlSrc, srcApp.Namespace, srcPod, "/usr/share/nginx/html/index.html", "<h1>HELLO WORLD</h1>\n")).NotTo(HaveOccurred())
+		secondCode, err := curlStatusCode(kubectlSrc, srcApp.Namespace, srcPod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(secondCode).To(Equal("200"), "expected a 200 once index.html exists")
+
+		By("Extract data to be pre-copied to target ahead of migration")
+		srcIndexHTML, err := readPodFile(kubectlSrc, srcApp.Namespace, srcPod, "/usr/share/nginx/html/index.html")
+		Expect(err).NotTo(HaveOccurred())
+		srcAccessLog, err := readPodFile(kubectlSrc, srcApp.Namespace, srcPod, "/var/log/nginx/access.log")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strings.Count(srcAccessLog, "403")).To(BeNumerically(">=", 1), "expected at least one 403 in source access.log")
+		srcErrorLog, err := readPodFile(kubectlSrc, srcApp.Namespace, srcPod, "/var/log/nginx/error.log")
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Import PV data ahead of time via a temporary instance of the same app")
+		Expect(tgtApp.Deploy()).NotTo(HaveOccurred())
+		Expect(tgtApp.Validate()).NotTo(HaveOccurred())
+		tgtSeedPod, err := getPodName(kubectlTgt, tgtApp.Namespace, podLabel)
+		Expect(err).NotTo(HaveOccurred())
+		log.Printf("seeding pre-existing PVC data via temporary pod %s\n", tgtSeedPod)
+		Expect(writePodFile(kubectlTgt, tgtApp.Namespace, tgtSeedPod, "/usr/share/nginx/html/index.html", srcIndexHTML+"\n")).NotTo(HaveOccurred())
+		Expect(writePodFile(kubectlTgt, tgtApp.Namespace, tgtSeedPod, "/var/log/nginx/access.log", srcAccessLog+"\n")).NotTo(HaveOccurred())
+		Expect(writePodFile(kubectlTgt, tgtApp.Namespace, tgtSeedPod, "/var/log/nginx/error.log", srcErrorLog+"\n")).NotTo(HaveOccurred())
+
+		By("Remove the temporary app, leaving the pre-populated PVCs bound")
+		_, err = kubectlTgt.Run("delete", "deployment", "nginx-deployment", "-n", tgtApp.Namespace, "--wait=true")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = kubectlTgt.Run("delete", "service", "my-nginx", "-n", tgtApp.Namespace)
+		Expect(err).NotTo(HaveOccurred())
+		tgtPVCs, err := ListPVCs(tgtApp.Namespace, "", tgtApp.Context)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tgtPVCs).To(HaveLen(2), "expected the two pre-populated PVCs to remain after removing the temporary app")
+
+		By("Run crane export/transform/apply pipeline (no transfer-pvc: PV migration is skipped)")
+		runner := scenario.Crane
+		runner.WorkDir = paths.TempDir
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
+
+		By("Verify rendered manifests contain no PVC/PV: crane's default pipeline never migrates PV data")
+		outputFiles, err := utils.ListFilesRecursivelyAsList(paths.OutputDir)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(outputFiles).NotTo(BeEmpty())
+		for _, f := range outputFiles {
+			Expect(f).NotTo(ContainSubstring("PersistentVolume"), "output should not contain a PVC/PV manifest file: %s", f)
+			content, err := os.ReadFile(filepath.Join(paths.OutputDir, f))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).NotTo(ContainSubstring("PersistentVolume"), "output file %s should not reference a PVC/PV", f)
+		}
+
+		By("Apply rendered manifests; the new pod must bind to the pre-existing, pre-populated PVCs")
+		Expect(ApplyOutputToTarget(kubectlTgt, tgtApp.Namespace, paths.OutputDir)).NotTo(HaveOccurred())
+		Eventually(tgtApp.Validate, "5m", "10s").Should(Succeed())
+		tgtPod, err := getPodName(kubectlTgt, tgtApp.Namespace, podLabel)
+		Expect(err).NotTo(HaveOccurred())
+		log.Printf("migrated pod %s is ready\n", tgtPod)
+
+		By("Verify the migrated app is functioning correctly using the pre-existing data, without a PV data transfer")
+		tgtIndexHTML, err := readPodFile(kubectlTgt, tgtApp.Namespace, tgtPod, "/usr/share/nginx/html/index.html")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tgtIndexHTML).To(Equal(srcIndexHTML), "index.html should be the pre-copied source content")
+		tgtAccessLog, err := readPodFile(kubectlTgt, tgtApp.Namespace, tgtPod, "/var/log/nginx/access.log")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tgtAccessLog).To(ContainSubstring(srcAccessLog), "access.log should still contain the pre-copied source content")
+		tgtErrorLog, err := readPodFile(kubectlTgt, tgtApp.Namespace, tgtPod, "/var/log/nginx/error.log")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tgtErrorLog).To(ContainSubstring(srcErrorLog), "error.log should still contain the pre-copied source content")
+
+		By("Final smoke test: the migrated app serves the pre-existing page correctly")
+		finalCode, err := curlStatusCode(kubectlTgt, tgtApp.Namespace, tgtPod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(finalCode).To(Equal("200"))
+	})
+})

--- a/e2e-tests/tests/tier1/mta_875_skip_premigrated_pvc_data_test.go
+++ b/e2e-tests/tests/tier1/mta_875_skip_premigrated_pvc_data_test.go
@@ -14,35 +14,10 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func getPodName(k KubectlRunner, namespace, label string) (string, error) {
-	out, err := k.Run("get", "pods", "-n", namespace, "-l", "app="+label, "-o", "jsonpath={.items[0].metadata.name}")
-	if err != nil {
-		return "", err
-	}
-	name := strings.TrimSpace(out)
-	if name == "" {
-		return "", fmt.Errorf("no pod found in namespace %q with label app=%s", namespace, label)
-	}
-	return name, nil
-}
-
-func readPodFile(k KubectlRunner, namespace, pod, path string) (string, error) {
-	return k.Run("exec", pod, "-n", namespace, "--", "cat", path)
-}
-
-func writePodFile(k KubectlRunner, namespace, pod, path, content string) error {
-	_, err := k.RunWithStdin(content, "exec", pod, "-n", namespace, "-i", "--", "sh", "-c", "cat > "+path)
-	return err
-}
-
-func curlStatusCode(k KubectlRunner, namespace, pod string) (string, error) {
-	return k.Run("exec", pod, "-n", namespace, "--", "sh", "-c", "curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8080/")
-}
-
 var _ = Describe("Skip PV migration when PV data was already migrated ahead of time", func() {
 	It("[MTA-875] Skip PV migration when PV data was already migrated ahead of time", Label("tier1", "pvc-transfer"), func() {
-		const podLabel = "nginx"
-		appName := "nginxpv"
+		const testFileName = "testfile.txt"
+		appName := "app-with-empty-pvc"
 		namespace := "mta-875-skip-pv"
 		scenario := NewMigrationScenario(
 			appName,
@@ -57,6 +32,20 @@ var _ = Describe("Skip PV migration when PV data was already migrated ahead of t
 		kubectlSrc := scenario.KubectlSrc
 		kubectlTgt := scenario.KubectlTgt
 
+		srcApp.ExtraVars = map[string]any{
+			"app_name":  appName,
+			"add_data":  "true",
+			"file_name": testFileName,
+			"file_size": 10,
+		}
+		tgtApp.ExtraVars = map[string]any{
+			"app_name": appName,
+			"add_data": "true",
+		}
+
+		By("Deploy a source app with a PVC and seed it with known data")
+		Expect(PrepareSourceAppNoQuiesce(srcApp)).NotTo(HaveOccurred())
+
 		paths, err := NewScenarioPaths("crane-export-*")
 		Expect(err).NotTo(HaveOccurred())
 		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
@@ -69,55 +58,54 @@ var _ = Describe("Skip PV migration when PV data was already migrated ahead of t
 			}
 		})
 
-		By("Deploy nginx app with two PVCs (html, logs)")
-		Expect(PrepareSourceAppNoQuiesce(srcApp)).NotTo(HaveOccurred())
-		srcPod, err := getPodName(kubectlSrc, srcApp.Namespace, podLabel)
+		By("Get file MD5 checksum")
+		srcMD5Output, err := kubectlSrc.Run("exec", appName, "-n", srcApp.Namespace, "--", "/bin/sh", "-c", fmt.Sprintf("cat /data/%s.md5", testFileName))
 		Expect(err).NotTo(HaveOccurred())
-		log.Printf("pod %s is ready\n", srcPod)
+		srcMD5 := strings.TrimSpace(srcMD5Output)
+		Expect(srcMD5).NotTo(BeEmpty(), "expected MD5 checksum file to exist on source")
+		log.Printf("MD5 checksum: %s\n", srcMD5)
 
-		By("Generate traffic/data (a 403 on empty html dir, then a real page)")
-		firstCode, err := curlStatusCode(kubectlSrc, srcApp.Namespace, srcPod)
+		By("List PVCs in the namespace")
+		pvcs, err := ListPVCs(srcApp.Namespace, "", srcApp.Context)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(firstCode).To(Equal("403"), "expected a 403 for the empty html dir")
-		Expect(writePodFile(kubectlSrc, srcApp.Namespace, srcPod, "/usr/share/nginx/html/index.html", "<h1>HELLO WORLD</h1>\n")).NotTo(HaveOccurred())
-		secondCode, err := curlStatusCode(kubectlSrc, srcApp.Namespace, srcPod)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(secondCode).To(Equal("200"), "expected a 200 once index.html exists")
+		Expect(pvcs).To(HaveLen(1), "expected exactly one PVC in namespace %q", srcApp.Namespace)
+		pvcName := pvcs[0].Name
+		log.Printf("Found PVC %s in namespace %q\n", pvcName, srcApp.Namespace)
 
-		By("Extract data to be pre-copied to target ahead of migration")
-		srcIndexHTML, err := readPodFile(kubectlSrc, srcApp.Namespace, srcPod, "/usr/share/nginx/html/index.html")
-		Expect(err).NotTo(HaveOccurred())
-		srcAccessLog, err := readPodFile(kubectlSrc, srcApp.Namespace, srcPod, "/var/log/nginx/access.log")
-		Expect(err).NotTo(HaveOccurred())
-		Expect(strings.Count(srcAccessLog, "403")).To(BeNumerically(">=", 1), "expected at least one 403 in source access.log")
-		srcErrorLog, err := readPodFile(kubectlSrc, srcApp.Namespace, srcPod, "/var/log/nginx/error.log")
-		Expect(err).NotTo(HaveOccurred())
+		By("Create target namespace")
+		Expect(kubectlTgt.CreateNamespace(tgtApp.Namespace)).NotTo(HaveOccurred())
 
-		By("Import PV data ahead of time via a temporary instance of the same app")
-		Expect(tgtApp.Deploy()).NotTo(HaveOccurred())
-		Expect(tgtApp.Validate()).NotTo(HaveOccurred())
-		tgtSeedPod, err := getPodName(kubectlTgt, tgtApp.Namespace, podLabel)
-		Expect(err).NotTo(HaveOccurred())
-		log.Printf("seeding pre-existing PVC data via temporary pod %s\n", tgtSeedPod)
-		Expect(writePodFile(kubectlTgt, tgtApp.Namespace, tgtSeedPod, "/usr/share/nginx/html/index.html", srcIndexHTML+"\n")).NotTo(HaveOccurred())
-		Expect(writePodFile(kubectlTgt, tgtApp.Namespace, tgtSeedPod, "/var/log/nginx/access.log", srcAccessLog+"\n")).NotTo(HaveOccurred())
-		Expect(writePodFile(kubectlTgt, tgtApp.Namespace, tgtSeedPod, "/var/log/nginx/error.log", srcErrorLog+"\n")).NotTo(HaveOccurred())
-
-		By("Remove the temporary app, leaving the pre-populated PVCs bound")
-		_, err = kubectlTgt.Run("delete", "deployment", "nginx-deployment", "-n", tgtApp.Namespace, "--wait=true")
-		Expect(err).NotTo(HaveOccurred())
-		_, err = kubectlTgt.Run("delete", "service", "my-nginx", "-n", tgtApp.Namespace)
-		Expect(err).NotTo(HaveOccurred())
-		tgtPVCs, err := ListPVCs(tgtApp.Namespace, "", tgtApp.Context)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(tgtPVCs).To(HaveLen(2), "expected the two pre-populated PVCs to remain after removing the temporary app")
-
-		By("Run crane export/transform/apply pipeline (no transfer-pvc: PV migration is skipped)")
+		By("Manually run crane transfer-pvc to migrate the PVC data to the target cluster ahead of the main app migration")
 		runner := scenario.Crane
 		runner.WorkDir = paths.TempDir
+		tgtIP, err := GetClusterNodeIP(tgtApp.Context)
+		Expect(err).NotTo(HaveOccurred())
+		transferOpts := TransferPVCOptions{
+			SourceContext:   srcApp.Context,
+			TargetContext:   tgtApp.Context,
+			PVCName:         pvcName,
+			PVCNamespaceMap: fmt.Sprintf("%s:%s", srcApp.Namespace, tgtApp.Namespace),
+			Subdomain:       fmt.Sprintf("%s.%s.%s.nip.io", pvcName, srcApp.Namespace, tgtIP),
+		}
+		Expect(runner.TransferPVC(transferOpts)).NotTo(HaveOccurred())
+
+		By("Wait for transfer-pvc's ephemeral rsync pods to be fully removed")
+		Eventually(func() (string, error) {
+			return kubectlSrc.Run("get", "pods", "-n", srcApp.Namespace, "-o", "name")
+		}, "60s", "2s").ShouldNot(ContainSubstring("rsync"))
+		Eventually(func() (string, error) {
+			return kubectlTgt.Run("get", "pods", "-n", tgtApp.Namespace, "-o", "name")
+		}, "60s", "2s").ShouldNot(ContainSubstring("rsync"))
+
+		By("Verify the destination PVC exists")
+		tgtPVCs, err := ListPVCs(tgtApp.Namespace, "", tgtApp.Context)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tgtPVCs).To(HaveLen(1), "expected the pre-migrated PVC to exist on target")
+
+		By("Run crane export/transform/apply for the app's namespace (PVCs whited out as usual)")
 		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 
-		By("Verify rendered manifests contain no PVC/PV: crane's default pipeline never migrates PV data")
+		By("Verify the rendered manifests contain no PVC/PV: the already-migrated PVC is not re-transferred or re-created")
 		outputFiles, err := utils.ListFilesRecursivelyAsList(paths.OutputDir)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(outputFiles).NotTo(BeEmpty())
@@ -128,27 +116,15 @@ var _ = Describe("Skip PV migration when PV data was already migrated ahead of t
 			Expect(string(content)).NotTo(ContainSubstring("PersistentVolume"), "output file %s should not reference a PVC/PV", f)
 		}
 
-		By("Apply rendered manifests; the new pod must bind to the pre-existing, pre-populated PVCs")
+		By("Deploy/scale up the app on the target cluster, reusing the pre-migrated PVC")
 		Expect(ApplyOutputToTarget(kubectlTgt, tgtApp.Namespace, paths.OutputDir)).NotTo(HaveOccurred())
 		Eventually(tgtApp.Validate, "5m", "10s").Should(Succeed())
-		tgtPod, err := getPodName(kubectlTgt, tgtApp.Namespace, podLabel)
-		Expect(err).NotTo(HaveOccurred())
-		log.Printf("migrated pod %s is ready\n", tgtPod)
 
-		By("Verify the migrated app is functioning correctly using the pre-existing data, without a PV data transfer")
-		tgtIndexHTML, err := readPodFile(kubectlTgt, tgtApp.Namespace, tgtPod, "/usr/share/nginx/html/index.html")
+		By("Verify the app reads the pre-migrated data with no data loss")
+		tgtMD5Output, err := kubectlTgt.Run("exec", appName, "-n", tgtApp.Namespace, "--", "/bin/sh", "-c", fmt.Sprintf("cat /data/%s.md5", testFileName))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(tgtIndexHTML).To(Equal(srcIndexHTML), "index.html should be the pre-copied source content")
-		tgtAccessLog, err := readPodFile(kubectlTgt, tgtApp.Namespace, tgtPod, "/var/log/nginx/access.log")
-		Expect(err).NotTo(HaveOccurred())
-		Expect(tgtAccessLog).To(ContainSubstring(srcAccessLog), "access.log should still contain the pre-copied source content")
-		tgtErrorLog, err := readPodFile(kubectlTgt, tgtApp.Namespace, tgtPod, "/var/log/nginx/error.log")
-		Expect(err).NotTo(HaveOccurred())
-		Expect(tgtErrorLog).To(ContainSubstring(srcErrorLog), "error.log should still contain the pre-copied source content")
-
-		By("Final smoke test: the migrated app serves the pre-existing page correctly")
-		finalCode, err := curlStatusCode(kubectlTgt, tgtApp.Namespace, tgtPod)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(finalCode).To(Equal("200"))
+		tgtMD5 := strings.TrimSpace(tgtMD5Output)
+		Expect(tgtMD5).To(Equal(srcMD5), "MD5 checksum on target should match source")
+		log.Printf("Source and target MD5 checksums match: %s\n", srcMD5)
 	})
 })

--- a/e2e-tests/tests/tier1/mta_875_skip_premigrated_pvc_data_test.go
+++ b/e2e-tests/tests/tier1/mta_875_skip_premigrated_pvc_data_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/konveyor/crane/e2e-tests/config"
@@ -13,6 +14,16 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+var pvcOrPVKindRegex = regexp.MustCompile(`(?m)^kind:\s*(PersistentVolume|PersistentVolumeClaim)\s*$`)
+
+func md5sumFile(k KubectlRunner, namespace, pod, path string) (string, error) {
+	out, err := k.Run("exec", pod, "-n", namespace, "--", "/bin/sh", "-c", fmt.Sprintf("md5sum %s | awk '{print $1}'", path))
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}
 
 var _ = Describe("Skip PV migration when PV data was already migrated ahead of time", func() {
 	It("[MTA-875] Skip PV migration when PV data was already migrated ahead of time", Label("tier1", "pvc-transfer"), func() {
@@ -59,10 +70,9 @@ var _ = Describe("Skip PV migration when PV data was already migrated ahead of t
 		})
 
 		By("Get file MD5 checksum")
-		srcMD5Output, err := kubectlSrc.Run("exec", appName, "-n", srcApp.Namespace, "--", "/bin/sh", "-c", fmt.Sprintf("cat /data/%s.md5", testFileName))
+		srcMD5, err := md5sumFile(kubectlSrc, srcApp.Namespace, appName, "/data/"+testFileName)
 		Expect(err).NotTo(HaveOccurred())
-		srcMD5 := strings.TrimSpace(srcMD5Output)
-		Expect(srcMD5).NotTo(BeEmpty(), "expected MD5 checksum file to exist on source")
+		Expect(srcMD5).NotTo(BeEmpty(), "expected to compute an MD5 checksum on source")
 		log.Printf("MD5 checksum: %s\n", srcMD5)
 
 		By("List PVCs in the namespace")
@@ -102,6 +112,43 @@ var _ = Describe("Skip PV migration when PV data was already migrated ahead of t
 		Expect(err).NotTo(HaveOccurred())
 		Expect(tgtPVCs).To(HaveLen(1), "expected the pre-migrated PVC to exist on target")
 
+		By("Verify the destination PVC's data already matches source, isolated from the rest of the migration")
+		const verifierPod = "mta-875-pvc-verifier"
+		verifierPodYAML := fmt.Sprintf(`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  containers:
+  - name: verifier
+    image: quay.io/openshifttest/alpine:multiarch
+    command: ["sleep", "300"]
+    volumeMounts:
+    - name: data
+      mountPath: /data
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      allowPrivilegeEscalation: false
+      seccompProfile:
+        type: RuntimeDefault
+  volumes:
+  - name: data
+    persistentVolumeClaim:
+      claimName: %s
+`, verifierPod, tgtApp.Namespace, pvcName)
+		Expect(kubectlTgt.ApplyYAMLSpec(verifierPodYAML, tgtApp.Namespace)).NotTo(HaveOccurred())
+		_, err = kubectlTgt.Run("wait", "--for=condition=Ready", "pod/"+verifierPod, "-n", tgtApp.Namespace, "--timeout=120s")
+		Expect(err).NotTo(HaveOccurred())
+		tgtMD5BeforeMigration, err := md5sumFile(kubectlTgt, tgtApp.Namespace, verifierPod, "/data/"+testFileName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tgtMD5BeforeMigration).To(Equal(srcMD5),
+			"destination PVC data should already match source right after transfer-pvc, before the main migration runs")
+		_, err = kubectlTgt.Run("delete", "pod", verifierPod, "-n", tgtApp.Namespace, "--wait=true")
+		Expect(err).NotTo(HaveOccurred())
+
 		By("Run crane export/transform/apply for the app's namespace (PVCs whited out as usual)")
 		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 
@@ -110,10 +157,10 @@ var _ = Describe("Skip PV migration when PV data was already migrated ahead of t
 		Expect(err).NotTo(HaveOccurred())
 		Expect(outputFiles).NotTo(BeEmpty())
 		for _, f := range outputFiles {
-			Expect(f).NotTo(ContainSubstring("PersistentVolume"), "output should not contain a PVC/PV manifest file: %s", f)
 			content, err := os.ReadFile(filepath.Join(paths.OutputDir, f))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(content)).NotTo(ContainSubstring("PersistentVolume"), "output file %s should not reference a PVC/PV", f)
+			Expect(pvcOrPVKindRegex.MatchString(string(content))).To(BeFalse(),
+				"output file %s should not declare a PersistentVolume/PersistentVolumeClaim kind", f)
 		}
 
 		By("Deploy/scale up the app on the target cluster, reusing the pre-migrated PVC")
@@ -121,9 +168,8 @@ var _ = Describe("Skip PV migration when PV data was already migrated ahead of t
 		Eventually(tgtApp.Validate, "5m", "10s").Should(Succeed())
 
 		By("Verify the app reads the pre-migrated data with no data loss")
-		tgtMD5Output, err := kubectlTgt.Run("exec", appName, "-n", tgtApp.Namespace, "--", "/bin/sh", "-c", fmt.Sprintf("cat /data/%s.md5", testFileName))
+		tgtMD5, err := md5sumFile(kubectlTgt, tgtApp.Namespace, appName, "/data/"+testFileName)
 		Expect(err).NotTo(HaveOccurred())
-		tgtMD5 := strings.TrimSpace(tgtMD5Output)
 		Expect(tgtMD5).To(Equal(srcMD5), "MD5 checksum on target should match source")
 		log.Printf("Source and target MD5 checksums match: %s\n", srcMD5)
 	})


### PR DESCRIPTION
[Jenkins run](https://jenkins-csb-migrationqe-main.dno.corp.redhat.com/job/mta/job/crane-ocp-tests-runner/384/console)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Tests

- Added end-to-end coverage for migrating applications with pre-populated persistent volumes.
- Verified volume data is transferred before application migration and remains intact afterward.
- Confirmed migrated applications reconnect to existing volumes and serve the expected content.
- Validated that generated migration output excludes unnecessary persistent volume resources when storage is already available.
- Added checks for transfer completion, data integrity, resource cleanup, and successful application redeployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->