### PR TITLE
:sparkles: feat(audit): improve logging in export dir

### DIFF
--- a/.github/workflows/e2e-pr-tester.yaml
+++ b/.github/workflows/e2e-pr-tester.yaml
@@ -143,7 +143,7 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 90
     env:
       CRANE_BIN: ${{ github.workspace }}/crane
       E2E_SUITE_DIR: e2e-tests/tests

--- a/cmd/export/cluster.go
+++ b/cmd/export/cluster.go
@@ -81,7 +81,7 @@ func (c *ClusterScopeHandler) filterRbacResources(resources []*groupResource, lo
 		for kind, count := range acceptedCounts {
 			parts = append(parts, fmt.Sprintf("%d %s", count, kind))
 		}
-		log.Infof("Cluster-scoped resources collected for _cluster/ directory: %s",
+		log.Infof("Cluster-scoped resources exported to _cluster/ directory: %s",
 			strings.Join(parts, ", "))
 	} else {
 		log.Info("No matching cluster-scoped resources found; _cluster/ directory will be empty")

--- a/cmd/export/cluster.go
+++ b/cmd/export/cluster.go
@@ -226,7 +226,7 @@ func (c *ClusterScopedRbacHandler) acceptClusterRoleBinding(clusterResource unst
 	err := runtime.DefaultUnstructuredConverter.
 		FromUnstructured(clusterResource.Object, &crb)
 	if err != nil {
-		c.log.Warnf("Cannot convert to rbacv1.ClusterRoleBinding: %v", err)
+		c.log.Warnf("Cannot convert %s %q to rbacv1.ClusterRoleBinding: %v", clusterResource.GetKind(), clusterResource.GetName(), err)
 		return false
 	}
 	nsSet := c.exportedSANamespaces()
@@ -237,7 +237,7 @@ func (c *ClusterScopedRbacHandler) acceptClusterRoleBinding(clusterResource unst
 		switch s.Kind {
 		case rbacv1.ServiceAccountKind:
 			if c.anyServiceAccountInNamespace(s.Namespace, s.Name) {
-				c.log.Debugf("Accepted %s of kind %s", clusterResource.GetName(), clusterResource.GetKind())
+				c.log.Debugf("Accepted %s of kind %s (match via ServiceAccount %s/%s)", clusterResource.GetName(), clusterResource.GetKind(), s.Namespace, s.Name)
 				return true
 			}
 		case rbacv1.GroupKind:
@@ -263,17 +263,17 @@ func (c *ClusterScopedRbacHandler) acceptClusterRole(clusterResource unstructure
 	err := runtime.DefaultUnstructuredConverter.
 		FromUnstructured(clusterResource.Object, &cr)
 	if err != nil {
-		c.log.Warnf("Cannot convert to rbacv1.ClusterRole: %v", err)
+		c.log.Warnf("Cannot convert %s %q to rbacv1.ClusterRole: %v", clusterResource.GetKind(), clusterResource.GetName(), err)
 	} else {
 		for _, f := range c.filteredClusterRoleBindings.objects.Items {
 			var crb rbacv1.ClusterRoleBinding
 			err := runtime.DefaultUnstructuredConverter.
 				FromUnstructured(f.Object, &crb)
 			if err != nil {
-				c.log.Warnf("Cannot convert to rbacv1.ClusterRoleBinding: %v", err)
+				c.log.Warnf("Cannot convert ClusterRoleBinding %q to rbacv1.ClusterRoleBinding: %v", f.GetName(), err)
 			} else {
 				if crb.RoleRef.Kind == "ClusterRole" && crb.RoleRef.Name == cr.Name {
-					c.log.Debugf("Accepted %s of kind %s", clusterResource.GetName(), clusterResource.GetKind())
+					c.log.Debugf("Accepted %s of kind %s (match via ClusterRoleBinding %s)", clusterResource.GetName(), clusterResource.GetKind(), crb.Name)
 					return true
 				}
 			}
@@ -287,7 +287,7 @@ func (c *ClusterScopedRbacHandler) acceptSecurityContextConstraints(clusterResou
 	err := runtime.DefaultUnstructuredConverter.
 		FromUnstructured(clusterResource.Object, &scc)
 	if err != nil {
-		c.log.Warnf("Cannot convert to securityv1.SecurityContextConstraints: %v", err)
+		c.log.Warnf("Cannot convert %s %q to securityv1.SecurityContextConstraints: %v", clusterResource.GetKind(), clusterResource.GetName(), err)
 		return false
 	}
 
@@ -296,12 +296,12 @@ func (c *ClusterScopedRbacHandler) acceptSecurityContextConstraints(clusterResou
 		err := runtime.DefaultUnstructuredConverter.
 			FromUnstructured(f.Object, &crb)
 		if err != nil {
-			c.log.Warnf("Cannot convert to rbacv1.ClusterRoleBinding: %v", err)
+			c.log.Warnf("Cannot convert ClusterRoleBinding %q to rbacv1.ClusterRoleBinding: %v", f.GetName(), err)
 			continue
 		}
 
 		if crb.RoleRef.Kind == "SecurityContextConstraints" && crb.RoleRef.Name == scc.Name {
-			c.log.Debugf("Accepted %s of kind %s", clusterResource.GetName(), clusterResource.GetKind())
+			c.log.Debugf("Accepted %s of kind %s (match via ClusterRoleBinding RoleRef %s)", clusterResource.GetName(), clusterResource.GetKind(), crb.Name)
 			return true
 		} else {
 			sccSystemName := fmt.Sprintf("system:openshift:scc:%s", clusterResource.GetName())

--- a/cmd/export/cluster.go
+++ b/cmd/export/cluster.go
@@ -55,7 +55,7 @@ func (c *ClusterScopeHandler) filterRbacResources(resources []*groupResource, lo
 			}
 		}
 		if isClusterScopedResource(r.APIGroup, kind) {
-			log.Debugf("Adding %d Cluster resource of type %s", len(r.objects.Items), kind)
+			log.Debugf("Adding %d cluster resource of type %s", len(r.objects.Items), kind)
 			handler.clusterResources[kind] = r
 		} else {
 			filteredResources = append(filteredResources, r)
@@ -81,7 +81,7 @@ func (c *ClusterScopeHandler) filterRbacResources(resources []*groupResource, lo
 		for kind, count := range acceptedCounts {
 			parts = append(parts, fmt.Sprintf("%d %s", count, kind))
 		}
-		log.Infof("Cluster-scoped resources exported to _cluster/ directory: %s",
+		log.Infof("Cluster-scoped resources collected for _cluster/ directory: %s",
 			strings.Join(parts, ", "))
 	} else {
 		log.Info("No matching cluster-scoped resources found; _cluster/ directory will be empty")
@@ -117,6 +117,7 @@ func (c *ClusterScopedRbacHandler) exportedSANamespaces() map[string]struct{} {
 			m[ns] = struct{}{}
 		}
 	}
+	
 	return m
 }
 
@@ -153,7 +154,7 @@ func parseServiceAccountUserSubject(userName string) (namespace, saName string, 
 
 func (c *ClusterScopedRbacHandler) prepareForFiltering() {
 	c.readyToFilter = true
-	c.log.Infof("Preparing matching ClusterRoleBindings")
+	c.log.Debug("Preparing matching ClusterRoleBindings")
 
 	clusterRoleBindings, ok := c.clusterResources["ClusterRoleBinding"]
 	if ok {
@@ -167,7 +168,7 @@ func (c *ClusterScopedRbacHandler) prepareForFiltering() {
 		for _, crb := range clusterRoleBindings.objects.Items {
 			if c.acceptClusterRoleBinding(crb) {
 				filteredClusterRoleBindings.Items = append(filteredClusterRoleBindings.Items, crb)
-				c.log.Infof("Found matching %s %s", crb.GetKind(), crb.GetName())
+				c.log.Debugf("Found matching %s %s", crb.GetKind(), crb.GetName())
 			}
 		}
 		c.filteredClusterRoleBindings.objects = &filteredClusterRoleBindings
@@ -225,7 +226,7 @@ func (c *ClusterScopedRbacHandler) acceptClusterRoleBinding(clusterResource unst
 	err := runtime.DefaultUnstructuredConverter.
 		FromUnstructured(clusterResource.Object, &crb)
 	if err != nil {
-		c.log.Warnf("Cannot convert to rbacv1.ClusterRoleBinding: %s", err)
+		c.log.Warnf("Cannot convert to rbacv1.ClusterRoleBinding: %v", err)
 		return false
 	}
 	nsSet := c.exportedSANamespaces()
@@ -236,19 +237,19 @@ func (c *ClusterScopedRbacHandler) acceptClusterRoleBinding(clusterResource unst
 		switch s.Kind {
 		case rbacv1.ServiceAccountKind:
 			if c.anyServiceAccountInNamespace(s.Namespace, s.Name) {
-				c.log.Infof("Accepted %s of kind %s", clusterResource.GetName(), clusterResource.GetKind())
+				c.log.Debugf("Accepted %s of kind %s", clusterResource.GetName(), clusterResource.GetKind())
 				return true
 			}
 		case rbacv1.GroupKind:
 			if groupMatchesExportedSANamespaces(s.Name, nsSet) {
-				c.log.Infof("Accepted %s of kind %s (match via Group %s)",
+				c.log.Debugf("Accepted %s of kind %s (match via Group %s)",
 					clusterResource.GetName(), clusterResource.GetKind(), s.Name)
 				return true
 			}
 		case rbacv1.UserKind:
 			ns, saName, ok := parseServiceAccountUserSubject(s.Name)
 			if ok && c.anyServiceAccountInNamespace(ns, saName) {
-				c.log.Infof("Accepted %s of kind %s (match via User %s)",
+				c.log.Debugf("Accepted %s of kind %s (match via User %s)",
 					clusterResource.GetName(), clusterResource.GetKind(), s.Name)
 				return true
 			}
@@ -262,17 +263,17 @@ func (c *ClusterScopedRbacHandler) acceptClusterRole(clusterResource unstructure
 	err := runtime.DefaultUnstructuredConverter.
 		FromUnstructured(clusterResource.Object, &cr)
 	if err != nil {
-		c.log.Warnf("Cannot convert to rbacv1.ClusterRole: %s", err)
+		c.log.Warnf("Cannot convert to rbacv1.ClusterRole: %v", err)
 	} else {
 		for _, f := range c.filteredClusterRoleBindings.objects.Items {
 			var crb rbacv1.ClusterRoleBinding
 			err := runtime.DefaultUnstructuredConverter.
 				FromUnstructured(f.Object, &crb)
 			if err != nil {
-				c.log.Warnf("Cannot convert to rbacv1.ClusterRoleBinding: %s", err)
+				c.log.Warnf("Cannot convert to rbacv1.ClusterRoleBinding: %v", err)
 			} else {
 				if crb.RoleRef.Kind == "ClusterRole" && crb.RoleRef.Name == cr.Name {
-					c.log.Infof("Accepted %s of kind %s", clusterResource.GetName(), clusterResource.GetKind())
+					c.log.Debugf("Accepted %s of kind %s", clusterResource.GetName(), clusterResource.GetKind())
 					return true
 				}
 			}
@@ -286,7 +287,7 @@ func (c *ClusterScopedRbacHandler) acceptSecurityContextConstraints(clusterResou
 	err := runtime.DefaultUnstructuredConverter.
 		FromUnstructured(clusterResource.Object, &scc)
 	if err != nil {
-		c.log.Warnf("Cannot convert to securityv1.SecurityContextConstraints: %s", err)
+		c.log.Warnf("Cannot convert to securityv1.SecurityContextConstraints: %v", err)
 		return false
 	}
 
@@ -295,17 +296,17 @@ func (c *ClusterScopedRbacHandler) acceptSecurityContextConstraints(clusterResou
 		err := runtime.DefaultUnstructuredConverter.
 			FromUnstructured(f.Object, &crb)
 		if err != nil {
-			c.log.Warnf("Cannot convert to rbacv1.ClusterRoleBinding: %s", err)
+			c.log.Warnf("Cannot convert to rbacv1.ClusterRoleBinding: %v", err)
 			continue
 		}
 
 		if crb.RoleRef.Kind == "SecurityContextConstraints" && crb.RoleRef.Name == scc.Name {
-			c.log.Infof("Accepted %s of kind %s", clusterResource.GetName(), clusterResource.GetKind())
+			c.log.Debugf("Accepted %s of kind %s", clusterResource.GetName(), clusterResource.GetKind())
 			return true
 		} else {
 			sccSystemName := fmt.Sprintf("system:openshift:scc:%s", clusterResource.GetName())
 			if crb.RoleRef.Kind == "ClusterRole" && crb.RoleRef.Name == sccSystemName {
-				c.log.Infof("Accepted %s of kind %s (match via ClusterRoleBinding %s)",
+				c.log.Debugf("Accepted %s of kind %s (match via ClusterRoleBinding %s)",
 					clusterResource.GetName(), clusterResource.GetKind(), crb.Name)
 				return true
 			}
@@ -315,7 +316,7 @@ func (c *ClusterScopedRbacHandler) acceptSecurityContextConstraints(clusterResou
 	// Last option, look at the users field if it contains one of the exported serviceaccounts
 	for _, u := range scc.Users {
 		if ns, saName, ok := parseServiceAccountUserSubject(u); ok && c.anyServiceAccountInNamespace(ns, saName) {
-			c.log.Infof("Accepted %s of kind %s (match via user %s)",
+			c.log.Debugf("Accepted %s of kind %s (match via User %s)",
 				clusterResource.GetName(), clusterResource.GetKind(), u)
 			return true
 		}
@@ -324,7 +325,7 @@ func (c *ClusterScopedRbacHandler) acceptSecurityContextConstraints(clusterResou
 	nsSet := c.exportedSANamespaces()
 	for _, g := range scc.Groups {
 		if groupMatchesExportedSANamespaces(g, nsSet) {
-			c.log.Infof("Accepted %s of kind %s (match via group %s)",
+			c.log.Debugf("Accepted %s of kind %s (match via Group %s)",
 				clusterResource.GetName(), clusterResource.GetKind(), g)
 			return true
 		}

--- a/cmd/export/crd.go
+++ b/cmd/export/crd.go
@@ -106,8 +106,10 @@ func collectRelatedCRDs(requestTimeout time.Duration, resources []*groupResource
 	}
 
 	if len(seen) == 0 {
+		log.Debug("No eligible custom resource groups found, skipping CRD collection")
 		return nil, nil
 	}
+	log.Debugf("Collecting CRDs for %d custom resource groups", len(seen))
 
 	crdClient := dynamicClient.Resource(crdGVR)
 	out := make([]*groupResource, 0, len(seen))
@@ -126,11 +128,11 @@ func collectRelatedCRDs(requestTimeout time.Duration, resources []*groupResource
 		if err != nil {
 			switch {
 			case apierrors.IsForbidden(err):
-				log.Warnf("cannot get CustomResourceDefinition %q (forbidden); ensure get on customresourcedefinitions.apiextensions.k8s.io", crdName)
+				log.Warnf("Cannot get CustomResourceDefinition %q (forbidden); ensure get on customresourcedefinitions.apiextensions.k8s.io", crdName)
 			case apierrors.IsNotFound(err):
 				log.Debugf("CustomResourceDefinition %q not found (plural may not match CRD spec.names.plural)", crdName)
 			default:
-				log.Warnf("error getting CustomResourceDefinition %q: %v", crdName, err)
+				log.Warnf("Error getting CustomResourceDefinition %q: %v", crdName, err)
 			}
 			outErrs = append(outErrs, &groupResourceError{
 				APIResource: metav1.APIResource{
@@ -146,11 +148,11 @@ func collectRelatedCRDs(requestTimeout time.Duration, resources []*groupResource
 		}
 
 		if manager := getOperatorManager(obj); manager != "" {
-			log.Warnf("Skipping CRD %q — managed by %s; install the operator on the target cluster instead", crdName, manager)
+			log.Warnf("Skipping CRD %q: managed by %s; install the operator on the target cluster instead", crdName, manager)
 			continue
 		}
 
-		log.Infof("exported CustomResourceDefinition %q for referenced custom resources", crdName)
+		log.Debugf("Collected CustomResourceDefinition %q for referenced custom resources", crdName)
 		out = append(out, &groupResource{
 			APIGroup:        crdGVR.Group,
 			APIVersion:      crdGVR.Version,

--- a/cmd/export/discover.go
+++ b/cmd/export/discover.go
@@ -220,6 +220,7 @@ func discoverPreferredResources(
 	if err != nil {
 		if discovery.IsGroupDiscoveryFailedError(err) {
 			if len(lists) == 0 {
+				log.Errorf("Failed to discover any preferred resources: %v", err)
 				return nil, err
 			}
 			log.Warnf("Some API groups failed discovery, continuing with available groups: %v", err)
@@ -286,18 +287,18 @@ func resourceToExtract(requestTimeout time.Duration, namespace string, labelSele
 			if err != nil {
 				// Check if error is due to timeout/deadline exceeded - fail fast
 				if apierrors.IsTimeout(err) || strings.Contains(err.Error(), "context deadline exceeded") {
-					log.Errorf("Request timeout exceeded for groupVersion %s, kind: %s: %v", g.APIGroupVersion, g.APIResource.Kind, err)
+					log.Errorf("Request timeout exceeded for groupVersion %s, resource: %s, kind: %s: %v", g.APIGroupVersion, g.APIResource.Name, g.APIResource.Kind, err)
 					return nil, []*groupResourceError{{resource, err}}
 				}
 				switch {
 				case apierrors.IsForbidden(err):
-					log.Debugf("Access denied for groupVersion %s, kind: %s (expected for namespace-admin users)", g.APIGroupVersion, g.APIResource.Kind)
+					log.Debugf("Access denied for groupVersion %s, resource: %s, kind: %s (expected for namespace-admin users)", g.APIGroupVersion, g.APIResource.Name, g.APIResource.Kind)
 				case apierrors.IsMethodNotSupported(err):
-					log.Warnf("List method not supported on the groupVersion %s, kind: %s", g.APIGroupVersion, g.APIResource.Kind)
+					log.Warnf("List method not supported on the groupVersion %s, resource: %s, kind: %s", g.APIGroupVersion, g.APIResource.Name, g.APIResource.Kind)
 				case apierrors.IsNotFound(err):
-					log.Debugf("Resource not found (virtual resource), groupVersion %s, kind: %s", g.APIGroupVersion, g.APIResource.Kind)
+					log.Debugf("Resource not found (virtual resource), groupVersion %s, resource: %s, kind: %s", g.APIGroupVersion, g.APIResource.Name, g.APIResource.Kind)
 				default:
-					log.Errorf("Error listing objects: %v, groupVersion %s, kind: %s", err, g.APIGroupVersion, g.APIResource.Kind)
+					log.Errorf("Error listing objects: %v, groupVersion %s, resource: %s, kind: %s", err, g.APIGroupVersion, g.APIResource.Name, g.APIResource.Kind)
 				}
 				errors = append(errors, &groupResourceError{resource, err})
 				continue
@@ -388,8 +389,8 @@ func iterateItemsByGet(requestTimeout time.Duration, c dynamic.NamespaceableReso
 		u, ok := object.(*unstructured.Unstructured)
 		if !ok {
 			// TODO: explore aggregating all the errors here instead of terminating the loop
-			logger.Errorf("Expected unstructured.Unstructured but got %T for groupResource %s and object: %v", object, g.APIResource.Name, object)
-			return fmt.Errorf("expected *unstructured.Unstructured but got %T", object)
+			logger.Errorf("Expected unstructured.Unstructured but got %T for groupVersion %s, resource: %s, object: %v", object, g.APIGroupVersion, g.APIResource.Name, object)
+			return fmt.Errorf("expected *unstructured.Unstructured but got %T for groupVersion %s, resource: %s", object, g.APIGroupVersion, g.APIResource.Name)
 		}
 		// Create fresh context with timeout for each Get request
 		ctx := context.Background()
@@ -409,7 +410,7 @@ func iterateItemsByGet(requestTimeout time.Duration, c dynamic.NamespaceableReso
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("unable to process the list for group: %s, kind: %s", g.APIGroup, g.APIResource.Kind)
+		return nil, fmt.Errorf("unable to process the list for group: %s, kind: %s: %w", g.APIGroup, g.APIResource.Kind, err)
 	}
 	return unstructuredList, nil
 }
@@ -424,14 +425,14 @@ func iterateItemsInList(list runtime.Object, g *groupResource, logger logrus.Fie
 		u, ok := object.(*unstructured.Unstructured)
 		if !ok {
 			// TODO: explore aggregating all the errors here instead of terminating the loop
-			logger.Errorf("Expected unstructured.Unstructured but got %T for groupResource %s and object: %v", object, g.APIResource.Name, object)
-			return fmt.Errorf("expected *unstructured.Unstructured but got %T", object)
+			logger.Errorf("Expected unstructured.Unstructured but got %T for groupVersion %s, resource: %s, object: %v", object, g.APIGroupVersion, g.APIResource.Name, object)
+			return fmt.Errorf("expected *unstructured.Unstructured but got %T for groupVersion %s, resource: %s", object, g.APIGroupVersion, g.APIResource.Name)
 		}
 		unstructuredList.Items = append(unstructuredList.Items, *u)
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("unable to process the list for group: %s, kind: %s", g.APIGroup, g.APIResource.Kind)
+		return nil, fmt.Errorf("unable to process the list for group: %s, kind: %s: %w", g.APIGroup, g.APIResource.Kind, err)
 	}
 	return unstructuredList, nil
 }

--- a/cmd/export/discover.go
+++ b/cmd/export/discover.go
@@ -87,7 +87,7 @@ func prepareFailuresDir(failuresDir string) error {
 func writeResources(resources []*groupResource, clusterResourceDir string, resourceDir string, log logrus.FieldLogger) []error {
 	errs := []error{}
 	for _, r := range resources {
-		log.Debugf("writing objects of resource: %s to the output directory", r.APIResource.Name)
+		log.Debugf("Writing objects of resource: %s to the output directory", r.APIResource.Name)
 
 		kind := r.APIResource.Kind
 
@@ -135,7 +135,7 @@ func writeResources(resources []*groupResource, clusterResourceDir string, resou
 func writeErrors(errors []*groupResourceError, failuresDir string, log logrus.FieldLogger) []error {
 	errs := []error{}
 	for _, r := range errors {
-		log.Debugf("writing error for resource %s, error: %v", r.APIResource.Name, r.Error)
+		log.Debugf("Writing error for resource %s, error: %v", r.APIResource.Name, r.Error)
 
 		kind := r.APIResource.Kind
 
@@ -222,9 +222,9 @@ func discoverPreferredResources(
 			if len(lists) == 0 {
 				return nil, err
 			}
-			log.Warnf("some API groups failed discovery, continuing with available groups: %v", err)
+			log.Warnf("Some API groups failed discovery, continuing with available groups: %v", err)
 		} else {
-			log.Errorf("failed to discover preferred resources: %v", err)
+			log.Errorf("Failed to discover preferred resources: %v", err)
 			return nil, err
 		}
 	}
@@ -248,29 +248,32 @@ func resourceToExtract(requestTimeout time.Duration, namespace string, labelSele
 
 	for _, list := range lists {
 		if len(list.APIResources) == 0 {
+			log.Debugf("Skipping group version %q: no API resources", list.GroupVersion)
 			continue
 		}
 		gv, err := schema.ParseGroupVersion(list.GroupVersion)
 		if err != nil {
+			log.Warnf("Failed to parse group version %q: %v", list.GroupVersion, err)
 			continue
 		}
 		for _, resource := range list.APIResources {
 			if len(resource.Verbs) == 0 {
+				log.Debugf("Skipping resource %s.%s: no verbs", gv.String(), resource.Kind)
 				continue
 			}
 
 			// TODO: alpatel: put this behing a flag
 			if resource.Kind == "Event" {
-				log.Debugf("skipping extracting events")
+				log.Debugf("Skipping extracting events")
 				continue
 			}
 
 			if !isAdmittedResource(gv, resource) {
-				log.Debugf("resource: %s.%s is clusterscoped or not admitted kind, skipping", gv.String(), resource.Kind)
+				log.Debugf("Resource: %s.%s is clusterscoped or not admitted kind, skipping", gv.String(), resource.Kind)
 				continue
 			}
 
-			log.Debugf("processing resource: %s.%s", gv.String(), resource.Kind)
+			log.Debugf("Processing resource: %s.%s", gv.String(), resource.Kind)
 
 			g := &groupResource{
 				APIGroup:        gv.Group,
@@ -283,18 +286,18 @@ func resourceToExtract(requestTimeout time.Duration, namespace string, labelSele
 			if err != nil {
 				// Check if error is due to timeout/deadline exceeded - fail fast
 				if apierrors.IsTimeout(err) || strings.Contains(err.Error(), "context deadline exceeded") {
-					log.Errorf("request timeout exceeded for groupVersion %s, kind: %s: %v", g.APIGroupVersion, g.APIResource.Kind, err)
+					log.Errorf("Request timeout exceeded for groupVersion %s, kind: %s: %v", g.APIGroupVersion, g.APIResource.Kind, err)
 					return nil, []*groupResourceError{{resource, err}}
 				}
 				switch {
 				case apierrors.IsForbidden(err):
-					log.Debugf("access denied for groupVersion %s, kind: %s (expected for namespace-admin users)", g.APIGroupVersion, g.APIResource.Kind)
+					log.Debugf("Access denied for groupVersion %s, kind: %s (expected for namespace-admin users)", g.APIGroupVersion, g.APIResource.Kind)
 				case apierrors.IsMethodNotSupported(err):
-					log.Warnf("list method not supported on the groupVersion %s, kind: %s", g.APIGroupVersion, g.APIResource.Kind)
+					log.Warnf("List method not supported on the groupVersion %s, kind: %s", g.APIGroupVersion, g.APIResource.Kind)
 				case apierrors.IsNotFound(err):
-					log.Debugf("resource not found (virtual resource), groupVersion %s, kind: %s", g.APIGroupVersion, g.APIResource.Kind)
+					log.Debugf("Resource not found (virtual resource), groupVersion %s, kind: %s", g.APIGroupVersion, g.APIResource.Kind)
 				default:
-					log.Errorf("error listing objects: %v, groupVersion %s, kind: %s", err, g.APIGroupVersion, g.APIResource.Kind)
+					log.Errorf("Error listing objects: %v, groupVersion %s, kind: %s", err, g.APIGroupVersion, g.APIResource.Kind)
 				}
 				errors = append(errors, &groupResourceError{resource, err})
 				continue
@@ -302,12 +305,12 @@ func resourceToExtract(requestTimeout time.Duration, namespace string, labelSele
 
 			if len(objs.Items) > 0 {
 				g.objects = objs
-				log.Infof("adding resource: %s to the list of GVRs to be extracted", resource.Name)
+				log.Infof("Adding resource: %s to the list of GVRs to be extracted", resource.Name)
 				resources = append(resources, g)
 				continue
 			}
 
-			log.Debugf("0 objects found, for resource %s, skipping", resource.Name)
+			log.Debugf("0 objects found for resource %s, skipping", resource.Name)
 		}
 	}
 
@@ -385,7 +388,7 @@ func iterateItemsByGet(requestTimeout time.Duration, c dynamic.NamespaceableReso
 		u, ok := object.(*unstructured.Unstructured)
 		if !ok {
 			// TODO: explore aggregating all the errors here instead of terminating the loop
-			logger.Errorf("expected unstructured.Unstructured but got %T for groupResource %s and object: %v", object, g.APIResource.Name, object)
+			logger.Errorf("Expected unstructured.Unstructured but got %T for groupResource %s and object: %v", object, g.APIResource.Name, object)
 			return fmt.Errorf("expected *unstructured.Unstructured but got %T", object)
 		}
 		// Create fresh context with timeout for each Get request
@@ -397,8 +400,9 @@ func iterateItemsByGet(requestTimeout time.Duration, c dynamic.NamespaceableReso
 		}
 		
 		obj, err := c.Namespace(namespace).Get(ctx, u.GetName(), metav1.GetOptions{})
-		cancel() 
+		cancel()
 		if err != nil {
+			logger.Errorf("Failed to get %s/%s (groupVersion: %s, resource: %s): %v", namespace, u.GetName(), g.APIGroupVersion, g.APIResource.Name, err)
 			return err
 		}
 		unstructuredList.Items = append(unstructuredList.Items, *obj)
@@ -420,7 +424,7 @@ func iterateItemsInList(list runtime.Object, g *groupResource, logger logrus.Fie
 		u, ok := object.(*unstructured.Unstructured)
 		if !ok {
 			// TODO: explore aggregating all the errors here instead of terminating the loop
-			logger.Errorf("expected unstructured.Unstructured but got %T for groupResource %s and object: %v", object, g.APIResource.Name, object)
+			logger.Errorf("Expected unstructured.Unstructured but got %T for groupResource %s and object: %v", object, g.APIResource.Name, object)
 			return fmt.Errorf("expected *unstructured.Unstructured but got %T", object)
 		}
 		unstructuredList.Items = append(unstructuredList.Items, *u)

--- a/cmd/export/discover.go
+++ b/cmd/export/discover.go
@@ -87,7 +87,7 @@ func prepareFailuresDir(failuresDir string) error {
 func writeResources(resources []*groupResource, clusterResourceDir string, resourceDir string, log logrus.FieldLogger) []error {
 	errs := []error{}
 	for _, r := range resources {
-		log.Infof("Writing objects of resource: %s to the output directory\n", r.APIResource.Name)
+		log.Debugf("writing objects of resource: %s to the output directory", r.APIResource.Name)
 
 		kind := r.APIResource.Kind
 
@@ -135,7 +135,7 @@ func writeResources(resources []*groupResource, clusterResourceDir string, resou
 func writeErrors(errors []*groupResourceError, failuresDir string, log logrus.FieldLogger) []error {
 	errs := []error{}
 	for _, r := range errors {
-		log.Debugf("Writing error for resource %s, error: %#v\n", r.APIResource.Name, r.Error)
+		log.Debugf("writing error for resource %s, error: %v", r.APIResource.Name, r.Error)
 
 		kind := r.APIResource.Kind
 
@@ -224,6 +224,7 @@ func discoverPreferredResources(
 			}
 			log.Warnf("some API groups failed discovery, continuing with available groups: %v", err)
 		} else {
+			log.Errorf("failed to discover preferred resources: %v", err)
 			return nil, err
 		}
 	}
@@ -260,16 +261,16 @@ func resourceToExtract(requestTimeout time.Duration, namespace string, labelSele
 
 			// TODO: alpatel: put this behing a flag
 			if resource.Kind == "Event" {
-				log.Debugf("skipping extracting events\n")
+				log.Debugf("skipping extracting events")
 				continue
 			}
 
 			if !isAdmittedResource(gv, resource) {
-				log.Debugf("resource: %s.%s is clusterscoped or not admitted kind, skipping\n", gv.String(), resource.Kind)
+				log.Debugf("resource: %s.%s is clusterscoped or not admitted kind, skipping", gv.String(), resource.Kind)
 				continue
 			}
 
-			log.Debugf("processing resource: %s.%s\n", gv.String(), resource.Kind)
+			log.Debugf("processing resource: %s.%s", gv.String(), resource.Kind)
 
 			g := &groupResource{
 				APIGroup:        gv.Group,
@@ -282,18 +283,18 @@ func resourceToExtract(requestTimeout time.Duration, namespace string, labelSele
 			if err != nil {
 				// Check if error is due to timeout/deadline exceeded - fail fast
 				if apierrors.IsTimeout(err) || strings.Contains(err.Error(), "context deadline exceeded") {
-					log.Errorf("request timeout exceeded for groupVersion %s, kind: %s: %v\n", g.APIGroupVersion, g.APIResource.Kind, err)
+					log.Errorf("request timeout exceeded for groupVersion %s, kind: %s: %v", g.APIGroupVersion, g.APIResource.Kind, err)
 					return nil, []*groupResourceError{{resource, err}}
 				}
 				switch {
 				case apierrors.IsForbidden(err):
-					log.Debugf("access denied for groupVersion %s, kind: %s (expected for namespace-admin users)\n", g.APIGroupVersion, g.APIResource.Kind)
+					log.Debugf("access denied for groupVersion %s, kind: %s (expected for namespace-admin users)", g.APIGroupVersion, g.APIResource.Kind)
 				case apierrors.IsMethodNotSupported(err):
-					log.Warnf("list method not supported on the groupVersion %s, kind: %s\n", g.APIGroupVersion, g.APIResource.Kind)
+					log.Warnf("list method not supported on the groupVersion %s, kind: %s", g.APIGroupVersion, g.APIResource.Kind)
 				case apierrors.IsNotFound(err):
-					log.Debugf("resource not found (virtual resource), groupVersion %s, kind: %s\n", g.APIGroupVersion, g.APIResource.Kind)
+					log.Debugf("resource not found (virtual resource), groupVersion %s, kind: %s", g.APIGroupVersion, g.APIResource.Kind)
 				default:
-					log.Errorf("error listing objects: %#v, groupVersion %s, kind: %s\n", err, g.APIGroupVersion, g.APIResource.Kind)
+					log.Errorf("error listing objects: %v, groupVersion %s, kind: %s", err, g.APIGroupVersion, g.APIResource.Kind)
 				}
 				errors = append(errors, &groupResourceError{resource, err})
 				continue
@@ -306,7 +307,7 @@ func resourceToExtract(requestTimeout time.Duration, namespace string, labelSele
 				continue
 			}
 
-			log.Debugf("0 objects found, for resource %s, skipping\n", resource.Name)
+			log.Debugf("0 objects found, for resource %s, skipping", resource.Name)
 		}
 	}
 
@@ -384,7 +385,7 @@ func iterateItemsByGet(requestTimeout time.Duration, c dynamic.NamespaceableReso
 		u, ok := object.(*unstructured.Unstructured)
 		if !ok {
 			// TODO: explore aggregating all the errors here instead of terminating the loop
-			logger.Errorf("expected unstructured.Unstructured but got %T for groupResource %s and object: %#v\n", object, g.APIResource.Name, object)
+			logger.Errorf("expected unstructured.Unstructured but got %T for groupResource %s and object: %v", object, g.APIResource.Name, object)
 			return fmt.Errorf("expected *unstructured.Unstructured but got %T", object)
 		}
 		// Create fresh context with timeout for each Get request
@@ -419,7 +420,7 @@ func iterateItemsInList(list runtime.Object, g *groupResource, logger logrus.Fie
 		u, ok := object.(*unstructured.Unstructured)
 		if !ok {
 			// TODO: explore aggregating all the errors here instead of terminating the loop
-			logger.Errorf("expected unstructured.Unstructured but got %T for groupResource %s and object: %#v\n", object, g.APIResource.Name, object)
+			logger.Errorf("expected unstructured.Unstructured but got %T for groupResource %s and object: %v", object, g.APIResource.Name, object)
 			return fmt.Errorf("expected *unstructured.Unstructured but got %T", object)
 		}
 		unstructuredList.Items = append(unstructuredList.Items, *u)

--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -197,7 +197,7 @@ func (o *ExportOptions) Run() error {
 
 	restConfig, err := o.configFlags.ToRESTConfig()
 	if err != nil {
-		log.Errorf("cannot create rest config: %#v", err)
+		log.Errorf("cannot create rest config: %v", err)
 		return err
 	}
 
@@ -207,7 +207,7 @@ func (o *ExportOptions) Run() error {
 
 	kubeClient, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
-		log.Errorf("cannot create kubernetes client: %#v", err)
+		log.Errorf("cannot create kubernetes client: %v", err)
 		return err
 	}
 	if err := validateExportNamespace(context.Background(), kubeClient, o.userSpecifiedNamespace, log); err != nil {
@@ -220,24 +220,24 @@ func (o *ExportOptions) Run() error {
 			return fmt.Errorf("export directory %q already exists; use --overwrite to replace it", o.exportDir)
 		}
 		if err = os.RemoveAll(o.exportDir); err != nil {
-			log.Errorf("error clearing export directory: %#v", err)
+			log.Errorf("error clearing export directory: %v", err)
 			return err
 		}
 	}
 	resourceDir := filepath.Join(o.exportDir, "resources", o.userSpecifiedNamespace)
 	if err = os.MkdirAll(resourceDir, 0700); err != nil {
-		log.Errorf("error creating the resources directory: %#v", err)
+		log.Errorf("error creating the resources directory: %v", err)
 		return err
 	}
 	failuresDir := filepath.Join(o.exportDir, "failures", o.userSpecifiedNamespace)
 	if err = os.MkdirAll(failuresDir, 0700); err != nil {
-		log.Errorf("error creating the failures directory: %#v", err)
+		log.Errorf("error creating the failures directory: %v", err)
 		return err
 	}
 
 	discoveryClient, err := o.configFlags.ToDiscoveryClient()
 	if err != nil {
-		log.Errorf("cannot create discovery client: %#v", err)
+		log.Errorf("cannot create discovery client: %v", err)
 		return err
 	}
 
@@ -246,7 +246,7 @@ func (o *ExportOptions) Run() error {
 
 	dynamicClient, err := dynamic.NewForConfig(restConfig)
 	if err != nil {
-		log.Errorf("cannot create dynamic client: %#v", err)
+		log.Errorf("cannot create dynamic client: %v", err)
 		return err
 	}
 
@@ -255,6 +255,7 @@ func (o *ExportOptions) Run() error {
 		log.Errorf("cannot discover preferred resources: %v", err)
 		return err
 	}
+	log.Debugf("discovered %d API resource types", len(resourceLists))
 
 	var errs []error
 
@@ -262,8 +263,10 @@ func (o *ExportOptions) Run() error {
 	requestTimeout := restConfig.Timeout
 
 	resources, resourceErrs := resourceToExtract(requestTimeout, o.userSpecifiedNamespace, o.labelSelector, dynamicClient, resourceLists, log)
+	log.Debugf("extracted %d resources (%d errors)", len(resources), len(resourceErrs))
 	clusterScopeHandler := NewClusterScopeHandler()
 	resources = clusterScopeHandler.filterRbacResources(resources, log)
+	log.Debugf("resources after RBAC filter: %d", len(resources))
 
 	clusterResourceDir := filepath.Join(o.exportDir, "resources", o.userSpecifiedNamespace, "_cluster")
 
@@ -284,7 +287,7 @@ func (o *ExportOptions) Run() error {
 
 	// After merging CRDs: prepare _cluster so hasClusterScopedManifests sees cluster-scoped CRD objects.
 	if err = prepareClusterResourceDir(clusterResourceDir, resources); err != nil {
-		log.Errorf("error preparing cluster resources directory: %#v", err)
+		log.Errorf("error preparing cluster resources directory: %v", err)
 		return err
 	}
 
@@ -297,12 +300,12 @@ func (o *ExportOptions) Run() error {
 	log.Debugf("attempting to write resources to files\n")
 	writeResourcesErrors := writeResources(resources, clusterResourceDir, resourceDir, log)
 	for _, e := range writeResourcesErrors {
-		log.Warnf("error writing manifests to file: %#v, ignoring\n", e)
+		log.Warnf("error writing manifests to file: %v, ignoring\n", e)
 	}
 
 	writeErrorsErrors := writeErrors(resourceErrs, failuresDir, log)
 	for _, e := range writeErrorsErrors {
-		log.Warnf("error writing errors to file: %#v, ignoring\n", e)
+		log.Warnf("error writing errors to file: %v, ignoring\n", e)
 	}
 
 	errs = append(errs, writeResourcesErrors...)

--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -211,7 +211,7 @@ func (o *ExportOptions) Run() error {
 		return err
 	}
 	if err := validateExportNamespace(context.Background(), kubeClient, o.userSpecifiedNamespace, log); err != nil {
-		log.Errorf("namespace validation failed: %v", err)
+		log.Errorf("namespace validation failed for %q: %v", o.userSpecifiedNamespace, err)
 		return err
 	}
 

--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -252,7 +252,6 @@ func (o *ExportOptions) Run() error {
 
 	resourceLists, err := discoverPreferredResources(discoveryClient, log)
 	if err != nil {
-		log.Errorf("Cannot discover preferred resources: %v", err)
 		return err
 	}
 	log.Debugf("Discovered %d API resource lists", len(resourceLists))

--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -148,7 +148,7 @@ func validateExportNamespace(ctx context.Context, client kubernetes.Interface, n
 		if apierrors.IsNotFound(err) {
 			return fmt.Errorf(`namespaces "%s" not found`, namespace)
 		}
-		log.Warnf("cannot verify namespace %q exists (may lack RBAC permission): %v", namespace, err)
+		log.Warnf("Cannot verify namespace %q exists (may lack RBAC permission): %v", namespace, err)
 	}
 	return nil
 }
@@ -197,7 +197,7 @@ func (o *ExportOptions) Run() error {
 
 	restConfig, err := o.configFlags.ToRESTConfig()
 	if err != nil {
-		log.Errorf("cannot create rest config: %v", err)
+		log.Errorf("Cannot create rest config: %v", err)
 		return err
 	}
 
@@ -207,11 +207,11 @@ func (o *ExportOptions) Run() error {
 
 	kubeClient, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
-		log.Errorf("cannot create kubernetes client: %v", err)
+		log.Errorf("Cannot create kubernetes client: %v", err)
 		return err
 	}
 	if err := validateExportNamespace(context.Background(), kubeClient, o.userSpecifiedNamespace, log); err != nil {
-		log.Errorf("namespace validation failed for %q: %v", o.userSpecifiedNamespace, err)
+		log.Errorf("Namespace validation failed for %q: %v", o.userSpecifiedNamespace, err)
 		return err
 	}
 
@@ -220,24 +220,24 @@ func (o *ExportOptions) Run() error {
 			return fmt.Errorf("export directory %q already exists; use --overwrite to replace it", o.exportDir)
 		}
 		if err = os.RemoveAll(o.exportDir); err != nil {
-			log.Errorf("error clearing export directory: %v", err)
+			log.Errorf("Error clearing export directory: %v", err)
 			return err
 		}
 	}
 	resourceDir := filepath.Join(o.exportDir, "resources", o.userSpecifiedNamespace)
 	if err = os.MkdirAll(resourceDir, 0700); err != nil {
-		log.Errorf("error creating the resources directory: %v", err)
+		log.Errorf("Error creating the resources directory: %v", err)
 		return err
 	}
 	failuresDir := filepath.Join(o.exportDir, "failures", o.userSpecifiedNamespace)
 	if err = os.MkdirAll(failuresDir, 0700); err != nil {
-		log.Errorf("error creating the failures directory: %v", err)
+		log.Errorf("Error creating the failures directory: %v", err)
 		return err
 	}
 
 	discoveryClient, err := o.configFlags.ToDiscoveryClient()
 	if err != nil {
-		log.Errorf("cannot create discovery client: %v", err)
+		log.Errorf("Cannot create discovery client: %v", err)
 		return err
 	}
 
@@ -246,16 +246,16 @@ func (o *ExportOptions) Run() error {
 
 	dynamicClient, err := dynamic.NewForConfig(restConfig)
 	if err != nil {
-		log.Errorf("cannot create dynamic client: %v", err)
+		log.Errorf("Cannot create dynamic client: %v", err)
 		return err
 	}
 
 	resourceLists, err := discoverPreferredResources(discoveryClient, log)
 	if err != nil {
-		log.Errorf("cannot discover preferred resources: %v", err)
+		log.Errorf("Cannot discover preferred resources: %v", err)
 		return err
 	}
-	log.Debugf("discovered %d API resource types", len(resourceLists))
+	log.Debugf("Discovered %d API resource lists", len(resourceLists))
 
 	var errs []error
 
@@ -263,10 +263,10 @@ func (o *ExportOptions) Run() error {
 	requestTimeout := restConfig.Timeout
 
 	resources, resourceErrs := resourceToExtract(requestTimeout, o.userSpecifiedNamespace, o.labelSelector, dynamicClient, resourceLists, log)
-	log.Debugf("extracted %d resources (%d errors)", len(resources), len(resourceErrs))
+	log.Debugf("Extracted %d resources (%d errors)", len(resources), len(resourceErrs))
 	clusterScopeHandler := NewClusterScopeHandler()
 	resources = clusterScopeHandler.filterRbacResources(resources, log)
-	log.Debugf("resources after RBAC filter: %d", len(resources))
+	log.Debugf("Resources after RBAC filter: %d", len(resources))
 
 	clusterResourceDir := filepath.Join(o.exportDir, "resources", o.userSpecifiedNamespace, "_cluster")
 
@@ -279,7 +279,7 @@ func (o *ExportOptions) Run() error {
 	for _, resErr := range resourceErrs {
 		if resErr != nil && resErr.Error != nil {
 			if apierrors.IsTimeout(resErr.Error) || strings.Contains(resErr.Error.Error(), "context deadline exceeded") {
-				log.Errorf("timeout listing resource %q: %v", resErr.APIResource.Kind, resErr.Error)
+				log.Errorf("Timeout listing resource %q: %v", resErr.APIResource.Kind, resErr.Error)
 				return resErr.Error
 			}
 		}
@@ -287,37 +287,41 @@ func (o *ExportOptions) Run() error {
 
 	// After merging CRDs: prepare _cluster so hasClusterScopedManifests sees cluster-scoped CRD objects.
 	if err = prepareClusterResourceDir(clusterResourceDir, resources); err != nil {
-		log.Errorf("error preparing cluster resources directory: %v", err)
+		log.Errorf("Error preparing cluster resources directory: %v", err)
 		return err
 	}
 
 	//count and log the no of crds
 	crdCount := len(crdResources)
 	if crdCount > 0 {
-		log.Infof("Exported %d CRDs for referenced custom resources to the _cluster resources directory\n", crdCount)
+		log.Infof("Collected %d CRDs for referenced custom resources", crdCount)
 	}
 
-	log.Debugf("attempting to write resources to files\n")
+	log.Debugf("Attempting to write resources to files")
 	writeResourcesErrors := writeResources(resources, clusterResourceDir, resourceDir, log)
 	for _, e := range writeResourcesErrors {
-		log.Warnf("error writing manifests to file: %v, ignoring\n", e)
+		log.Warnf("Error writing manifests to file: %v, continuing", e)
 	}
 
 	writeErrorsErrors := writeErrors(resourceErrs, failuresDir, log)
 	for _, e := range writeErrorsErrors {
-		log.Warnf("error writing errors to file: %v, ignoring\n", e)
+		log.Warnf("Error writing errors to file: %v, continuing", e)
 	}
 
 	errs = append(errs, writeResourcesErrors...)
 	errs = append(errs, writeErrorsErrors...)
 	if allResourceListsForbidden(resources, resourceErrs) {
-		log.Warnf("all resource types returned Forbidden for namespace %q", o.userSpecifiedNamespace)
+		log.Warnf("All resource types returned Forbidden for namespace %q", o.userSpecifiedNamespace)
 		errs = append(errs, fmt.Errorf(
 			"all resource types returned Forbidden for namespace %q -- verify the namespace exists and your user has list permissions",
 			o.userSpecifiedNamespace,
 		))
 	}
-	log.Infof("Export complete for namespace %q", o.userSpecifiedNamespace)
+	if len(errs) > 0 {
+		log.Warnf("Export completed with %d error(s) for namespace %q", len(errs), o.userSpecifiedNamespace)
+	} else {
+		log.Infof("Export complete for namespace %q", o.userSpecifiedNamespace)
+	}
 	return errorsutil.NewAggregate(errs)
 }
 

--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -193,6 +193,7 @@ func (o *ExportOptions) Run() error {
 	var err error
 
 	log := o.globalFlags.GetLogger()
+	log.Infof("Starting export for namespace %q", o.userSpecifiedNamespace)
 
 	restConfig, err := o.configFlags.ToRESTConfig()
 	if err != nil {
@@ -210,6 +211,7 @@ func (o *ExportOptions) Run() error {
 		return err
 	}
 	if err := validateExportNamespace(context.Background(), kubeClient, o.userSpecifiedNamespace, log); err != nil {
+		log.Errorf("namespace validation failed: %v", err)
 		return err
 	}
 
@@ -250,6 +252,7 @@ func (o *ExportOptions) Run() error {
 
 	resourceLists, err := discoverPreferredResources(discoveryClient, log)
 	if err != nil {
+		log.Errorf("cannot discover preferred resources: %v", err)
 		return err
 	}
 
@@ -273,6 +276,7 @@ func (o *ExportOptions) Run() error {
 	for _, resErr := range resourceErrs {
 		if resErr != nil && resErr.Error != nil {
 			if apierrors.IsTimeout(resErr.Error) || strings.Contains(resErr.Error.Error(), "context deadline exceeded") {
+				log.Errorf("timeout listing resource %q: %v", resErr.APIResource.Kind, resErr.Error)
 				return resErr.Error
 			}
 		}
@@ -304,11 +308,13 @@ func (o *ExportOptions) Run() error {
 	errs = append(errs, writeResourcesErrors...)
 	errs = append(errs, writeErrorsErrors...)
 	if allResourceListsForbidden(resources, resourceErrs) {
+		log.Warnf("all resource types returned Forbidden for namespace %q", o.userSpecifiedNamespace)
 		errs = append(errs, fmt.Errorf(
 			"all resource types returned Forbidden for namespace %q -- verify the namespace exists and your user has list permissions",
 			o.userSpecifiedNamespace,
 		))
 	}
+	log.Infof("Export complete for namespace %q", o.userSpecifiedNamespace)
 	return errorsutil.NewAggregate(errs)
 }
 


### PR DESCRIPTION
https://github.com/migtools/crane/issues/773

 Adds missing log statements to the export command:
  - Info log at start and end of export run
  - Error logs before returns that were silent (discoverPreferredResources, validateExportNamespace, timeout
  detection)
  - Warn log when all resource types return Forbidden


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Improved export status reporting throughout discovery, collection, writing, timeout handling, validation, filtering, and completion.
  * Added clearer diagnostics for skipped resources, parsing and retrieval failures, custom resource handling, and access restrictions.
  * Standardized log formatting, capitalization, error details, and severity levels for more consistent export output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->