### PR TITLE
:test_tube: Add tier0 e2e test for stage + cutover migration flow (MTA-898)

### DIFF
--- a/e2e-tests/framework/test_helpers.go
+++ b/e2e-tests/framework/test_helpers.go
@@ -173,7 +173,7 @@ type VerifierPodOptions struct {
 func DeployVerifierPod(k KubectlRunner, opts VerifierPodOptions) error {
 	var labelLines strings.Builder
 	for key, val := range opts.Labels {
-		labelLines.WriteString(fmt.Sprintf("    %s: %q\n", key, val))
+		fmt.Fprintf(&labelLines, "    %s: %q\n", key, val)
 	}
 	labelsBlock := ""
 	if labelLines.Len() > 0 {
@@ -183,8 +183,8 @@ func DeployVerifierPod(k KubectlRunner, opts VerifierPodOptions) error {
 	var mounts, volumes strings.Builder
 	for i, v := range opts.Volumes {
 		name := fmt.Sprintf("vol%d", i)
-		mounts.WriteString(fmt.Sprintf("    - name: %s\n      mountPath: %s\n", name, v.MountPath))
-		volumes.WriteString(fmt.Sprintf("  - name: %s\n    persistentVolumeClaim:\n      claimName: %s\n", name, v.PVCName))
+		fmt.Fprintf(&mounts, "    - name: %s\n      mountPath: %s\n", name, v.MountPath)
+		fmt.Fprintf(&volumes, "  - name: %s\n    persistentVolumeClaim:\n      claimName: %s\n", name, v.PVCName)
 	}
 
 	commandJSON, err := json.Marshal(opts.Command)
@@ -208,14 +208,17 @@ metadata:
 %s`, opts.Name, opts.Namespace, labelsBlock, opts.Image, string(commandJSON), mounts.String(), volumes.String())
 
 	if err := k.ApplyYAMLSpec(manifest, opts.Namespace); err != nil {
-		return err
+		return fmt.Errorf("apply verifier pod %s/%s: %w", opts.Namespace, opts.Name, err)
 	}
-	_, err = k.Run("wait", "--for=condition=Ready", "pod/"+opts.Name, "-n", opts.Namespace, "--timeout=120s")
-	return err
+	if _, err := k.Run("wait", "--for=condition=Ready", "pod/"+opts.Name, "-n", opts.Namespace, "--timeout=120s"); err != nil {
+		return fmt.Errorf("wait for verifier pod %s/%s to become ready: %w", opts.Namespace, opts.Name, err)
+	}
+	return nil
 }
 
-// DeleteVerifierPod deletes a pod created by DeployVerifierPod.
+// DeleteVerifierPod deletes a pod created by DeployVerifierPod. Safe to call
+// even if the pod was already removed (e.g. by an earlier DeferCleanup).
 func DeleteVerifierPod(k KubectlRunner, namespace, name string) error {
-	_, err := k.Run("delete", "pod", name, "-n", namespace, "--wait=true")
+	_, err := k.Run("delete", "pod", name, "-n", namespace, "--ignore-not-found", "--wait=true")
 	return err
 }

--- a/e2e-tests/framework/test_helpers.go
+++ b/e2e-tests/framework/test_helpers.go
@@ -140,3 +140,82 @@ func GetSecretData(kubectl KubectlRunner, namespace, secretName string) (map[str
 	}
 	return secretObj.Data, nil
 }
+
+// PodVolumeMount maps a PVC to a mount path inside a VerifierPodOptions pod.
+type PodVolumeMount struct {
+	PVCName   string
+	MountPath string
+}
+
+// VerifierPodOptions configures a disposable pod created by DeployVerifierPod.
+type VerifierPodOptions struct {
+	Name      string
+	Namespace string
+	Image     string
+	Command   []string
+	Volumes   []PodVolumeMount
+	// Labels are applied to the pod's metadata. Useful when the pod needs to
+	// match a Deployment's selector (e.g. simulating the real app briefly)
+	// rather than just being a throwaway inspector.
+	Labels map[string]string
+}
+
+// DeployVerifierPod creates a disposable pod that mounts one or more existing
+// PVCs, so their data can be inspected directly (e.g. via kubectl exec)
+// independent of whatever application normally owns them. This is commonly
+// needed mid-migration: a PVC has been transferred to the target cluster, but
+// the owning application hasn't been deployed there yet, so there's nothing
+// else to mount it and let you look inside.
+//
+// PVCs are typically ReadWriteOnce, so callers must call DeleteVerifierPod
+// before mounting the same PVC anywhere else (a subsequent transfer-pvc run,
+// or the real app).
+func DeployVerifierPod(k KubectlRunner, opts VerifierPodOptions) error {
+	var labelLines strings.Builder
+	for key, val := range opts.Labels {
+		labelLines.WriteString(fmt.Sprintf("    %s: %q\n", key, val))
+	}
+	labelsBlock := ""
+	if labelLines.Len() > 0 {
+		labelsBlock = "  labels:\n" + labelLines.String()
+	}
+
+	var mounts, volumes strings.Builder
+	for i, v := range opts.Volumes {
+		name := fmt.Sprintf("vol%d", i)
+		mounts.WriteString(fmt.Sprintf("    - name: %s\n      mountPath: %s\n", name, v.MountPath))
+		volumes.WriteString(fmt.Sprintf("  - name: %s\n    persistentVolumeClaim:\n      claimName: %s\n", name, v.PVCName))
+	}
+
+	commandJSON, err := json.Marshal(opts.Command)
+	if err != nil {
+		return fmt.Errorf("marshal verifier pod command: %w", err)
+	}
+
+	manifest := fmt.Sprintf(`apiVersion: v1
+kind: Pod
+metadata:
+  name: %s
+  namespace: %s
+%sspec:
+  restartPolicy: Never
+  containers:
+  - name: verifier
+    image: %s
+    command: %s
+    volumeMounts:
+%s  volumes:
+%s`, opts.Name, opts.Namespace, labelsBlock, opts.Image, string(commandJSON), mounts.String(), volumes.String())
+
+	if err := k.ApplyYAMLSpec(manifest, opts.Namespace); err != nil {
+		return err
+	}
+	_, err = k.Run("wait", "--for=condition=Ready", "pod/"+opts.Name, "-n", opts.Namespace, "--timeout=120s")
+	return err
+}
+
+// DeleteVerifierPod deletes a pod created by DeployVerifierPod.
+func DeleteVerifierPod(k KubectlRunner, namespace, name string) error {
+	_, err := k.Run("delete", "pod", name, "-n", namespace, "--wait=true")
+	return err
+}

--- a/e2e-tests/framework/test_helpers.go
+++ b/e2e-tests/framework/test_helpers.go
@@ -186,6 +186,11 @@ func DeployVerifierPod(k KubectlRunner, opts VerifierPodOptions) error {
 		fmt.Fprintf(&mounts, "    - name: %s\n      mountPath: %s\n", name, v.MountPath)
 		fmt.Fprintf(&volumes, "  - name: %s\n    persistentVolumeClaim:\n      claimName: %s\n", name, v.PVCName)
 	}
+	mountsBlock, volumesBlock := "", ""
+	if len(opts.Volumes) > 0 {
+		mountsBlock = "    volumeMounts:\n" + mounts.String()
+		volumesBlock = "  volumes:\n" + volumes.String()
+	}
 
 	commandJSON, err := json.Marshal(opts.Command)
 	if err != nil {
@@ -203,9 +208,7 @@ metadata:
   - name: verifier
     image: %s
     command: %s
-    volumeMounts:
-%s  volumes:
-%s`, opts.Name, opts.Namespace, labelsBlock, opts.Image, string(commandJSON), mounts.String(), volumes.String())
+%s%s`, opts.Name, opts.Namespace, labelsBlock, opts.Image, string(commandJSON), mountsBlock, volumesBlock)
 
 	if err := k.ApplyYAMLSpec(manifest, opts.Namespace); err != nil {
 		return fmt.Errorf("apply verifier pod %s/%s: %w", opts.Namespace, opts.Name, err)
@@ -219,6 +222,8 @@ metadata:
 // DeleteVerifierPod deletes a pod created by DeployVerifierPod. Safe to call
 // even if the pod was already removed (e.g. by an earlier DeferCleanup).
 func DeleteVerifierPod(k KubectlRunner, namespace, name string) error {
-	_, err := k.Run("delete", "pod", name, "-n", namespace, "--ignore-not-found", "--wait=true")
-	return err
+	if _, err := k.Run("delete", "pod", name, "-n", namespace, "--ignore-not-found", "--wait=true", "--timeout=120s"); err != nil {
+		return fmt.Errorf("delete verifier pod %s/%s: %w", namespace, name, err)
+	}
+	return nil
 }

--- a/e2e-tests/tests/tier0/mta_898_stage_cutover_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_898_stage_cutover_migration_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Stage and cutover migration flow", func() {
 			Volumes:   []PodVolumeMount{{PVCName: pvcName, MountPath: "/data"}},
 		}
 		Expect(DeployVerifierPod(kubectlTgt, verifierOpts)).NotTo(HaveOccurred())
-		verifyValue, err := redisGet(kubectlTgt, tgtApp.Namespace, verifierPod, "redis", "mytestkey")
+		verifyValue, err := redisGet(kubectlTgt, tgtApp.Namespace, verifierPod, "verifier", "mytestkey")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(verifyValue).To(Equal(initial))
 		Expect(DeleteVerifierPod(kubectlTgt, tgtApp.Namespace, verifierPod)).NotTo(HaveOccurred())
@@ -144,10 +144,10 @@ var _ = Describe("Stage and cutover migration flow", func() {
 
 		By("Verify no data is missing: both the initial and new keys are present on target")
 		Expect(DeployVerifierPod(kubectlTgt, verifierOpts)).NotTo(HaveOccurred())
-		mytestkeyAfterStage2, err := redisGet(kubectlTgt, tgtApp.Namespace, verifierPod, "redis", "mytestkey")
+		mytestkeyAfterStage2, err := redisGet(kubectlTgt, tgtApp.Namespace, verifierPod, "verifier", "mytestkey")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(mytestkeyAfterStage2).To(Equal(initial))
-		stage1ValueOnTarget, err := redisGet(kubectlTgt, tgtApp.Namespace, verifierPod, "redis", "stage1key")
+		stage1ValueOnTarget, err := redisGet(kubectlTgt, tgtApp.Namespace, verifierPod, "verifier", "stage1key")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(stage1ValueOnTarget).To(Equal("stage1-value"))
 		Expect(DeleteVerifierPod(kubectlTgt, tgtApp.Namespace, verifierPod)).NotTo(HaveOccurred())

--- a/e2e-tests/tests/tier0/mta_898_stage_cutover_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_898_stage_cutover_migration_test.go
@@ -16,10 +16,7 @@ import (
 )
 
 const (
-	mta898RedisPassword = "PASSWORD"
-	// deltaBaselineKey holds a large, unchanging value so a genuine incremental
-	// sync (only the small stage1key addition) is trivially distinguishable from
-	// a full re-copy of the PVC.
+	mta898RedisPassword    = "PASSWORD"
 	deltaBaselineKey       = "delta-test-baseline"
 	deltaBaselineSizeBytes = 3_000_000
 )
@@ -104,11 +101,21 @@ var _ = Describe("Stage and cutover migration flow", func() {
 
 		By("Verify the initial data landed on target via a throwaway redis instance on the migrated PVC")
 		const verifierPod = "mta-898-redis-verifier"
-		Expect(deployRedisVerifier(kubectlTgt, tgtApp.Namespace, verifierPod, pvcName)).NotTo(HaveOccurred())
+		// Reused as-is for every verifier deploy below — same pod name, same PVC,
+		// just torn down and recreated between transfer-pvc runs since the PVC
+		// is ReadWriteOnce.
+		verifierOpts := VerifierPodOptions{
+			Name:      verifierPod,
+			Namespace: tgtApp.Namespace,
+			Image:     "redis:latest",
+			Command:   []string{"redis-server", "--requirepass", mta898RedisPassword},
+			Volumes:   []PodVolumeMount{{PVCName: pvcName, MountPath: "/data"}},
+		}
+		Expect(DeployVerifierPod(kubectlTgt, verifierOpts)).NotTo(HaveOccurred())
 		verifyValue, err := redisGet(kubectlTgt, tgtApp.Namespace, verifierPod, "redis", "mytestkey")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(verifyValue).To(Equal(initial))
-		Expect(deleteRedisVerifier(kubectlTgt, tgtApp.Namespace, verifierPod)).NotTo(HaveOccurred())
+		Expect(DeleteVerifierPod(kubectlTgt, tgtApp.Namespace, verifierPod)).NotTo(HaveOccurred())
 
 		By("Insert new data on source while the app is still running")
 		Expect(redisSet(kubectlSrc, srcApp.Namespace, srcPodName, appName, "stage1key", "stage1-value")).NotTo(HaveOccurred())
@@ -136,14 +143,14 @@ var _ = Describe("Stage and cutover migration flow", func() {
 			literalBytes, deltaBaselineSizeBytes)
 
 		By("Verify no data is missing: both the initial and new keys are present on target")
-		Expect(deployRedisVerifier(kubectlTgt, tgtApp.Namespace, verifierPod, pvcName)).NotTo(HaveOccurred())
+		Expect(DeployVerifierPod(kubectlTgt, verifierOpts)).NotTo(HaveOccurred())
 		mytestkeyAfterStage2, err := redisGet(kubectlTgt, tgtApp.Namespace, verifierPod, "redis", "mytestkey")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(mytestkeyAfterStage2).To(Equal(initial))
 		stage1ValueOnTarget, err := redisGet(kubectlTgt, tgtApp.Namespace, verifierPod, "redis", "stage1key")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(stage1ValueOnTarget).To(Equal("stage1-value"))
-		Expect(deleteRedisVerifier(kubectlTgt, tgtApp.Namespace, verifierPod)).NotTo(HaveOccurred())
+		Expect(DeleteVerifierPod(kubectlTgt, tgtApp.Namespace, verifierPod)).NotTo(HaveOccurred())
 
 		By("Insert a second new data set on source")
 		Expect(redisSet(kubectlSrc, srcApp.Namespace, srcPodName, appName, "stage2key", "stage2-value")).NotTo(HaveOccurred())
@@ -200,8 +207,6 @@ var _ = Describe("Stage and cutover migration flow", func() {
 	})
 })
 
-// redisExec runs a redis-cli command against a container in the given pod,
-// stripping kubectl warning noise (e.g. the "-a" password warning) from the output.
 func redisExec(k KubectlRunner, namespace, pod, container string, args ...string) (string, error) {
 	cmdArgs := append([]string{"exec", pod, "-n", namespace, "-c", container, "--", "redis-cli", "-a", mta898RedisPassword}, args...)
 	out, err := k.Run(cmdArgs...)
@@ -233,70 +238,18 @@ func redisStrlen(k KubectlRunner, namespace, pod, container, key string) (int64,
 	return strconv.ParseInt(out, 10, 64)
 }
 
-// redisSetRandomBlob generates sizeBytes of random data inside the pod itself
-// (avoiding passing large payloads through kubectl exec argv) and stores it,
-// base64-encoded, under key.
 func redisSetRandomBlob(k KubectlRunner, namespace, pod, container, key string, sizeBytes int) error {
 	shellCmd := fmt.Sprintf("head -c %d /dev/urandom | base64 | redis-cli -a %s -x set %s", sizeBytes, mta898RedisPassword, key)
 	_, err := k.Run("exec", pod, "-n", namespace, "-c", container, "--", "/bin/sh", "-c", shellCmd)
 	return err
 }
 
-// deployRedisVerifier starts a throwaway redis instance mounting the given PVC,
-// so its persisted data can be inspected directly with redis-cli. The migrated
-// PVC is ReadWriteOnce, so callers must delete this pod (deleteRedisVerifier)
-// before mounting the same PVC again (e.g. a subsequent transfer-pvc run).
-func deployRedisVerifier(k KubectlRunner, namespace, podName, pvcName string) error {
-	manifest := fmt.Sprintf(`apiVersion: v1
-kind: Pod
-metadata:
-  name: %s
-  namespace: %s
-spec:
-  restartPolicy: Never
-  containers:
-  - name: redis
-    image: redis:latest
-    command: ["redis-server", "--requirepass", "%s"]
-    volumeMounts:
-    - name: data
-      mountPath: /data
-  volumes:
-  - name: data
-    persistentVolumeClaim:
-      claimName: %s
-`, podName, namespace, mta898RedisPassword, pvcName)
-	if err := k.ApplyYAMLSpec(manifest, namespace); err != nil {
-		return err
-	}
-	_, err := k.Run("wait", "--for=condition=Ready", "pod/"+podName, "-n", namespace, "--timeout=120s")
-	return err
-}
-
-func deleteRedisVerifier(k KubectlRunner, namespace, podName string) error {
-	_, err := k.Run("delete", "pod", podName, "-n", namespace, "--wait=true")
-	return err
-}
-
-// literalDataRegex matches rsync's "Literal data: X bytes" stats line, where X
-// may be a plain comma-grouped integer (e.g. "32,847") or a human-readable
-// value with a unit suffix (e.g. "2.66K", "4.05M").
 var literalDataRegex = regexp.MustCompile(`Literal data: ([\d,.]+)\s*([KMGT]?) bytes`)
 
 var byteUnitMultipliers = map[string]float64{
 	"": 1, "K": 1_000, "M": 1_000_000, "G": 1_000_000_000, "T": 1_000_000_000_000,
 }
 
-// literalDataBytes extracts rsync's own authoritative "Literal data" figure
-// from a raw rsync client log — the count of bytes actually sent because they
-// were new, as opposed to "Matched data" (bytes rsync found already present
-// on the receiver and reused instead of resending). This is the correct
-// metric for verifying an incremental sync; "Total transferred file size"
-// counts every file rsync touched regardless of whether its content was new.
-// crane's own progress display (cmd/transfer-pvc/progress.go) has a buffered-
-// line parsing bug that can misreport its stats, so tests that need a
-// trustworthy number should read them from the client pod's raw log via
-// captureRsyncClientLog instead.
 func literalDataBytes(rsyncLog string) (float64, error) {
 	matched := literalDataRegex.FindStringSubmatch(rsyncLog)
 	if len(matched) < 3 {
@@ -309,12 +262,6 @@ func literalDataBytes(rsyncLog string) (float64, error) {
 	return val * byteUnitMultipliers[matched[2]], nil
 }
 
-// captureRsyncClientLog polls namespace for the ephemeral "rsync-client-*" pod
-// that transfer-pvc creates on the source cluster during a copy, and
-// continuously re-fetches its raw "rsync" container log. It sends the last
-// successfully captured log once the pod is cleaned up (the transfer
-// finished) or a generous deadline elapses, whichever comes first. Intended to
-// be started in a goroutine immediately before calling TransferPVC.
 func captureRsyncClientLog(k KubectlRunner, namespace string, result chan<- string) {
 	deadline := time.Now().Add(180 * time.Second)
 	var lastLog string

--- a/e2e-tests/tests/tier0/mta_898_stage_cutover_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_898_stage_cutover_migration_test.go
@@ -101,9 +101,6 @@ var _ = Describe("Stage and cutover migration flow", func() {
 
 		By("Verify the initial data landed on target via a throwaway redis instance on the migrated PVC")
 		const verifierPod = "mta-898-redis-verifier"
-		// Reused as-is for every verifier deploy below — same pod name, same PVC,
-		// just torn down and recreated between transfer-pvc runs since the PVC
-		// is ReadWriteOnce.
 		verifierOpts := VerifierPodOptions{
 			Name:      verifierPod,
 			Namespace: tgtApp.Namespace,
@@ -111,6 +108,11 @@ var _ = Describe("Stage and cutover migration flow", func() {
 			Command:   []string{"redis-server", "--requirepass", mta898RedisPassword},
 			Volumes:   []PodVolumeMount{{PVCName: pvcName, MountPath: "/data"}},
 		}
+		DeferCleanup(func() {
+			if err := DeleteVerifierPod(kubectlTgt, tgtApp.Namespace, verifierPod); err != nil {
+				log.Printf("cleanup verifier pod %q: %v", verifierPod, err)
+			}
+		})
 		Expect(DeployVerifierPod(kubectlTgt, verifierOpts)).NotTo(HaveOccurred())
 		verifyValue, err := redisGet(kubectlTgt, tgtApp.Namespace, verifierPod, "verifier", "mytestkey")
 		Expect(err).NotTo(HaveOccurred())
@@ -131,7 +133,7 @@ var _ = Describe("Stage and cutover migration flow", func() {
 
 		By("Run the second stage transfer-pvc while capturing the rsync client's raw log for delta verification")
 		rsyncLogCh := make(chan string, 1)
-		go captureRsyncClientLog(kubectlSrc, srcApp.Namespace, rsyncLogCh)
+		go captureRsyncClientLog(kubectlSrc, srcApp.Namespace, pvcName, rsyncLogCh)
 		Expect(runner.TransferPVC(transferOpts)).NotTo(HaveOccurred())
 		rsyncLog := <-rsyncLogCh
 
@@ -262,35 +264,33 @@ func literalDataBytes(rsyncLog string) (float64, error) {
 	return val * byteUnitMultipliers[matched[2]], nil
 }
 
-func captureRsyncClientLog(k KubectlRunner, namespace string, result chan<- string) {
+func captureRsyncClientLog(k KubectlRunner, namespace, pvcName string, result chan<- string) {
+	selector := fmt.Sprintf(
+		"app.kubernetes.io/component=transfer-pvc,app.konveyor.io/role=client,app.konveyor.io/created-for-pvc=%s",
+		pvcName,
+	)
 	deadline := time.Now().Add(180 * time.Second)
 	var lastLog string
 	seenPod := false
 	for time.Now().Before(deadline) {
-		out, err := k.Run("get", "pods", "-n", namespace, "-o", "name")
-		if err != nil {
-			time.Sleep(300 * time.Millisecond)
-			continue
-		}
-		podName := ""
-		for _, line := range strings.Split(out, "\n") {
-			if strings.HasPrefix(line, "pod/rsync-client") {
-				podName = strings.TrimPrefix(line, "pod/")
-				break
-			}
-		}
-		if podName == "" {
+		out, err := k.Run("get", "pods", "-n", namespace, "-l", selector, "-o", "name")
+		if err != nil || strings.TrimSpace(out) == "" {
 			if seenPod {
 				break
 			}
 			time.Sleep(300 * time.Millisecond)
 			continue
 		}
+		podName := strings.TrimPrefix(strings.Split(strings.TrimSpace(out), "\n")[0], "pod/")
 		seenPod = true
 		if podLog, err := k.Run("logs", podName, "-n", namespace, "-c", "rsync"); err == nil && podLog != "" {
 			lastLog = podLog
 		}
 		time.Sleep(300 * time.Millisecond)
+	}
+	if !seenPod {
+		result <- fmt.Sprintf("no rsync-client pod found in namespace %q (selector %q) within the capture window", namespace, selector)
+		return
 	}
 	result <- lastLog
 }

--- a/e2e-tests/tests/tier0/mta_898_stage_cutover_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_898_stage_cutover_migration_test.go
@@ -129,11 +129,11 @@ var _ = Describe("Stage and cutover migration flow", func() {
 		rsyncLog := <-rsyncLogCh
 
 		By("Verify only the newly added data was transferred, not a full re-copy of the PVC")
-		transferredBytes, err := totalTransferredBytes(rsyncLog)
+		literalBytes, err := literalDataBytes(rsyncLog)
 		Expect(err).NotTo(HaveOccurred(), "expected to find rsync's stats summary in the client log:\n%s", rsyncLog)
-		Expect(transferredBytes).To(BeNumerically("<", int64(deltaBaselineSizeBytes)/10),
-			"second sync transferred %d bytes; expected well under the %d-byte baseline blob if only the new key was sent",
-			transferredBytes, deltaBaselineSizeBytes)
+		Expect(literalBytes).To(BeNumerically("<", float64(deltaBaselineSizeBytes)/10),
+			"second sync sent %.0f bytes of literal (new) data; expected well under the %d-byte baseline blob if only the new key was sent, not a full re-copy",
+			literalBytes, deltaBaselineSizeBytes)
 
 		By("Verify no data is missing: both the initial and new keys are present on target")
 		Expect(deployRedisVerifier(kubectlTgt, tgtApp.Namespace, verifierPod, pvcName)).NotTo(HaveOccurred())
@@ -278,19 +278,35 @@ func deleteRedisVerifier(k KubectlRunner, namespace, podName string) error {
 	return err
 }
 
-var totalTransferredBytesRegex = regexp.MustCompile(`Total transferred file size: ([\d,]+) bytes`)
+// literalDataRegex matches rsync's "Literal data: X bytes" stats line, where X
+// may be a plain comma-grouped integer (e.g. "32,847") or a human-readable
+// value with a unit suffix (e.g. "2.66K", "4.05M").
+var literalDataRegex = regexp.MustCompile(`Literal data: ([\d,.]+)\s*([KMGT]?) bytes`)
 
-// totalTransferredBytes extracts rsync's own authoritative "Total transferred
-// file size" from a raw rsync client log. crane's own progress display
-// (cmd/transfer-pvc/progress.go) has a buffered-line parsing bug that can
-// misreport this value, so tests that need a trustworthy number should read
-// it from the client pod's raw log via captureRsyncClientLog instead.
-func totalTransferredBytes(rsyncLog string) (int64, error) {
-	matched := totalTransferredBytesRegex.FindStringSubmatch(rsyncLog)
-	if len(matched) < 2 {
-		return 0, fmt.Errorf("could not find %q in rsync client log", "Total transferred file size")
+var byteUnitMultipliers = map[string]float64{
+	"": 1, "K": 1_000, "M": 1_000_000, "G": 1_000_000_000, "T": 1_000_000_000_000,
+}
+
+// literalDataBytes extracts rsync's own authoritative "Literal data" figure
+// from a raw rsync client log — the count of bytes actually sent because they
+// were new, as opposed to "Matched data" (bytes rsync found already present
+// on the receiver and reused instead of resending). This is the correct
+// metric for verifying an incremental sync; "Total transferred file size"
+// counts every file rsync touched regardless of whether its content was new.
+// crane's own progress display (cmd/transfer-pvc/progress.go) has a buffered-
+// line parsing bug that can misreport its stats, so tests that need a
+// trustworthy number should read them from the client pod's raw log via
+// captureRsyncClientLog instead.
+func literalDataBytes(rsyncLog string) (float64, error) {
+	matched := literalDataRegex.FindStringSubmatch(rsyncLog)
+	if len(matched) < 3 {
+		return 0, fmt.Errorf("could not find %q in rsync client log", "Literal data")
 	}
-	return strconv.ParseInt(strings.ReplaceAll(matched[1], ",", ""), 10, 64)
+	val, err := strconv.ParseFloat(strings.ReplaceAll(matched[1], ",", ""), 64)
+	if err != nil {
+		return 0, err
+	}
+	return val * byteUnitMultipliers[matched[2]], nil
 }
 
 // captureRsyncClientLog polls namespace for the ephemeral "rsync-client-*" pod

--- a/e2e-tests/tests/tier0/mta_898_stage_cutover_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_898_stage_cutover_migration_test.go
@@ -266,7 +266,7 @@ func literalDataBytes(rsyncLog string) (float64, error) {
 
 func captureRsyncClientLog(k KubectlRunner, namespace, pvcName string, result chan<- string) {
 	selector := fmt.Sprintf(
-		"app.kubernetes.io/component=transfer-pvc,app.konveyor.io/role=client,app.konveyor.io/created-for-pvc=%s",
+		"app.kubernetes.io/component=transfer-pvc,app.konveyor.io/created-for-pvc=%s",
 		pvcName,
 	)
 	deadline := time.Now().Add(180 * time.Second)

--- a/e2e-tests/tests/tier0/mta_898_stage_cutover_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_898_stage_cutover_migration_test.go
@@ -1,0 +1,333 @@
+package e2e
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	"github.com/konveyor/crane/e2e-tests/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	mta898RedisPassword = "PASSWORD"
+	// deltaBaselineKey holds a large, unchanging value so a genuine incremental
+	// sync (only the small stage1key addition) is trivially distinguishable from
+	// a full re-copy of the PVC.
+	deltaBaselineKey       = "delta-test-baseline"
+	deltaBaselineSizeBytes = 3_000_000
+)
+
+var _ = Describe("Stage and cutover migration flow", func() {
+	It("[MTA-898] Verify stage + cutover migration flow", Label("tier0", "pvc-transfer"), func() {
+		appName := "redis"
+		namespace := "mta-898-stage-cutover"
+
+		scenario := NewMigrationScenario(
+			appName,
+			namespace,
+			config.K8sDeployBin,
+			config.CraneBin,
+			config.SourceContext,
+			config.TargetContext,
+		)
+		srcApp := scenario.SrcApp
+		tgtApp := scenario.TgtApp
+		kubectlSrc := scenario.KubectlSrc
+		kubectlTgt := scenario.KubectlTgt
+
+		paths, err := NewScenarioPaths("crane-mta-898-*")
+		Expect(err).NotTo(HaveOccurred())
+		runner := scenario.Crane
+		runner.WorkDir = paths.TempDir
+		exportOpts := ExportOptions{Namespace: namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{TransformDir: paths.TransformDir, OutputDir: paths.OutputDir}
+
+		DeferCleanup(func() {
+			By("Cleanup source and target resources")
+			if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
+				log.Printf("cleanup: %v", err)
+			}
+		})
+
+		By("Deploy a source app with a PVC seeded with initial known data")
+		Expect(srcApp.Deploy()).NotTo(HaveOccurred())
+		Expect(srcApp.Validate()).NotTo(HaveOccurred())
+
+		srcPodName, err := GetPodNameByLabel(kubectlSrc, srcApp.Namespace, "name="+appName)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("List the PVC created by the source app")
+		pvcs, err := ListPVCs(srcApp.Namespace, "", srcApp.Context)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pvcs).To(HaveLen(1), "expected exactly one PVC in namespace %q", srcApp.Namespace)
+		pvcName := pvcs[0].Name
+
+		initial, err := redisGet(kubectlSrc, srcApp.Namespace, srcPodName, appName, "mytestkey")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(initial).To(ContainSubstring("Hello world"))
+
+		By("Seed a multi-MB baseline value so a genuine incremental sync is distinguishable from a full re-copy")
+		Expect(redisSetRandomBlob(kubectlSrc, srcApp.Namespace, srcPodName, appName, deltaBaselineKey, deltaBaselineSizeBytes)).NotTo(HaveOccurred())
+		Expect(redisSave(kubectlSrc, srcApp.Namespace, srcPodName, appName)).NotTo(HaveOccurred())
+		baselineLen, err := redisStrlen(kubectlSrc, srcApp.Namespace, srcPodName, appName, deltaBaselineKey)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(baselineLen).To(BeNumerically(">", int64(deltaBaselineSizeBytes)))
+
+		By("Create target namespace")
+		Expect(kubectlTgt.CreateNamespace(tgtApp.Namespace)).NotTo(HaveOccurred())
+
+		tgtIP, err := GetClusterNodeIP(tgtApp.Context)
+		Expect(err).NotTo(HaveOccurred())
+		transferOpts := TransferPVCOptions{
+			SourceContext:   srcApp.Context,
+			TargetContext:   tgtApp.Context,
+			PVCName:         pvcName,
+			PVCNamespaceMap: fmt.Sprintf("%s:%s", srcApp.Namespace, tgtApp.Namespace),
+			Subdomain:       fmt.Sprintf("%s.%s.%s.nip.io", pvcName, srcApp.Namespace, tgtIP),
+		}
+
+		By("Run the first stage transfer-pvc while the app is still running on source")
+		Expect(runner.TransferPVC(transferOpts)).NotTo(HaveOccurred())
+
+		By("Verify the source app is unaffected and still running after the stage sync")
+		srcPhase, err := kubectlSrc.Run("get", "pod", srcPodName, "-n", srcApp.Namespace, "-o", "jsonpath={.status.phase}")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(srcPhase).To(Equal("Running"))
+
+		By("Verify the initial data landed on target via a throwaway redis instance on the migrated PVC")
+		const verifierPod = "mta-898-redis-verifier"
+		Expect(deployRedisVerifier(kubectlTgt, tgtApp.Namespace, verifierPod, pvcName)).NotTo(HaveOccurred())
+		verifyValue, err := redisGet(kubectlTgt, tgtApp.Namespace, verifierPod, "redis", "mytestkey")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(verifyValue).To(Equal(initial))
+		Expect(deleteRedisVerifier(kubectlTgt, tgtApp.Namespace, verifierPod)).NotTo(HaveOccurred())
+
+		By("Insert new data on source while the app is still running")
+		Expect(redisSet(kubectlSrc, srcApp.Namespace, srcPodName, appName, "stage1key", "stage1-value")).NotTo(HaveOccurred())
+		Expect(redisSave(kubectlSrc, srcApp.Namespace, srcPodName, appName)).NotTo(HaveOccurred())
+
+		By("Verify the new data is present on source and the original data set is untouched")
+		stage1OnSource, err := redisGet(kubectlSrc, srcApp.Namespace, srcPodName, appName, "stage1key")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stage1OnSource).To(Equal("stage1-value"))
+		mytestkeyAfterInsert1, err := redisGet(kubectlSrc, srcApp.Namespace, srcPodName, appName, "mytestkey")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mytestkeyAfterInsert1).To(Equal(initial))
+
+		By("Run the second stage transfer-pvc while capturing the rsync client's raw log for delta verification")
+		rsyncLogCh := make(chan string, 1)
+		go captureRsyncClientLog(kubectlSrc, srcApp.Namespace, rsyncLogCh)
+		Expect(runner.TransferPVC(transferOpts)).NotTo(HaveOccurred())
+		rsyncLog := <-rsyncLogCh
+
+		By("Verify only the newly added data was transferred, not a full re-copy of the PVC")
+		transferredBytes, err := totalTransferredBytes(rsyncLog)
+		Expect(err).NotTo(HaveOccurred(), "expected to find rsync's stats summary in the client log:\n%s", rsyncLog)
+		Expect(transferredBytes).To(BeNumerically("<", int64(deltaBaselineSizeBytes)/10),
+			"second sync transferred %d bytes; expected well under the %d-byte baseline blob if only the new key was sent",
+			transferredBytes, deltaBaselineSizeBytes)
+
+		By("Verify no data is missing: both the initial and new keys are present on target")
+		Expect(deployRedisVerifier(kubectlTgt, tgtApp.Namespace, verifierPod, pvcName)).NotTo(HaveOccurred())
+		mytestkeyAfterStage2, err := redisGet(kubectlTgt, tgtApp.Namespace, verifierPod, "redis", "mytestkey")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mytestkeyAfterStage2).To(Equal(initial))
+		stage1ValueOnTarget, err := redisGet(kubectlTgt, tgtApp.Namespace, verifierPod, "redis", "stage1key")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stage1ValueOnTarget).To(Equal("stage1-value"))
+		Expect(deleteRedisVerifier(kubectlTgt, tgtApp.Namespace, verifierPod)).NotTo(HaveOccurred())
+
+		By("Insert a second new data set on source")
+		Expect(redisSet(kubectlSrc, srcApp.Namespace, srcPodName, appName, "stage2key", "stage2-value")).NotTo(HaveOccurred())
+		Expect(redisSave(kubectlSrc, srcApp.Namespace, srcPodName, appName)).NotTo(HaveOccurred())
+
+		By("Verify the second new data set is present on source and prior data is untouched")
+		stage2OnSource, err := redisGet(kubectlSrc, srcApp.Namespace, srcPodName, appName, "stage2key")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stage2OnSource).To(Equal("stage2-value"))
+		mytestkeyAfterInsert2, err := redisGet(kubectlSrc, srcApp.Namespace, srcPodName, appName, "mytestkey")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mytestkeyAfterInsert2).To(Equal(initial))
+		stage1AfterInsert2, err := redisGet(kubectlSrc, srcApp.Namespace, srcPodName, appName, "stage1key")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stage1AfterInsert2).To(Equal("stage1-value"))
+
+		By("Quiesce the source app for cutover")
+		Expect(kubectlSrc.ScaleDeploymentIfPresent(srcApp.Namespace, appName, 0)).NotTo(HaveOccurred())
+		WaitForSourceQuiesce(kubectlSrc, srcApp.Namespace, "name="+appName, appName)
+
+		By("Run the cutover pipeline in order: export, transform, final transfer-pvc sync, apply")
+		Expect(runner.Export(exportOpts)).NotTo(HaveOccurred())
+		Expect(runner.Transform(transformOpts)).NotTo(HaveOccurred())
+		Expect(runner.TransferPVC(transferOpts)).NotTo(HaveOccurred())
+		Expect(runner.Apply(applyOpts)).NotTo(HaveOccurred())
+
+		By("Verify rendered output excludes the PVC: it is migrated separately via transfer-pvc")
+		Expect(utils.AssertNoKindsInOutput(paths.OutputDir, []string{"PersistentVolumeClaim"})).NotTo(HaveOccurred())
+
+		By("Apply rendered manifests to target and scale the app back up")
+		Expect(ApplyOutputToTarget(kubectlTgt, tgtApp.Namespace, paths.OutputDir)).NotTo(HaveOccurred())
+		Expect(kubectlTgt.ScaleDeployment(tgtApp.Namespace, appName, 1)).NotTo(HaveOccurred())
+		Eventually(tgtApp.Validate, "5m", "10s").Should(Succeed())
+
+		By("Validate all data inserted throughout the test is present on target")
+		tgtPodName, err := GetPodNameByLabel(kubectlTgt, tgtApp.Namespace, "name="+appName)
+		Expect(err).NotTo(HaveOccurred())
+
+		finalMytestkey, err := redisGet(kubectlTgt, tgtApp.Namespace, tgtPodName, appName, "mytestkey")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(finalMytestkey).To(Equal(initial))
+
+		finalStage1, err := redisGet(kubectlTgt, tgtApp.Namespace, tgtPodName, appName, "stage1key")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(finalStage1).To(Equal("stage1-value"))
+
+		finalStage2, err := redisGet(kubectlTgt, tgtApp.Namespace, tgtPodName, appName, "stage2key")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(finalStage2).To(Equal("stage2-value"))
+
+		finalBaselineLen, err := redisStrlen(kubectlTgt, tgtApp.Namespace, tgtPodName, appName, deltaBaselineKey)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(finalBaselineLen).To(Equal(baselineLen))
+	})
+})
+
+// redisExec runs a redis-cli command against a container in the given pod,
+// stripping kubectl warning noise (e.g. the "-a" password warning) from the output.
+func redisExec(k KubectlRunner, namespace, pod, container string, args ...string) (string, error) {
+	cmdArgs := append([]string{"exec", pod, "-n", namespace, "-c", container, "--", "redis-cli", "-a", mta898RedisPassword}, args...)
+	out, err := k.Run(cmdArgs...)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(StripKubectlWarnings(out)), nil
+}
+
+func redisGet(k KubectlRunner, namespace, pod, container, key string) (string, error) {
+	return redisExec(k, namespace, pod, container, "get", key)
+}
+
+func redisSet(k KubectlRunner, namespace, pod, container, key, value string) error {
+	_, err := redisExec(k, namespace, pod, container, "set", key, value)
+	return err
+}
+
+func redisSave(k KubectlRunner, namespace, pod, container string) error {
+	_, err := redisExec(k, namespace, pod, container, "save")
+	return err
+}
+
+func redisStrlen(k KubectlRunner, namespace, pod, container, key string) (int64, error) {
+	out, err := redisExec(k, namespace, pod, container, "strlen", key)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseInt(out, 10, 64)
+}
+
+// redisSetRandomBlob generates sizeBytes of random data inside the pod itself
+// (avoiding passing large payloads through kubectl exec argv) and stores it,
+// base64-encoded, under key.
+func redisSetRandomBlob(k KubectlRunner, namespace, pod, container, key string, sizeBytes int) error {
+	shellCmd := fmt.Sprintf("head -c %d /dev/urandom | base64 | redis-cli -a %s -x set %s", sizeBytes, mta898RedisPassword, key)
+	_, err := k.Run("exec", pod, "-n", namespace, "-c", container, "--", "/bin/sh", "-c", shellCmd)
+	return err
+}
+
+// deployRedisVerifier starts a throwaway redis instance mounting the given PVC,
+// so its persisted data can be inspected directly with redis-cli. The migrated
+// PVC is ReadWriteOnce, so callers must delete this pod (deleteRedisVerifier)
+// before mounting the same PVC again (e.g. a subsequent transfer-pvc run).
+func deployRedisVerifier(k KubectlRunner, namespace, podName, pvcName string) error {
+	manifest := fmt.Sprintf(`apiVersion: v1
+kind: Pod
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  restartPolicy: Never
+  containers:
+  - name: redis
+    image: redis:latest
+    command: ["redis-server", "--requirepass", "%s"]
+    volumeMounts:
+    - name: data
+      mountPath: /data
+  volumes:
+  - name: data
+    persistentVolumeClaim:
+      claimName: %s
+`, podName, namespace, mta898RedisPassword, pvcName)
+	if err := k.ApplyYAMLSpec(manifest, namespace); err != nil {
+		return err
+	}
+	_, err := k.Run("wait", "--for=condition=Ready", "pod/"+podName, "-n", namespace, "--timeout=120s")
+	return err
+}
+
+func deleteRedisVerifier(k KubectlRunner, namespace, podName string) error {
+	_, err := k.Run("delete", "pod", podName, "-n", namespace, "--wait=true")
+	return err
+}
+
+var totalTransferredBytesRegex = regexp.MustCompile(`Total transferred file size: ([\d,]+) bytes`)
+
+// totalTransferredBytes extracts rsync's own authoritative "Total transferred
+// file size" from a raw rsync client log. crane's own progress display
+// (cmd/transfer-pvc/progress.go) has a buffered-line parsing bug that can
+// misreport this value, so tests that need a trustworthy number should read
+// it from the client pod's raw log via captureRsyncClientLog instead.
+func totalTransferredBytes(rsyncLog string) (int64, error) {
+	matched := totalTransferredBytesRegex.FindStringSubmatch(rsyncLog)
+	if len(matched) < 2 {
+		return 0, fmt.Errorf("could not find %q in rsync client log", "Total transferred file size")
+	}
+	return strconv.ParseInt(strings.ReplaceAll(matched[1], ",", ""), 10, 64)
+}
+
+// captureRsyncClientLog polls namespace for the ephemeral "rsync-client-*" pod
+// that transfer-pvc creates on the source cluster during a copy, and
+// continuously re-fetches its raw "rsync" container log. It sends the last
+// successfully captured log once the pod is cleaned up (the transfer
+// finished) or a generous deadline elapses, whichever comes first. Intended to
+// be started in a goroutine immediately before calling TransferPVC.
+func captureRsyncClientLog(k KubectlRunner, namespace string, result chan<- string) {
+	deadline := time.Now().Add(180 * time.Second)
+	var lastLog string
+	seenPod := false
+	for time.Now().Before(deadline) {
+		out, err := k.Run("get", "pods", "-n", namespace, "-o", "name")
+		if err != nil {
+			time.Sleep(300 * time.Millisecond)
+			continue
+		}
+		podName := ""
+		for _, line := range strings.Split(out, "\n") {
+			if strings.HasPrefix(line, "pod/rsync-client") {
+				podName = strings.TrimPrefix(line, "pod/")
+				break
+			}
+		}
+		if podName == "" {
+			if seenPod {
+				break
+			}
+			time.Sleep(300 * time.Millisecond)
+			continue
+		}
+		seenPod = true
+		if podLog, err := k.Run("logs", podName, "-n", namespace, "-c", "rsync"); err == nil && podLog != "" {
+			lastLog = podLog
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+	result <- lastLog
+}

--- a/e2e-tests/tests/tier0/mta_898_stage_cutover_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_898_stage_cutover_migration_test.go
@@ -286,7 +286,7 @@ func captureRsyncClientLog(k KubectlRunner, namespace, pvcName string, result ch
 		if podLog, err := k.Run("logs", podName, "-n", namespace, "-c", "rsync"); err == nil && podLog != "" {
 			lastLog = podLog
 		}
-		time.Sleep(300 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond)
 	}
 	if !seenPod {
 		result <- fmt.Sprintf("no rsync-client pod found in namespace %q (selector %q) within the capture window", namespace, selector)


### PR DESCRIPTION
Adds a tier0 e2e test covering the stage + cutover migration flow: repeated `crane transfer-pvc` runs while the app is still running (verifying incremental-only sync via rsync's own stats, not crane's progress display), followed by a full quiesce + export/transform/transfer-pvc/apply cutover with data-loss checks at each stage.

Closes #747

Draft while CI/Jenkins runs are validated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for staged and cutover migrations using Redis workloads.
  * Validates incremental data transfer, data preservation, final synchronization, and target readiness.
  * Added reusable support for deploying and cleaning up temporary Kubernetes verification pods.
  * Added checks for transfer progress, client logs, and migration behavior while the source remains active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->