### PR TITLE
:book: chore: Update documentation semantic indexes

### DIFF
--- a/docs/.doc-index/_root.index.md
+++ b/docs/.doc-index/_root.index.md
@@ -1,38 +1,42 @@
 # _ROOT Documentation Index
 
 ## Overview
-This documentation provides a comprehensive guide to the **Crane** migration tool, focusing on its multi-stage Kustomize-based transformation pipeline, resource migration compatibility, and manifest validation workflows. It covers the full lifecycle of a migration from cluster export and transformation through to final deployment and target cluster compatibility checks.
+This documentation covers the operational workflow, architecture, and configuration of **Crane**, a Kubernetes migration tool. It describes the end-to-end process of exporting, transforming, validating, and applying cluster resources, including the plugin-based multi-stage pipeline and compatibility requirements.
 
 ## Files Summary
-* **kustomize-multistage.md**: Describes the architecture and usage of the multi-stage Kustomize pipeline, including directory structures, plugin priorities, and stage chaining.
-* **CRANE_COMPATIBILITY_MATRIX.md**: Defines the operational boundaries of Crane regarding namespace-scoped vs. cluster-scoped resources and outlines the prerequisites for successful migrations.
-* **pre-apply-validation-guide.md**: Provides a checklist and scripts for validating Kubernetes manifests against a target cluster API and RBAC permissions before execution.
-* **transform.md**: Details the internal structure of the `transform/` directory, including how to work with input/output, manual edits, and Git best practices.
-* **stateless-migration-quickstart.md**: Offers a step-by-step tutorial for executing a complete stateless migration workflow, from export to final application on a target cluster.
+* **kustomize-multistage.md**: Describes the sequential, plugin-driven transformation pipeline using Kustomize and directory-based staging.
+* **CRANE_COMPATIBILITY_MATRIX.md**: Outlines the support boundaries between namespace-scoped and cluster-scoped resources during migration.
+* **pre-apply-validation-guide.md**: Provides a checklist and scripts for validating manifests against cluster APIs and permissions before deployment.
+* **plugins.md**: Details how to use, write, and manage plugins for resource transformation.
+* **transform.md**: Explains the directory structure, Kustomize configuration, and manual editing workflows for the transformation pipeline.
+* **resource-compatibility.md**: A detailed reference on resource migration boundaries, RBAC requirements, and namespace-renaming warnings.
+* **multistage-pipeline.md**: A comprehensive guide to the multi-stage pipeline, including CLI usage, priority assignment, and stage chaining.
+* **stateless-migration-quickstart.md**: A step-by-step tutorial for performing a basic stateless migration from export to apply.
+* **installation.md**: Instructions for building, installing, and verifying the Crane CLI.
+* **README.md**: The top-level entry point and documentation hub for the project.
 
 ## Code Changes That Would Require Documentation Updates
-* **Pipeline Logic**: Changes to the stage discovery, ordering algorithm, or the `crane transform` execution flow.
-* **Plugin System**: Changes to how plugins are loaded, how priorities are assigned, or changes to the built-in `KubernetesPlugin`.
-* **File Structure**: Changes to the naming conventions of `transform/` subdirectories (`input/`, `patches/`, `output/`) or the `kustomization.yaml` requirements.
-* **CLI Arguments/Flags**: Addition, removal, or modification of flags for `crane transform`, `crane apply`, `crane export`, or `crane validate`.
-* **Output Formats**: Changes to the structure of the final `output/` directory or the `output.yaml` manifest generation.
-* **Validation Logic**: Updates to how `crane validate` performs live-cluster compatibility checks or how it generates reports.
-* **Whiteout/Filtering**: Changes to how resources are excluded (whiteout) or filtered during the transformation phase.
+* **Pipeline Logic**: Changes to the transformation sequence, stage directory discovery, or the `kustomization.yaml` generation logic.
+* **Plugin Interface**: Changes to how plugins interact with stdin/stdout, input/output structures, or how they are discovered in `~/.local/share/crane/plugins/`.
+* **CLI Commands**: Addition, removal, or parameter changes for `crane export`, `crane transform`, `crane apply`, or `crane validate`.
+* **Resource Support**: Updates to the `crane-lib` logic that handles resource extraction or server-managed field removal (e.g., adding new exclusions).
+* **Validation Logic**: Changes to the `kubectl` dry-run mechanisms or `kubectl auth can-i` checks performed by the validation command.
+* **Configuration/Metadata**: Changes to `.crane-metadata.json` or any requirements for the `instructions.yaml` file.
+* **Default Behaviors**: Alterations to default plugin priorities or automatic stage creation logic.
 
 ## Key Technical Concepts
