### PR TITLE
:sparkles: Indirect migration support

### DIFF
--- a/.github/workflows/e2e-pr-tester.yaml
+++ b/.github/workflows/e2e-pr-tester.yaml
@@ -143,7 +143,7 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 90
     env:
       CRANE_BIN: ${{ github.workspace }}/crane
       E2E_SUITE_DIR: e2e-tests/tests

--- a/cmd/transfer-pvc/indirect.go
+++ b/cmd/transfer-pvc/indirect.go
@@ -1,0 +1,208 @@
+package transfer_pvc
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/konveyor/crane-lib/state_transfer/transfer/indirect"
+)
+
+func (t *TransferPVCCommand) runIndirect() error {
+	fmt.Fprintf(os.Stderr, "\ncrane transfer-pvc (indirect via cloud storage)\n")
+	fmt.Fprintf(os.Stderr, "source context:      %s\n", t.Flags.SourceContext)
+	fmt.Fprintf(os.Stderr, "destination context: %s\n", t.Flags.DestinationContext)
+	fmt.Fprintf(os.Stderr, "PVC:                 %s/%s -> %s/%s\n",
+		t.PVC.Namespace.source, t.PVC.Name.source,
+		t.PVC.Namespace.destination, t.PVC.Name.destination)
+	fmt.Fprintf(os.Stderr, "cloud storage:       %s\n", t.Flags.CloudStorage)
+	fmt.Fprintln(os.Stderr)
+
+	srcClient, err := t.getClientFromContext(t.Flags.SourceContext)
+	if err != nil {
+		return fmt.Errorf("unable to get source client: %w", err)
+	}
+	destClient, err := t.getClientFromContext(t.Flags.DestinationContext)
+	if err != nil {
+		return fmt.Errorf("unable to get destination client: %w", err)
+	}
+
+	// Read source PVC
+	fmt.Fprintf(os.Stderr, "[1/6] Reading source PVC ...\n")
+	srcPVC := &corev1.PersistentVolumeClaim{}
+	err = srcClient.Get(context.TODO(), client.ObjectKey{
+		Namespace: t.PVC.Namespace.source,
+		Name:      t.PVC.Name.source,
+	}, srcPVC)
+	if err != nil {
+		return fmt.Errorf("unable to get source PVC: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "[1/6] Reading source PVC ... ok\n")
+
+	// Create destination PVC
+	fmt.Fprintf(os.Stderr, "[2/6] Creating destination PVC ...\n")
+	destPVC := t.buildDestinationPVC(srcPVC)
+	err = destClient.Create(context.TODO(), destPVC, &client.CreateOptions{})
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("unable to create destination PVC: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "[2/6] Creating destination PVC ... ok\n")
+
+	// Resolve rclone config secret name
+	configSecret := t.Flags.RcloneConfigSecret
+	if t.Flags.RcloneConfigFile != "" {
+		secretName, err := t.createTempRcloneSecret(srcClient, t.PVC.Namespace.source, t.Flags.RcloneConfigFile)
+		if err != nil {
+			return fmt.Errorf("failed to create rclone config secret on source: %w", err)
+		}
+		configSecret = secretName
+
+		_, err = t.createTempRcloneSecret(destClient, t.PVC.Namespace.destination, t.Flags.RcloneConfigFile)
+		if err != nil {
+			return fmt.Errorf("failed to create rclone config secret on destination: %w", err)
+		}
+	}
+
+	// Get security contexts for source and target separately
+	uploadSecCtx, err := getSourcePodSecurityContext(srcClient, srcPVC.Namespace, srcPVC.Name)
+	if err != nil {
+		log.Printf("WARN: could not determine source security context: %v", err)
+		uploadSecCtx = &corev1.PodSecurityContext{}
+	}
+
+	downloadSecCtx, err := getTargetPodSecurityContext(destClient, destPVC.Namespace, destPVC.Name)
+	if err != nil {
+		log.Printf("WARN: could not determine target security context: %v", err)
+		downloadSecCtx = &corev1.PodSecurityContext{}
+	}
+	if downloadSecCtx.RunAsUser == nil && uploadSecCtx.RunAsUser != nil {
+		downloadSecCtx = uploadSecCtx
+	}
+
+	image := t.Flags.SourceImage
+	if image == "" {
+		image = "quay.io/konveyor/rsync-transfer:latest"
+	}
+
+	transfer := indirect.New(srcClient, destClient, indirect.Options{
+		Image:                  image,
+		CloudStorage:           t.Flags.CloudStorage,
+		ConfigSecret:           configSecret,
+		Encrypt:                t.Flags.Encrypt,
+		KeepCloudData:          t.Flags.KeepCloudData,
+		UploadSecurityContext:  *uploadSecCtx,
+		DownloadSecurityContext: *downloadSecCtx,
+	})
+
+	// Upload
+	fmt.Fprintf(os.Stderr, "[3/6] Uploading data to cloud storage ...\n")
+	uploadPod, err := transfer.Upload(context.TODO(), srcPVC)
+	if err != nil {
+		return fmt.Errorf("upload failed: %w", err)
+	}
+	if err := waitForPodComplete(srcClient, uploadPod.Name, uploadPod.Namespace); err != nil {
+		return fmt.Errorf("upload pod failed: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "[3/6] Uploading data to cloud storage ... ok\n")
+
+	// Download
+	fmt.Fprintf(os.Stderr, "[4/6] Downloading data from cloud storage ...\n")
+	downloadPod, err := transfer.Download(context.TODO(), destPVC, srcPVC.Namespace, srcPVC.Name)
+	if err != nil {
+		return fmt.Errorf("download failed: %w", err)
+	}
+	if err := waitForPodComplete(destClient, downloadPod.Name, downloadPod.Namespace); err != nil {
+		return fmt.Errorf("download pod failed: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "[4/6] Downloading data from cloud storage ... ok\n")
+
+	// Cleanup cloud data
+	fmt.Fprintf(os.Stderr, "[5/6] Cleaning up cloud storage ...\n")
+	if !t.Flags.KeepCloudData {
+		fmt.Fprintf(os.Stderr, "[5/6] Cleaning up cloud storage ... skipped (not implemented yet)\n")
+	} else {
+		fmt.Fprintf(os.Stderr, "[5/6] Cleaning up cloud storage ... skipped (--keep-cloud-data)\n")
+	}
+
+	// Cleanup pods
+	fmt.Fprintf(os.Stderr, "[6/6] Cleaning up transfer pods ...\n")
+	if err := transfer.Cleanup(context.TODO(), srcClient, srcPVC.Namespace, srcPVC.Name); err != nil {
+		log.Printf("WARN: source cleanup: %v", err)
+	}
+	if err := transfer.Cleanup(context.TODO(), destClient, destPVC.Namespace, destPVC.Name); err != nil {
+		log.Printf("WARN: destination cleanup: %v", err)
+	}
+	fmt.Fprintf(os.Stderr, "[6/6] Cleaning up transfer pods ... ok\n")
+
+	fmt.Fprintf(os.Stderr, "\nSummary\n-------\n")
+	fmt.Fprintf(os.Stderr, "PVC data copy: succeeded (indirect via cloud storage)\n")
+	fmt.Fprintf(os.Stderr, "Done.\n")
+
+	return nil
+}
+
+func waitForPodComplete(c client.Client, podName, namespace string) error {
+	return wait.PollUntil(time.Second*5, func() (done bool, err error) {
+		pod := &corev1.Pod{}
+		if err := c.Get(context.TODO(), client.ObjectKey{Name: podName, Namespace: namespace}, pod); err != nil {
+			return false, nil
+		}
+		switch pod.Status.Phase {
+		case corev1.PodSucceeded:
+			return true, nil
+		case corev1.PodFailed:
+			return true, fmt.Errorf("pod %s/%s failed", namespace, podName)
+		default:
+			return false, nil
+		}
+	}, make(<-chan struct{}))
+}
+
+func (t *TransferPVCCommand) createTempRcloneSecret(c client.Client, namespace, configFilePath string) (string, error) {
+	data, err := os.ReadFile(configFilePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read rclone config file %s: %w", configFilePath, err)
+	}
+
+	secretName := fmt.Sprintf("crane-rclone-config-%s", getValidatedResourceName(t.PVC.Name.source))
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":          "crane",
+				"app.kubernetes.io/component":     "indirect-transfer",
+				"app.kubernetes.io/managed-by":    "crane",
+				"app.konveyor.io/created-for-pvc": getValidatedResourceName(t.PVC.Name.source),
+			},
+		},
+		Data: map[string][]byte{
+			"rclone.conf": data,
+		},
+	}
+
+	err = c.Create(context.TODO(), secret)
+	if errors.IsAlreadyExists(err) {
+		existing := &corev1.Secret{}
+		if getErr := c.Get(context.TODO(), client.ObjectKey{Name: secretName, Namespace: namespace}, existing); getErr != nil {
+			return "", fmt.Errorf("failed to get existing rclone secret: %w", getErr)
+		}
+		existing.Data = secret.Data
+		if updateErr := c.Update(context.TODO(), existing); updateErr != nil {
+			return "", fmt.Errorf("failed to update rclone secret: %w", updateErr)
+		}
+	} else if err != nil {
+		return "", fmt.Errorf("failed to create rclone secret: %w", err)
+	}
+
+	return secretName, nil
+}

--- a/cmd/transfer-pvc/indirect.go
+++ b/cmd/transfer-pvc/indirect.go
@@ -113,6 +113,17 @@ func (t *TransferPVCCommand) runIndirect() error {
 		DownloadSecurityContext: *downloadSecCtx,
 	})
 
+	defer func() {
+		fmt.Fprintf(os.Stderr, "[6/6] Cleaning up transfer pods ...\n")
+		if err := transfer.Cleanup(context.TODO(), srcClient, srcPVC.Namespace, srcPVC.Name); err != nil {
+			log.Printf("WARN: source cleanup: %v", err)
+		}
+		if err := transfer.Cleanup(context.TODO(), destClient, destPVC.Namespace, destPVC.Name); err != nil {
+			log.Printf("WARN: destination cleanup: %v", err)
+		}
+		fmt.Fprintf(os.Stderr, "[6/6] Cleaning up transfer pods ... ok\n")
+	}()
+
 	// Upload
 	fmt.Fprintf(os.Stderr, "[3/6] Uploading data to cloud storage ...\n")
 	uploadPod, err := transfer.Upload(context.TODO(), srcPVC)
@@ -142,16 +153,6 @@ func (t *TransferPVCCommand) runIndirect() error {
 	} else {
 		fmt.Fprintf(os.Stderr, "[5/6] Cleaning up cloud storage ... skipped (--keep-cloud-data)\n")
 	}
-
-	// Cleanup pods
-	fmt.Fprintf(os.Stderr, "[6/6] Cleaning up transfer pods ...\n")
-	if err := transfer.Cleanup(context.TODO(), srcClient, srcPVC.Namespace, srcPVC.Name); err != nil {
-		log.Printf("WARN: source cleanup: %v", err)
-	}
-	if err := transfer.Cleanup(context.TODO(), destClient, destPVC.Namespace, destPVC.Name); err != nil {
-		log.Printf("WARN: destination cleanup: %v", err)
-	}
-	fmt.Fprintf(os.Stderr, "[6/6] Cleaning up transfer pods ... ok\n")
 
 	fmt.Fprintf(os.Stderr, "\nSummary\n-------\n")
 	fmt.Fprintf(os.Stderr, "PVC data copy: succeeded (indirect via cloud storage)\n")
@@ -191,13 +192,19 @@ func followPodLogsUntilComplete(restCfg *rest.Config, c client.Client, podName, 
 	if err != nil {
 		return fmt.Errorf("failed to stream logs for pod %s/%s: %w", namespace, podName, err)
 	}
-	defer stream.Close()
+	defer func() {
+		if closeErr := stream.Close(); closeErr != nil {
+			log.Printf("WARN: failed to close log stream for pod %s/%s: %v", namespace, podName, closeErr)
+		}
+	}()
 
 	buf := make([]byte, 4096)
 	for {
 		n, readErr := stream.Read(buf)
 		if n > 0 {
-			os.Stderr.Write(buf[:n])
+			if _, writeErr := os.Stderr.Write(buf[:n]); writeErr != nil {
+				return fmt.Errorf("failed to write logs for pod %s/%s: %w", namespace, podName, writeErr)
+			}
 		}
 		if readErr != nil {
 			break

--- a/cmd/transfer-pvc/indirect.go
+++ b/cmd/transfer-pvc/indirect.go
@@ -11,6 +11,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/konveyor/crane-lib/state_transfer/transfer/indirect"
@@ -33,6 +35,15 @@ func (t *TransferPVCCommand) runIndirect() error {
 	destClient, err := t.getClientFromContext(t.Flags.DestinationContext)
 	if err != nil {
 		return fmt.Errorf("unable to get destination client: %w", err)
+	}
+
+	srcCfg, err := t.getRestConfigFromContext(t.Flags.SourceContext)
+	if err != nil {
+		return fmt.Errorf("unable to get source rest config: %w", err)
+	}
+	destCfg, err := t.getRestConfigFromContext(t.Flags.DestinationContext)
+	if err != nil {
+		return fmt.Errorf("unable to get destination rest config: %w", err)
 	}
 
 	// Read source PVC
@@ -108,7 +119,7 @@ func (t *TransferPVCCommand) runIndirect() error {
 	if err != nil {
 		return fmt.Errorf("upload failed: %w", err)
 	}
-	if err := waitForPodComplete(srcClient, uploadPod.Name, uploadPod.Namespace); err != nil {
+	if err := followPodLogsUntilComplete(srcCfg, srcClient, uploadPod.Name, uploadPod.Namespace, "rclone"); err != nil {
 		return fmt.Errorf("upload pod failed: %w", err)
 	}
 	fmt.Fprintf(os.Stderr, "[3/6] Uploading data to cloud storage ... ok\n")
@@ -119,7 +130,7 @@ func (t *TransferPVCCommand) runIndirect() error {
 	if err != nil {
 		return fmt.Errorf("download failed: %w", err)
 	}
-	if err := waitForPodComplete(destClient, downloadPod.Name, downloadPod.Namespace); err != nil {
+	if err := followPodLogsUntilComplete(destCfg, destClient, downloadPod.Name, downloadPod.Namespace, "rclone"); err != nil {
 		return fmt.Errorf("download pod failed: %w", err)
 	}
 	fmt.Fprintf(os.Stderr, "[4/6] Downloading data from cloud storage ... ok\n")
@@ -149,21 +160,59 @@ func (t *TransferPVCCommand) runIndirect() error {
 	return nil
 }
 
-func waitForPodComplete(c client.Client, podName, namespace string) error {
-	return wait.PollUntil(time.Second*5, func() (done bool, err error) {
+func followPodLogsUntilComplete(restCfg *rest.Config, c client.Client, podName, namespace, containerName string) error {
+	clientset, err := kubernetes.NewForConfig(restCfg)
+	if err != nil {
+		return fmt.Errorf("failed to create clientset: %w", err)
+	}
+
+	// Wait for pod to be running
+	if err := wait.PollUntil(time.Second*3, func() (done bool, err error) {
 		pod := &corev1.Pod{}
 		if err := c.Get(context.TODO(), client.ObjectKey{Name: podName, Namespace: namespace}, pod); err != nil {
 			return false, nil
 		}
 		switch pod.Status.Phase {
-		case corev1.PodSucceeded:
+		case corev1.PodRunning, corev1.PodSucceeded, corev1.PodFailed:
 			return true, nil
-		case corev1.PodFailed:
-			return true, fmt.Errorf("pod %s/%s failed", namespace, podName)
 		default:
 			return false, nil
 		}
-	}, make(<-chan struct{}))
+	}, make(<-chan struct{})); err != nil {
+		return fmt.Errorf("timed out waiting for pod %s/%s to start: %w", namespace, podName, err)
+	}
+
+	// Follow logs
+	req := clientset.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{
+		Container: containerName,
+		Follow:    true,
+	})
+	stream, err := req.Stream(context.TODO())
+	if err != nil {
+		return fmt.Errorf("failed to stream logs for pod %s/%s: %w", namespace, podName, err)
+	}
+	defer stream.Close()
+
+	buf := make([]byte, 4096)
+	for {
+		n, readErr := stream.Read(buf)
+		if n > 0 {
+			os.Stderr.Write(buf[:n])
+		}
+		if readErr != nil {
+			break
+		}
+	}
+
+	// Check final pod status
+	pod := &corev1.Pod{}
+	if err := c.Get(context.TODO(), client.ObjectKey{Name: podName, Namespace: namespace}, pod); err != nil {
+		return fmt.Errorf("failed to get pod status: %w", err)
+	}
+	if pod.Status.Phase == corev1.PodFailed {
+		return fmt.Errorf("pod %s/%s failed", namespace, podName)
+	}
+	return nil
 }
 
 func (t *TransferPVCCommand) createTempRcloneSecret(c client.Client, namespace, configFilePath string) (string, error) {

--- a/cmd/transfer-pvc/indirect.go
+++ b/cmd/transfer-pvc/indirect.go
@@ -70,13 +70,13 @@ func (t *TransferPVCCommand) runIndirect() error {
 	// Resolve rclone config secret name
 	configSecret := t.Flags.RcloneConfigSecret
 	if t.Flags.RcloneConfigFile != "" {
-		secretName, err := t.createTempRcloneSecret(srcClient, t.PVC.Namespace.source, t.Flags.RcloneConfigFile)
+		secretName, err := t.createTempRcloneSecret(srcClient, t.PVC.Namespace.source, t.Flags.RcloneConfigFile, t.PVC.Name.source)
 		if err != nil {
 			return fmt.Errorf("failed to create rclone config secret on source: %w", err)
 		}
 		configSecret = secretName
 
-		_, err = t.createTempRcloneSecret(destClient, t.PVC.Namespace.destination, t.Flags.RcloneConfigFile)
+		_, err = t.createTempRcloneSecret(destClient, t.PVC.Namespace.destination, t.Flags.RcloneConfigFile, t.PVC.Name.destination)
 		if err != nil {
 			return fmt.Errorf("failed to create rclone config secret on destination: %w", err)
 		}
@@ -167,10 +167,12 @@ func followPodLogsUntilComplete(restCfg *rest.Config, c client.Client, podName, 
 		return fmt.Errorf("failed to create clientset: %w", err)
 	}
 
-	// Wait for pod to be running
-	if err := wait.PollUntil(time.Second*3, func() (done bool, err error) {
+	// Wait for pod to be running (5-minute timeout to catch ImagePullBackOff, Unschedulable, etc.)
+	startCtx, startCancel := context.WithTimeout(context.TODO(), 5*time.Minute)
+	defer startCancel()
+	if err := wait.PollUntilContextCancel(startCtx, 3*time.Second, true, func(ctx context.Context) (bool, error) {
 		pod := &corev1.Pod{}
-		if err := c.Get(context.TODO(), client.ObjectKey{Name: podName, Namespace: namespace}, pod); err != nil {
+		if err := c.Get(ctx, client.ObjectKey{Name: podName, Namespace: namespace}, pod); err != nil {
 			return false, nil
 		}
 		switch pod.Status.Phase {
@@ -179,7 +181,7 @@ func followPodLogsUntilComplete(restCfg *rest.Config, c client.Client, podName, 
 		default:
 			return false, nil
 		}
-	}, make(<-chan struct{})); err != nil {
+	}); err != nil {
 		return fmt.Errorf("timed out waiting for pod %s/%s to start: %w", namespace, podName, err)
 	}
 
@@ -211,23 +213,38 @@ func followPodLogsUntilComplete(restCfg *rest.Config, c client.Client, podName, 
 		}
 	}
 
-	// Check final pod status
-	pod := &corev1.Pod{}
-	if err := c.Get(context.TODO(), client.ObjectKey{Name: podName, Namespace: namespace}, pod); err != nil {
-		return fmt.Errorf("failed to get pod status: %w", err)
-	}
-	if pod.Status.Phase == corev1.PodFailed {
-		return fmt.Errorf("pod %s/%s failed", namespace, podName)
+	// Check final pod status — wait for terminal state in case the log stream
+	// ended before the pod completed (e.g. network interruption).
+	waitCtx, waitCancel := context.WithTimeout(context.TODO(), 2*time.Minute)
+	defer waitCancel()
+	if err := wait.PollUntilContextCancel(waitCtx, 3*time.Second, true, func(ctx context.Context) (bool, error) {
+		pod := &corev1.Pod{}
+		if err := c.Get(ctx, client.ObjectKey{Name: podName, Namespace: namespace}, pod); err != nil {
+			return false, fmt.Errorf("failed to get pod status: %w", err)
+		}
+		switch pod.Status.Phase {
+		case corev1.PodSucceeded:
+			return true, nil
+		case corev1.PodFailed:
+			return true, fmt.Errorf("pod %s/%s failed", namespace, podName)
+		default:
+			return false, nil
+		}
+	}); err != nil {
+		return err
 	}
 	return nil
 }
 
-func (t *TransferPVCCommand) createTempRcloneSecret(c client.Client, namespace, configFilePath string) (string, error) {
+func (t *TransferPVCCommand) createTempRcloneSecret(c client.Client, namespace, configFilePath, labelPVCName string) (string, error) {
 	data, err := os.ReadFile(configFilePath)
 	if err != nil {
 		return "", fmt.Errorf("failed to read rclone config file %s: %w", configFilePath, err)
 	}
 
+	// Secret name uses source PVC name so both clusters use the same name
+	// (crane-lib references a single ConfigSecret for upload and download).
+	// Label uses the per-cluster PVC name so Cleanup can find it by label selector.
 	secretName := fmt.Sprintf("crane-rclone-config-%s", getValidatedResourceName(t.PVC.Name.source))
 
 	secret := &corev1.Secret{
@@ -238,7 +255,7 @@ func (t *TransferPVCCommand) createTempRcloneSecret(c client.Client, namespace, 
 				"app.kubernetes.io/name":          "crane",
 				"app.kubernetes.io/component":     "indirect-transfer",
 				"app.kubernetes.io/managed-by":    "crane",
-				"app.konveyor.io/created-for-pvc": getValidatedResourceName(t.PVC.Name.source),
+				"app.konveyor.io/created-for-pvc": getValidatedResourceName(labelPVCName),
 			},
 		},
 		Data: map[string][]byte{

--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -79,6 +79,11 @@ type Flags struct {
 	Verify             bool
 	RsyncFlags         []string
 	ProgressOutput     string
+	CloudStorage       string
+	RcloneConfigSecret string
+	RcloneConfigFile   string
+	Encrypt            bool
+	KeepCloudData      bool
 }
 
 // EndpointFlags defines command line flags specific
@@ -187,6 +192,11 @@ func addFlagsToTransferPVCCommand(c *Flags, cmd *cobra.Command) {
 	cmd.Flags().StringVar(&c.Endpoint.IngressClass, "ingress-class", "", "IngressClass to use for the ingress endpoint")
 	cmd.Flags().BoolVar(&c.Verify, "verify", false, "Enable checksum verification")
 	cmd.Flags().StringVar(&c.ProgressOutput, "output", "", "Write data transfer stats to specified output file")
+	cmd.Flags().StringVar(&c.CloudStorage, "cloud-storage", "", "S3-compatible cloud storage path for indirect transfer (e.g. remote:my-bucket)")
+	cmd.Flags().StringVar(&c.RcloneConfigSecret, "rclone-config-secret", "", "Name of the K8s Secret containing rclone.conf for indirect transfer")
+	cmd.Flags().StringVar(&c.RcloneConfigFile, "rclone-config-file", "", "Path to local rclone.conf file for indirect transfer (crane creates temporary Secrets)")
+	cmd.Flags().BoolVar(&c.Encrypt, "encrypt", false, "Enable client-side encryption for indirect transfer")
+	cmd.Flags().BoolVar(&c.KeepCloudData, "keep-cloud-data", false, "Skip cloud storage cleanup after indirect transfer")
 	cmd.MarkFlagRequired("source-context")
 	cmd.MarkFlagRequired("destination-context")
 	cmd.MarkFlagRequired("pvc-name")
@@ -241,6 +251,16 @@ func (t *TransferPVCCommand) Validate() error {
 		return err
 	}
 
+	if t.Flags.CloudStorage != "" {
+		if t.Flags.RcloneConfigSecret == "" && t.Flags.RcloneConfigFile == "" {
+			return fmt.Errorf("--cloud-storage requires --rclone-config-secret or --rclone-config-file")
+		}
+		if t.Flags.RcloneConfigSecret != "" && t.Flags.RcloneConfigFile != "" {
+			return fmt.Errorf("--rclone-config-secret and --rclone-config-file are mutually exclusive")
+		}
+		return nil
+	}
+
 	err = t.Endpoint.Validate()
 	if err != nil {
 		return err
@@ -250,6 +270,9 @@ func (t *TransferPVCCommand) Validate() error {
 }
 
 func (t *TransferPVCCommand) Run() error {
+	if t.Flags.CloudStorage != "" {
+		return t.runIndirect()
+	}
 	return t.run()
 }
 
@@ -470,12 +493,12 @@ func (t *TransferPVCCommand) run() (retErr error) {
 	destPVCList := transfer.NewSingletonPVC(destPVC)
 	srcPVCList := transfer.NewSingletonPVC(srcPVC)
 
-	clientPodSecCtx, err := getRsyncClientPodSecurityContext(srcClient, srcPVC.Namespace, srcPVC.Name)
+	clientPodSecCtx, err := getSourcePodSecurityContext(srcClient, srcPVC.Namespace, srcPVC.Name)
 	if err != nil {
 		return phases.Fail(err, "error creating security context for rsync client")
 	}
 
-	serverPodSecContext, err := getRsyncServerPodSecurityContext(destClient, destPVC.Namespace, destPVC.Name)
+	serverPodSecContext, err := getTargetPodSecurityContext(destClient, destPVC.Namespace, destPVC.Name)
 	if err != nil {
 		return phases.Fail(err, "error creating security context for rsync server")
 	}
@@ -964,11 +987,11 @@ func inspectPVCFileOwnership(c client.Client, namespace string, pvcName string) 
 	return &uid, nil
 }
 
-func getRsyncClientPodSecurityContext(c client.Client, namespace string, pvcName string) (*corev1.PodSecurityContext, error) {
+func getSourcePodSecurityContext(c client.Client, namespace string, pvcName string) (*corev1.PodSecurityContext, error) {
 	return getIDsForNamespace(c, namespace, pvcName)
 }
 
-func getRsyncServerPodSecurityContext(c client.Client, namespace string, pvcName string) (*corev1.PodSecurityContext, error) {
+func getTargetPodSecurityContext(c client.Client, namespace string, pvcName string) (*corev1.PodSecurityContext, error) {
 	return getIDsForNamespace(c, namespace, pvcName)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/gnostic-models v0.7.0
 	github.com/google/go-cmp v0.7.0
 	github.com/jarcoal/httpmock v1.2.0
-	github.com/konveyor/crane-lib v0.1.6-0.20260618130404-9791be7b44bd
+	github.com/konveyor/crane-lib v0.1.6-0.20260807130033-222a325c7cee
 	github.com/migtools/pvc-transfer v0.0.0-20260805073413-1b1f9d254821
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/ginkgo/v2 v2.28.1

--- a/go.sum
+++ b/go.sum
@@ -337,8 +337,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/konveyor/crane-lib v0.1.6-0.20260618130404-9791be7b44bd h1:40YRFVxxE2zq1jxtpZ7tCvQgEmEQz9GaZLqDdn5liz4=
-github.com/konveyor/crane-lib v0.1.6-0.20260618130404-9791be7b44bd/go.mod h1:oYw915/11lZhW5k+nVxZtWdpl5AGc0lL52Z1YcKjU7Y=
+github.com/konveyor/crane-lib v0.1.6-0.20260807130033-222a325c7cee h1:T3i160U9L0PjkleTXOFpoyAS/npIc8oG9XBlEjE/Uo8=
+github.com/konveyor/crane-lib v0.1.6-0.20260807130033-222a325c7cee/go.mod h1:oYw915/11lZhW5k+nVxZtWdpl5AGc0lL52Z1YcKjU7Y=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
## Summary

  Add indirect PVC data migration via S3-compatible cloud storage to `crane transfer-pvc`. This enables data transfer between clusters without direct network connectivity — each cluster only needs outbound access to the
  object store.

  ## Changes

  - New `--cloud-storage` flag activates indirect mode (upload to S3, download from S3)
  - New `--rclone-config-secret` and `--rclone-config-file` flags for rclone credentials
  - `--encrypt` and `--keep-cloud-data` flags added as placeholders for future implementation
  - Separate security contexts for upload (source UID) and download (target UID) pods
  - Pods and Secrets labeled with `app.konveyor.io/created-for-pvc` for scoped cleanup
  - Renamed `getRsyncClientPodSecurityContext` to `getSourcePodSecurityContext` and `getRsyncServerPodSecurityContext` to `getTargetPodSecurityContext`
  - Updated crane-lib to v0.1.6-0.20260807130033-222a325c7cee

  ## Tested on

  - Minikube to Minikube via MinIO — PASS
  - OCP 4.19 to OCP 4.20 via AWS S3 — PASS
  - OCP different namespace UIDs (1000750000 to 1000760000) — PASS, files owned by target UID
  - Incremental sync (2GB dataset, 4 runs) — PASS, delta only
  - Parallel PVC cleanup isolation — PASS, scoped by PVC label

  100% backward compatible. Existing direct rsync/stunnel flow is unchanged.

  Fixes #751

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added indirect PVC transfers through cloud storage.
  * Added options for cloud storage location, rclone configuration, encryption, and retaining cloud data.
  * Added progress reporting, completion monitoring, failure reporting, and cleanup for cloud-based transfers.
  * Added support for preparing destination PVCs during cloud-based transfers.
* **Bug Fixes**
  * Improved validation to ensure cloud-storage transfers use exactly one rclone configuration source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->