### PR TITLE
:book: update documentation from PR #667

### DIFF
--- a/docs/commands/transfer-pvc.md
+++ b/docs/commands/transfer-pvc.md
@@ -12,6 +12,8 @@ crane transfer-pvc [flags]
 
 The `transfer-pvc` subcommand transfers a PersistentVolumeClaim resource and its volume data to a destination cluster. It establishes a connection to the destination cluster by creating a public endpoint of the user's choice in the destination namespace. It then creates a PVC and an rsync daemon Pod in the destination namespace to receive data from the source PVC. Finally, it creates an rsync client Pod in the source namespace which transfers data to the rsync daemon using the endpoint. The connection is encrypted using self-signed certificates created automatically at the time of transfer.
 
+`transfer-pvc` supports transfers between different clusters or within the same cluster. When performing transfers within the same cluster and namespace, the source and destination PVC names must be different.
+
 ## Example
 
 ```bash
@@ -63,11 +65,11 @@ crane transfer-pvc --pvc-name=source-pvc:destination-pvc \
   --source-context=source --destination-context=destination --endpoint=route
 ```
 
-Transfer data within the same cluster to a new PVC with a different StorageClass (e.g., migrating from `standard` to `gp3`):
+Transfer a PVC to a new name within the same cluster and namespace (useful for storage class conversion):
 
 ```bash
-crane transfer-pvc --source-context=cluster-a --destination-context=cluster-a \
-  --pvc-name="mysql-data:mysql-data-new" --pvc-namespace=myapp \
+crane transfer-pvc --source-context=mycluster --destination-context=mycluster \
+  --pvc-name=mysql-data:mysql-data-new --pvc-namespace=myapp \
   --dest-storage-class=gp3 --endpoint=route
 ```
 

--- a/docs/commands/transfer-pvc.md
+++ b/docs/commands/transfer-pvc.md
@@ -63,6 +63,14 @@ crane transfer-pvc --pvc-name=source-pvc:destination-pvc \
   --source-context=source --destination-context=destination --endpoint=route
 ```
 
+Transfer data within the same cluster to a new PVC with a different StorageClass (e.g., migrating from `standard` to `gp3`):
+
+```bash
+crane transfer-pvc --source-context=cluster-a --destination-context=cluster-a \
+  --pvc-name="mysql-data:mysql-data-new" --pvc-namespace=myapp \
+  --dest-storage-class=gp3 --endpoint=route
+```
+
 ### Endpoint Options
 
 Endpoint enables a connection between the source and destination cluster for data transfer. It is created in the destination cluster. The destination cluster must support the kind of endpoint used.


### PR DESCRIPTION
Documentation updates based on merged PR #667.

Files updated:
- `docs//commands/transfer-pvc.md`

*Assisted by code-to-docs AI*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that PVC transfers can occur between different clusters or within the same cluster.
  * Documented the requirement for different source and destination PVC names when transferring within the same cluster and namespace.
  * Added an example showing same-cluster PVC renaming with storage class conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->