-* **Multi-Stage Pipeline**: Sequential transformation process where stage output becomes next-stage input.
-* **Kustomize**: The underlying engine used for resource patching and manifest management.
-* **Stage Directory Structure**: The `<priority>_<plugin-name>` convention used to organize transformations.
-* **Plugin Priorities**: Numeric ordering (e.g., 10, 20, 30) for determining the execution order of transform plugins.
-* **Dirty Check**: A safety mechanism that prevents overwriting manual user edits to transform stages.
-* **Pass-through Stage**: A manual transformation stage that lacks a plugin and persists user-applied changes.
-* **Server-side Dry-run**: `kubectl apply --dry-run=server` validation against the target API server.
-* **RBAC Context**: The permissions required to export/import specific resource types (e.g., SCCs, CRDs).
-* **Whiteout**: The process of excluding resources from the final migration output.
+* **Multi-Stage Pipeline**: The sequential execution of transform stages based on numeric priority.
+* **Kustomize Integration**: Use of `kustomization.yaml` and patches to mutate manifests.
+* **Dirty Check**: Protection mechanism preventing the overwrite of manually edited stages without the `--overwrite` flag.
+* **Whiteout**: The process of excluding resources from the final output.
+* **Stateless Migration**: The `export` → `transform` → `apply` → `validate` workflow.
+* **Plugin Priority**: Numeric assignment (e.g., `10_`, `20_`) determining the order of transformation.
+* **Server-Managed Fields**: Metadata like `uid` and `resourceVersion` that require removal during cross-cluster migration.
+* **Live Validation**: Using `kubectl --dry-run=server` to check manifest compatibility against the target cluster.
 
 ## Related Components
-* **Crane CLI**: The primary user-facing tool for migration orchestration.
-* **crane-lib**: The library containing built-in plugins (e.g., `kubernetes` plugin).
-* **Kustomize**: Integrated directly into the `transform` and `apply` phases.
-* **Kubernetes API Server**: Target for validation and deployment.
-* **Git**: Used for version controlling the `transform/` directory configuration.
+* **Crane-lib**: The underlying library used for plugin definitions and resource cleanup logic.
+* **Kustomize**: The engine used for patching and resource materialization within stages.
+* **Crane-plugins**: The repository of community-contributed plugins (e.g., OpenshiftPlugin).
+* **Kubectl/OC**: External CLI tools required for live cluster interaction and validation.
+* **Go Runtime**: The base environment for the Crane CLI and custom plugin development.

--- a/docs/.doc-index/commands.index.md
+++ b/docs/.doc-index/commands.index.md
@@ -1,0 +1,38 @@
+# COMMANDS Documentation Index
+
+## Overview
+This documentation area defines the command-line interface for `crane`, a Kubernetes migration tool designed to facilitate the movement of workloads between clusters. It covers the full lifecycle of a migration pipeline: exporting resources, transforming them via plugins, applying them with Kustomize, validating them against cluster APIs, and migrating stateful PersistentVolume data.
+
+## Files Summary
+*   **commands/export.md**: Details the process of discovering and writing Kubernetes objects and CRDs from a source cluster to local YAML files.
+*   **commands/transform.md**: Explains the multi-stage pipeline for modifying exported manifests using Kustomize patches and custom/plugin-based transformation stages.
+*   **commands/validate.md**: Describes the procedure for checking that final, transformed manifests are compatible with the target cluster's API surface, supporting both live and offline modes.
+*   **commands/apply.md**: Covers the usage of the embedded Kustomize engine to render the final manifest set, including options for dependency-ordered output and non-admin migrations.
+*   **commands/transfer-pvc.md**: Details the mechanism for moving PersistentVolumeClaim resources and their underlying data between clusters using rsync-based pods and network endpoints.
+
+## Code Changes That Would Require Documentation Updates
+*   **Flag Additions/Removals**: Any changes to CLI flags, default values, or flag types across any `crane` command.
+*   **Pipeline Architecture**: Changes to the sequential flow of data between `export`, `transform`, `apply`, and `validate` (e.g., changes to internal directory structures).
+*   **Transformation Logic**: Modifications to the plugin discovery mechanism, stage naming conventions (`<number>_<name>`), or the precedence rules for `Plugin` vs. "Pass-through" stages.
+*   **API/GVK Handling**: Changes to how CRDs are collected during export, or how `crane validate` performs GVK matching against the target cluster API.
+*   **Kustomize Integration**: Upgrades or changes to the embedded `krusty` API, or changes to how `kustomization.yaml` is generated/interpreted.
+*   **RBAC/Impersonation**: Updates to how `crane` handles `Forbidden` errors, namespace verification, or the `--as` impersonation flags.
+*   **PVC Transfer Mechanism**: Changes to the rsync pod orchestration, new supported endpoint types (e.g., LoadBalancer), or modifications to the PVC/Namespace mapping logic.
+
+## Key Technical Concepts
+*   **GVK (Group/Version/Kind)**: The core mechanism for matching and validating resource compatibility.
+*   **Multi-Stage Pipeline**: The sequential execution of transformations where the output of one stage acts as the input for the next.
+*   **Kustomize / Krusty**: The underlying engine used for manifest patching and resource rendering.
+*   **Namespace-scoped vs. Cluster-scoped Resources**: The distinction in handling resources like `ConfigMap` versus `ClusterRole`.
+*   **Whiteout/Filtering**: The removal or exclusion of specific resources during the transformation process.
+*   **Impersonation**: The use of `--as` and `--as-extras` flags for handling non-admin migrations.
+*   **rsync-based Data Transfer**: The method used by `transfer-pvc` to migrate block storage data between source and destination pods.
+*   **API Surface Capture**: The process of generating an offline `api-surface.json` for validation in air-gapped environments.
+
+## Related Components
+*   **`crane` Binary**: The main entry point and CLI controller.
+*   **Kustomize (embedded)**: The processing engine for manifest transformations.
+*   **Plugins**: External or internal logic hooks used during the `transform` phase.
+*   **Kubeconfig**: The authentication and cluster-connectivity provider.
+*   **Target/Source Clusters**: The Kubernetes environments acting as origin and destination.
+*   **Rsync Daemon/Client**: The temporary pods used for data synchronization during `transfer-pvc`.

