### PR TITLE
:bug: fix annotations on pvc migration

### DIFF
--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -1167,6 +1167,7 @@ func (t *TransferPVCCommand) buildDestinationPVC(sourcePVC *corev1.PersistentVol
 	pvc.Namespace = t.PVC.Namespace.destination
 	pvc.Name = t.PVC.Name.destination
 	pvc.Labels = sourcePVC.Labels
+	pvc.Annotations = stripServerManagedPVCAnnotations(sourcePVC.Annotations)
 	pvc.Spec = *sourcePVC.Spec.DeepCopy()
 	if t.PVC.StorageRequests.quantity != nil {
 		pvc.Spec.Resources.Requests[corev1.ResourceStorage] = *t.PVC.StorageRequests.quantity
@@ -1178,6 +1179,37 @@ func (t *TransferPVCCommand) buildDestinationPVC(sourcePVC *corev1.PersistentVol
 	pvc.Spec.VolumeMode = nil
 	pvc.Spec.VolumeName = ""
 	return pvc
+}
+
+func stripServerManagedPVCAnnotations(annotations map[string]string) map[string]string {
+	if len(annotations) == 0 {
+		return nil
+	}
+	result := make(map[string]string)
+	for key, val := range annotations {
+		if isServerManagedPVCAnnotation(key) {
+			continue
+		}
+		result[key] = val
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+func isServerManagedPVCAnnotation(key string) bool {
+	for _, prefix := range []string{
+		"pv.kubernetes.io/",
+		"volume.kubernetes.io/",
+		"volume.beta.kubernetes.io/",
+		"kubectl.kubernetes.io/",
+	} {
+		if strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // verify enables/disables --checksum option in Rsync

--- a/cmd/transfer-pvc/transfer-pvc_test.go
+++ b/cmd/transfer-pvc/transfer-pvc_test.go
@@ -965,3 +965,80 @@ func TestCertSecretNaming(t *testing.T) {
 		})
 	}
 }
+
+func TestStripServerManagedPVCAnnotations(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		want        map[string]string
+	}{
+		{
+			name:        "nil annotations",
+			annotations: nil,
+			want:        nil,
+		},
+		{
+			name:        "empty annotations",
+			annotations: map[string]string{},
+			want:        nil,
+		},
+		{
+			name: "only user annotations — all preserved",
+			annotations: map[string]string{
+				"backup.company.com/schedule":  "daily",
+				"backup.company.com/retention": "30d",
+				"storage.company.com/tier":     "premium",
+			},
+			want: map[string]string{
+				"backup.company.com/schedule":  "daily",
+				"backup.company.com/retention": "30d",
+				"storage.company.com/tier":     "premium",
+			},
+		},
+		{
+			name: "only server-managed annotations — all stripped",
+			annotations: map[string]string{
+				"pv.kubernetes.io/bind-completed":                   "yes",
+				"volume.kubernetes.io/storage-provisioner":          "ebs.csi.aws.com",
+				"volume.beta.kubernetes.io/storage-provisioner":     "kubernetes.io/gce-pd",
+				"kubectl.kubernetes.io/last-applied-configuration":  "{}",
+			},
+			want: nil,
+		},
+		{
+			name: "mixed — user preserved, server stripped",
+			annotations: map[string]string{
+				"backup.company.com/schedule":              "daily",
+				"pv.kubernetes.io/bind-completed":          "yes",
+				"volume.kubernetes.io/storage-provisioner": "ebs.csi.aws.com",
+				"app.kubernetes.io/managed-by":             "helm",
+			},
+			want: map[string]string{
+				"backup.company.com/schedule":  "daily",
+				"app.kubernetes.io/managed-by": "helm",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripServerManagedPVCAnnotations(tt.annotations)
+			if tt.want == nil && got != nil {
+				t.Errorf("want nil, got %v", got)
+				return
+			}
+			if tt.want != nil && got == nil {
+				t.Errorf("want %v, got nil", tt.want)
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Errorf("length mismatch: got %v, want %v", got, tt.want)
+				return
+			}
+			for k, v := range tt.want {
+				if got[k] != v {
+					t.Errorf("key %q: got %q, want %q", k, got[k], v)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
 ## Summary

  Copy user-defined annotations from source PVC to destination PVC during `transfer-pvc`, stripping server-managed annotations that are cluster-specific.

  ## Problem

  `buildDestinationPVC()` copies labels and spec from the source PVC but skips annotations entirely. User-defined annotations (e.g. `backup.company.com/schedule: daily`) are silently lost on the destination PVC.

  ## Fix

  Added `stripServerManagedPVCAnnotations()` which copies all annotations except those with known server-managed prefixes:

  - `pv.kubernetes.io/`
  - `volume.kubernetes.io/`
  - `volume.beta.kubernetes.io/`
  - `kubectl.kubernetes.io/`

  These prefixes cover all K8s distributions (EKS, GKE, AKS, OCP). CSI-specific annotations use these same prefixes on PVCs — the CSI driver name appears in the annotation **value** (e.g.
  `volume.kubernetes.io/storage-provisioner: ebs.csi.aws.com`), not as a separate key prefix.

  User annotations use company/org domain prefixes (`backup.company.com/`, `app.kubernetes.io/`) which are never stripped.

  ## Tests

  5 test cases for `TestStripServerManagedPVCAnnotations`:
  - nil annotations — returns nil
  - empty annotations — returns nil
  - user-only annotations — all preserved
  - server-managed only — all stripped
  - mixed — user preserved, server stripped

  Fixes #672

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Destination persistent volume claims now preserve user-defined annotations while excluding Kubernetes server-managed metadata.
  * Empty annotation sets are handled correctly during PVC transfers.

* **Tests**
  * Added coverage for nil, empty, user-defined, server-managed, and mixed annotation sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->