--- a/docs/.doc-index/development.index.md
+++ b/docs/.doc-index/development.index.md
@@ -1,0 +1,37 @@
+# DEVELOPMENT Documentation Index
+
+## Overview
+This documentation area provides a comprehensive guide for contributors to the Crane project. It covers the end-to-end development lifecycle, including environment setup, architectural design, testing methodologies, and the extensibility of the plugin-based transformation system.
+
+## Files Summary
+- **development/setup.md**: Instructions for setting up the Go development environment, project layout, CLI development, and configuring test Kubernetes clusters.
+- **development/plugin-development.md**: Guidelines for creating, naming, testing, and managing the lifecycle of transformation plugins that generate JSONPatch operations.
+- **development/testing.md**: Standards for unit testing with Go, conventions for table-driven tests, and execution procedures for the E2E test framework.
+- **development/architecture.md**: Technical deep-dive into the pipeline architecture (Export/Transform/Apply/Validate) and the internal data flow between disk-based stages.
+- **development/README.md**: Central navigation hub and quick-reference guide for the repository structure and related projects.
+
+## Code Changes That Would Require Documentation Updates
+- **CLI Changes**: Adding, removing, or renaming CLI commands or changing how global flags (e.g., via Viper/Mapstructure) are registered.
+- **Pipeline Logic**: Modifications to the sequence of the `Export -> Transform -> Apply -> Validate` data flow or changes to how data is persisted to the local directory structure.
+- **Plugin System**: Changes to the plugin interface (stdin/stdout contract), the discovery path (default directory), or the priority/stage execution logic.
+- **Internal API/Library Usage**: Upgrading or swapping the embedded Kustomize (`krusty`) library or changing the `unstructured` resource handling patterns.
+- **Testing Framework**: Additions or breaking changes to the `e2e-tests/framework` package or the format of `golden-manifests`.
+- **Project Structure**: Renaming or moving packages within `cmd/` or `internal/` or modifying the project layout patterns.
+
+## Key Technical Concepts
+- **JSONPatch (RFC 6902)**: The mechanism used by plugins to define resource transformations.
+- **Kustomize (krusty API)**: The engine embedded within Crane to apply patches and render manifests.
+- **Stage Discovery**: The `<number>_<name>` directory convention used to determine execution order.
+- **Unstructured API**: The `k8s.io/apimachinery` pattern used for processing dynamic Kubernetes resources.
+- **Dynamic Client**: The interface used by the export phase to handle arbitrary resource types.
+- **Table-Driven Testing**: The standard pattern required for Go unit tests.
+- **Golden Manifests**: The fixture-based comparison method used for E2E validation.
+- **PVC Transfer**: The specific sub-process using `pvc-transfer` for data migration.
+
+## Related Components
+- **`cmd/`**: CLI entry points and command constructors.
+- **`internal/`**: The core logic (orchestrator, kustomize runner, plugin loader, validator).
+- **`e2e-tests/`**: The integration testing framework and suite.
+- **`crane-lib`**: External library containing common transformation logic (e.g., `KubernetesPlugin`).
+- **`crane-plugins` / `crane-plugin-openshift`**: External repositories for platform-specific transformations.
+- **`pvc-transfer`**: The underlying library for persistent volume data migration.

--- a/docs/.doc-index/manifest.json
+++ b/docs/.doc-index/manifest.json
@@ -3,15 +3,40 @@
   "created": "2026-08-03T13:08:46.169594",
   "folders": {
     "_root": {
-      "built": "2026-08-03T13:08:50.348481",
+      "built": "2026-08-04T13:52:57.759778",
       "doc_hashes": {
         "kustomize-multistage.md": "8c415d04eaa67e60fde0f58bc7adddfc64181c31a9dec7ecb9cf46e86d91d581",
         "CRANE_COMPATIBILITY_MATRIX.md": "3344f95d520f5a237f5d196b8d2d41d8314e8b9a362ce9c49d61ee36f5e7bd2b",
         "pre-apply-validation-guide.md": "4d9ece1a2c840cb94051b519b3cbc09efc0e0b0d5937049f0800a1000737573b",
+        "plugins.md": "8a21b9e8e67fa89adb5b0c2ba5af063f0e6fc142e7c7c4c8adf21a54c8aa33c3",
         "transform.md": "06f12a97b8e110074cb98c3578d7a17dca2574c2e1152fa7a527ff45d668cc62",
-        "stateless-migration-quickstart.md": "7e37d54bfaad9cd08fa908cfc461a5d6a813fefd01d5adec27295f0c5347e9b8"
+        "resource-compatibility.md": "f0a3d255b125113b0166e74e3f66f48246bab81b356f55f74557cc25bdc16210",
+        "multistage-pipeline.md": "1472830c2360560be41cedbb510586c1a91eb2558e8e39d77a2a9304236263f7",
+        "stateless-migration-quickstart.md": "7e37d54bfaad9cd08fa908cfc461a5d6a813fefd01d5adec27295f0c5347e9b8",
+        "installation.md": "61f403b6eeb95a2bd92bf97478ce04f3dffd4dd491397bad10516404a0846e1c",
+        "README.md": "f58e2efde76bbbe8e3e4002f72b125199940037b84d2d72e39a4b5ae5ec277e0"
+      }
+    },
+    "commands": {
+      "built": "2026-08-04T13:53:02.254731",
+      "doc_hashes": {
+        "commands/export.md": "18d5f3a7088cb799a8d88d34c033fd44221128ff1a72d9b7cadffc211493f3d4",
+        "commands/transform.md": "2f067699ade74ba84c49fa40f12fe7253f30978a503cddb3186b7ae65d51d80e",
+        "commands/validate.md": "be296169a1e5dbf222ae233c49843d7b76cbbe8759fc0f16220c27d68592d305",
+        "commands/apply.md": "64902f9c980f3aa86f7aeddc0a9819cbb1031467e3263b26ac83b9494ba7b4ba",
+        "commands/transfer-pvc.md": "c0a6e7fb147d0ac5e52e696ca2be4cb44ca1589f8389807f1e9811008b874ba1"
+      }
+    },
+    "development": {
+      "built": "2026-08-04T13:53:05.284684",
+      "doc_hashes": {
+        "development/setup.md": "c2064cf8412e64c2d259a121c1717fe305d9e3c6782413640a1041ed5c8e1ea4",
+        "development/plugin-development.md": "18be806fa9771eda99dfd7af775ac728f2e86b647ea9280f7b4f7271b29b220e",
+        "development/testing.md": "60d476a324f8c241ef502f61e85f1fc444d45dbc299e1658afc24b0b253de357",
+        "development/architecture.md": "e1346c1411bebf6aca860317bdb0fbbc92eae3810e3a2a66ab5a981b4bec9531",
+        "development/README.md": "02cb2ad963534727279a3cddd5a357a95e95b8117dad2f38803ae4333cf3c271"
       }
     }
   },
-  "updated": "2026-08-03T13:08:50.349316"
+  "updated": "2026-08-04T13:53:05.285283"
 }


### PR DESCRIPTION
This PR updates documentation semantic indexes.

These are auto-generated indexes and file summaries used by the code-to-docs action to speed up documentation file discovery.

*Auto-generated by code-to-docs action*