### PR TITLE
:test_tube: added indirect migration e2e tests workflow

### DIFF
--- a/.github/actions/run-crane-e2e-tier/action.yml
+++ b/.github/actions/run-crane-e2e-tier/action.yml
@@ -45,6 +45,14 @@ inputs:
     description: Pass verbose logs flag to tests
     required: false
     default: "true"
+  cloud_storage:
+    description: S3-compatible cloud storage path for indirect transfer (e.g. remote:my-bucket)
+    required: false
+    default: ""
+  rclone_config_file:
+    description: Path to local rclone.conf file for indirect transfer
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -107,6 +115,13 @@ runs:
 
         if [ "${{ inputs.verbose_logs }}" = "true" ]; then
           GINKGO_ARGS+=(--verbose-logs)
+        fi
+
+        if [ -n "${{ inputs.cloud_storage }}" ]; then
+          GINKGO_ARGS+=(--cloud-storage="${{ inputs.cloud_storage }}")
+        fi
+        if [ -n "${{ inputs.rclone_config_file }}" ]; then
+          GINKGO_ARGS+=(--rclone-config-file="${{ inputs.rclone_config_file }}")
         fi
 
         ginkgo run -v -r --label-filter="${{ inputs.label_filter }}" e2e-tests/tests -- "${GINKGO_ARGS[@]}"

--- a/.github/actions/setup-indirect-minio/action.yml
+++ b/.github/actions/setup-indirect-minio/action.yml
@@ -1,0 +1,134 @@
+name: setup-indirect-minio
+description: Deploy MinIO on the source minikube cluster, create a bucket, and generate rclone config
+
+inputs:
+  source_context:
+    description: Kubectl context for the source cluster
+    required: false
+    default: src
+  minikube_profile:
+    description: Minikube profile name for the source cluster
+    required: false
+    default: src
+  bucket_name:
+    description: MinIO bucket name to create
+    required: false
+    default: crane-indirect-e2e
+  rclone_config_path:
+    description: Path to write the generated rclone.conf
+    required: false
+    default: /tmp/rclone-ci.conf
+
+outputs:
+  cloud_storage:
+    description: Cloud storage path for crane transfer-pvc (e.g. remote:bucket-name)
+    value: "remote:${{ inputs.bucket_name }}"
+  rclone_config_file:
+    description: Path to the generated rclone.conf file
+    value: ${{ inputs.rclone_config_path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Deploy MinIO on source cluster
+      shell: bash
+      env:
+        SRC_CTX: ${{ inputs.source_context }}
+      run: |
+        kubectl --context "$SRC_CTX" create namespace minio
+        cat <<'EOF' | kubectl --context "$SRC_CTX" apply -f -
+        apiVersion: v1
+        kind: PersistentVolumeClaim
+        metadata:
+          name: minio-data
+          namespace: minio
+        spec:
+          accessModes: [ReadWriteOnce]
+          resources:
+            requests:
+              storage: 2Gi
+        ---
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: minio
+          namespace: minio
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: minio
+          template:
+            metadata:
+              labels:
+                app: minio
+            spec:
+              containers:
+              - name: minio
+                image: quay.io/minio/minio:latest
+                command: ["minio", "server", "/data"]
+                ports:
+                - containerPort: 9000
+                env:
+                - name: MINIO_ROOT_USER
+                  value: minioadmin
+                - name: MINIO_ROOT_PASSWORD
+                  value: minioadmin
+                volumeMounts:
+                - name: data
+                  mountPath: /data
+              volumes:
+              - name: data
+                persistentVolumeClaim:
+                  claimName: minio-data
+        ---
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: minio
+          namespace: minio
+        spec:
+          type: NodePort
+          selector:
+            app: minio
+          ports:
+          - port: 9000
+            targetPort: 9000
+        EOF
+        kubectl --context "$SRC_CTX" wait --for=condition=Available deployment/minio -n minio --timeout=120s
+
+    - name: Create MinIO bucket
+      shell: bash
+      env:
+        SRC_CTX: ${{ inputs.source_context }}
+        PROFILE: ${{ inputs.minikube_profile }}
+        BUCKET: ${{ inputs.bucket_name }}
+      run: |
+        MINIO_IP=$(minikube ip -p "$PROFILE")
+        MINIO_PORT=$(kubectl --context "$SRC_CTX" get svc minio -n minio -o jsonpath='{.spec.ports[0].nodePort}')
+        kubectl --context "$SRC_CTX" run minio-setup --restart=Never \
+          --image=quay.io/minio/mc:latest \
+          --command -- sh -c "mc alias set local http://${MINIO_IP}:${MINIO_PORT} minioadmin minioadmin && mc mb local/${BUCKET} --ignore-existing"
+        kubectl --context "$SRC_CTX" wait --for=jsonpath='{.status.phase}'=Succeeded pod/minio-setup --timeout=120s
+        kubectl --context "$SRC_CTX" logs minio-setup
+        kubectl --context "$SRC_CTX" delete pod minio-setup --ignore-not-found
+
+    - name: Generate rclone config
+      shell: bash
+      env:
+        SRC_CTX: ${{ inputs.source_context }}
+        PROFILE: ${{ inputs.minikube_profile }}
+        CONFIG_PATH: ${{ inputs.rclone_config_path }}
+      run: |
+        MINIO_IP=$(minikube ip -p "$PROFILE")
+        MINIO_PORT=$(kubectl --context "$SRC_CTX" get svc minio -n minio -o jsonpath='{.spec.ports[0].nodePort}')
+        cat > "$CONFIG_PATH" <<EOF
+        [remote]
+        type = s3
+        provider = Minio
+        access_key_id = minioadmin
+        secret_access_key = minioadmin
+        endpoint = http://${MINIO_IP}:${MINIO_PORT}
+        EOF
+        echo "MinIO endpoint: http://${MINIO_IP}:${MINIO_PORT}"
+        echo "rclone config: ${CONFIG_PATH}"

--- a/.github/workflows/e2e-indirect-pr-tester.yaml
+++ b/.github/workflows/e2e-indirect-pr-tester.yaml
@@ -111,11 +111,16 @@ jobs:
           echo "focus_file_regex=$FOCUS_FILE_REGEX" >> "$GITHUB_OUTPUT"
 
       - name: Print execution plan
+        env:
+          RUN_MODE: ${{ steps.changed_tests.outputs.run_mode }}
+          FULL_REASON: ${{ steps.changed_tests.outputs.full_reason }}
+          TEST_PATHS: ${{ steps.changed_tests.outputs.test_paths }}
+          FOCUS_FILE_REGEX: ${{ steps.changed_tests.outputs.focus_file_regex }}
         run: |
-          echo "Run mode: ${{ steps.changed_tests.outputs.run_mode }}"
-          echo "Full reason: ${{ steps.changed_tests.outputs.full_reason }}"
+          echo "Run mode: $RUN_MODE"
+          echo "Full reason: $FULL_REASON"
           echo "Transfer mode: INDIRECT (via MinIO)"
-          case "${{ steps.changed_tests.outputs.full_reason }}" in
+          case "$FULL_REASON" in
             outside_e2e)
               echo "Running full suite in parallel: tier0 + tier1 (indirect)"
               echo "Reason: changes outside e2e-tests/ (crane or repo paths)"
@@ -125,8 +130,8 @@ jobs:
               echo "Reason: impactful non-test file(s) or suite bootstrap changed under e2e-tests/"
               ;;
             focused)
-              echo "Running touched tests (indirect): ${{ steps.changed_tests.outputs.test_paths }}"
-              echo "Using focus-file regex: ${{ steps.changed_tests.outputs.focus_file_regex }}"
+              echo "Running touched tests (indirect): $TEST_PATHS"
+              echo "Using focus-file regex: $FOCUS_FILE_REGEX"
               ;;
             *)
               echo "Skipping E2E run (no applicable changes)."
@@ -240,7 +245,7 @@ jobs:
           kubectl --context src run minio-setup --restart=Never \
             --image=quay.io/minio/mc:latest \
             --command -- sh -c "mc alias set local http://${MINIO_IP}:${MINIO_PORT} minioadmin minioadmin && mc mb local/crane-indirect-e2e --ignore-existing"
-          sleep 15
+          kubectl --context src wait --for=jsonpath='{.status.phase}'=Succeeded pod/minio-setup --timeout=120s
           kubectl --context src logs minio-setup
           kubectl --context src delete pod minio-setup --ignore-not-found
 
@@ -393,7 +398,7 @@ jobs:
           kubectl --context src run minio-setup --restart=Never \
             --image=quay.io/minio/mc:latest \
             --command -- sh -c "mc alias set local http://${MINIO_IP}:${MINIO_PORT} minioadmin minioadmin && mc mb local/crane-indirect-e2e --ignore-existing"
-          sleep 15
+          kubectl --context src wait --for=jsonpath='{.status.phase}'=Succeeded pod/minio-setup --timeout=120s
           kubectl --context src logs minio-setup
           kubectl --context src delete pod minio-setup --ignore-not-found
 
@@ -550,7 +555,7 @@ jobs:
           kubectl --context src run minio-setup --restart=Never \
             --image=quay.io/minio/mc:latest \
             --command -- sh -c "mc alias set local http://${MINIO_IP}:${MINIO_PORT} minioadmin minioadmin && mc mb local/crane-indirect-e2e --ignore-existing"
-          sleep 15
+          kubectl --context src wait --for=jsonpath='{.status.phase}'=Succeeded pod/minio-setup --timeout=120s
           kubectl --context src logs minio-setup
           kubectl --context src delete pod minio-setup --ignore-not-found
 
@@ -630,12 +635,17 @@ jobs:
       contents: read
     steps:
       - name: Aggregate E2E results (indirect)
+        env:
+          RUN_MODE: ${{ needs.detect-changes.outputs.run_mode }}
+          TIER0_RESULT: ${{ needs.e2e-indirect-tier0.result }}
+          TIER1_RESULT: ${{ needs.e2e-indirect-tier1.result }}
+          FOCUSED_RESULT: ${{ needs.e2e-indirect-focused.result }}
         run: |
           set -euo pipefail
-          run_mode="${{ needs.detect-changes.outputs.run_mode }}"
-          tier0_result="${{ needs.e2e-indirect-tier0.result }}"
-          tier1_result="${{ needs.e2e-indirect-tier1.result }}"
-          focused_result="${{ needs.e2e-indirect-focused.result }}"
+          run_mode="$RUN_MODE"
+          tier0_result="$TIER0_RESULT"
+          tier1_result="$TIER1_RESULT"
+          focused_result="$FOCUSED_RESULT"
 
           echo "run_mode=${run_mode}"
           echo "e2e-indirect-tier0=${tier0_result}"

--- a/.github/workflows/e2e-indirect-pr-tester.yaml
+++ b/.github/workflows/e2e-indirect-pr-tester.yaml
@@ -1,0 +1,664 @@
+name: E2E Tests PR Tester (Indirect Migration)
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: e2e-indirect-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  detect-changes:
+    permissions:
+      contents: read
+    runs-on: ubuntu-22.04
+    outputs:
+      run_tests: ${{ steps.changed_tests.outputs.run_tests }}
+      run_mode: ${{ steps.changed_tests.outputs.run_mode }}
+      test_paths: ${{ steps.changed_tests.outputs.test_paths }}
+      focus_file_regex: ${{ steps.changed_tests.outputs.focus_file_regex }}
+      full_reason: ${{ steps.changed_tests.outputs.full_reason }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect touched e2e test files
+        id: changed_tests
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          ALL_CHANGED="$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA")"
+
+          has_outside_e2e=false
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            case "$file" in
+              e2e-tests/*|.github/*|docs/*|README.md) ;;
+              *) has_outside_e2e=true; break ;;
+            esac
+          done <<EOF
+          $ALL_CHANGED
+          EOF
+
+          if [ "$has_outside_e2e" = "true" ]; then
+            echo "run_tests=true" >> "$GITHUB_OUTPUT"
+            echo "run_mode=all" >> "$GITHUB_OUTPUT"
+            echo "full_reason=outside_e2e" >> "$GITHUB_OUTPUT"
+            echo "test_paths=" >> "$GITHUB_OUTPUT"
+            echo "focus_file_regex=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          CHANGED_E2E_FILES="$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA" -- e2e-tests/)"
+
+          if [ -z "$CHANGED_E2E_FILES" ]; then
+            echo "run_tests=false" >> "$GITHUB_OUTPUT"
+            echo "run_mode=none" >> "$GITHUB_OUTPUT"
+            echo "full_reason=skip" >> "$GITHUB_OUTPUT"
+            echo "test_paths=" >> "$GITHUB_OUTPUT"
+            echo "focus_file_regex=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          has_tests=false
+          has_impactful_non_test=false
+          suite_file_changed=false
+          test_files=""
+
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            case "$file" in
+              e2e-tests/tests/tier0/*_test.go|e2e-tests/tests/tier1/*_test.go)
+                has_tests=true
+                test_files="${test_files}${file}"$'\n'
+                if [ "$file" = "e2e-tests/tests/tier0/e2e_suite_test.go" ] || [ "$file" = "e2e-tests/tests/tier1/e2e_suite_test.go" ]; then
+                  suite_file_changed=true
+                fi
+                ;;
+              e2e-tests/framework/*|e2e-tests/config/*|e2e-tests/utils/*|e2e-tests/testdata/*|e2e-tests/tests/*)
+                has_impactful_non_test=true
+                ;;
+            esac
+          done <<EOF
+          $CHANGED_E2E_FILES
+          EOF
+
+          if [ "$has_tests" = "false" ] && [ "$has_impactful_non_test" = "false" ]; then
+            echo "run_tests=false" >> "$GITHUB_OUTPUT"
+            echo "run_mode=none" >> "$GITHUB_OUTPUT"
+            echo "full_reason=skip" >> "$GITHUB_OUTPUT"
+            echo "test_paths=" >> "$GITHUB_OUTPUT"
+            echo "focus_file_regex=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          TEST_PATHS="$(printf '%s' "$test_files" | sort -u | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+          FOCUS_FILE_REGEX="$(printf '%s' "$test_files" | sort -u | sed -E 's/[][(){}.^$*+?|\\]/\\&/g' | paste -sd'|' -)"
+
+          if [ "$has_impactful_non_test" = "true" ] || [ "$suite_file_changed" = "true" ] || [ "$has_tests" = "false" ]; then
+            echo "run_mode=all" >> "$GITHUB_OUTPUT"
+            echo "full_reason=e2e_impact" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_mode=focused" >> "$GITHUB_OUTPUT"
+            echo "full_reason=focused" >> "$GITHUB_OUTPUT"
+          fi
+          echo "run_tests=true" >> "$GITHUB_OUTPUT"
+          echo "test_paths=$TEST_PATHS" >> "$GITHUB_OUTPUT"
+          echo "focus_file_regex=$FOCUS_FILE_REGEX" >> "$GITHUB_OUTPUT"
+
+      - name: Print execution plan
+        run: |
+          echo "Run mode: ${{ steps.changed_tests.outputs.run_mode }}"
+          echo "Full reason: ${{ steps.changed_tests.outputs.full_reason }}"
+          echo "Transfer mode: INDIRECT (via MinIO)"
+          case "${{ steps.changed_tests.outputs.full_reason }}" in
+            outside_e2e)
+              echo "Running full suite in parallel: tier0 + tier1 (indirect)"
+              echo "Reason: changes outside e2e-tests/ (crane or repo paths)"
+              ;;
+            e2e_impact)
+              echo "Running full suite in parallel: tier0 + tier1 (indirect)"
+              echo "Reason: impactful non-test file(s) or suite bootstrap changed under e2e-tests/"
+              ;;
+            focused)
+              echo "Running touched tests (indirect): ${{ steps.changed_tests.outputs.test_paths }}"
+              echo "Using focus-file regex: ${{ steps.changed_tests.outputs.focus_file_regex }}"
+              ;;
+            *)
+              echo "Skipping E2E run (no applicable changes)."
+              ;;
+          esac
+
+  # Setup MinIO and generate rclone config (shared by tier jobs)
+  setup-minio:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.run_tests == 'true'
+    permissions:
+      contents: read
+    runs-on: ubuntu-22.04
+    outputs:
+      rclone_config: ${{ steps.minio.outputs.rclone_config }}
+    steps:
+      - name: Generate MinIO config reference
+        id: minio
+        run: |
+          echo "rclone_config=generated-at-runtime" >> "$GITHUB_OUTPUT"
+
+  # Full suite: run tier0 and tier1 in parallel with indirect transfer
+  e2e-indirect-tier0:
+    needs: [detect-changes, setup-minio]
+    if: needs.detect-changes.outputs.run_tests == 'true' && needs.detect-changes.outputs.run_mode == 'all'
+    permissions:
+      contents: read
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup minikube clusters
+        uses: ./.github/actions/setup-minikube-clusters
+        with:
+          cpus: max
+          memory: "8192"
+          create_users: "true"
+          src_user: "dev"
+          tgt_user: "dev"
+
+      - name: Deploy MinIO on source cluster
+        run: |
+          kubectl --context src create namespace minio
+          cat <<'MINIO_EOF' | kubectl --context src apply -f -
+          apiVersion: v1
+          kind: PersistentVolumeClaim
+          metadata:
+            name: minio-data
+            namespace: minio
+          spec:
+            accessModes: [ReadWriteOnce]
+            resources:
+              requests:
+                storage: 2Gi
+          ---
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: minio
+            namespace: minio
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app: minio
+            template:
+              metadata:
+                labels:
+                  app: minio
+              spec:
+                containers:
+                - name: minio
+                  image: quay.io/minio/minio:latest
+                  command: ["minio", "server", "/data"]
+                  ports:
+                  - containerPort: 9000
+                  env:
+                  - name: MINIO_ROOT_USER
+                    value: minioadmin
+                  - name: MINIO_ROOT_PASSWORD
+                    value: minioadmin
+                  volumeMounts:
+                  - name: data
+                    mountPath: /data
+                volumes:
+                - name: data
+                  persistentVolumeClaim:
+                    claimName: minio-data
+          ---
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: minio
+            namespace: minio
+          spec:
+            type: NodePort
+            selector:
+              app: minio
+            ports:
+            - port: 9000
+              targetPort: 9000
+          MINIO_EOF
+          kubectl --context src wait --for=condition=Available deployment/minio -n minio --timeout=120s
+
+      - name: Create MinIO bucket
+        run: |
+          MINIO_IP=$(minikube ip -p src)
+          MINIO_PORT=$(kubectl --context src get svc minio -n minio -o jsonpath='{.spec.ports[0].nodePort}')
+          kubectl --context src run minio-setup --restart=Never \
+            --image=quay.io/minio/mc:latest \
+            --command -- sh -c "mc alias set local http://${MINIO_IP}:${MINIO_PORT} minioadmin minioadmin && mc mb local/crane-indirect-e2e --ignore-existing"
+          sleep 15
+          kubectl --context src logs minio-setup
+          kubectl --context src delete pod minio-setup --ignore-not-found
+
+      - name: Generate rclone config
+        run: |
+          MINIO_IP=$(minikube ip -p src)
+          MINIO_PORT=$(kubectl --context src get svc minio -n minio -o jsonpath='{.spec.ports[0].nodePort}')
+          cat > /tmp/rclone-ci.conf <<RCLONE_EOF
+          [remote]
+          type = s3
+          provider = Minio
+          access_key_id = minioadmin
+          secret_access_key = minioadmin
+          endpoint = http://${MINIO_IP}:${MINIO_PORT}
+          RCLONE_EOF
+          echo "MinIO endpoint: http://${MINIO_IP}:${MINIO_PORT}"
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Clone k8s-apps-deployer
+        run: git clone https://github.com/stillalearner/k8s-apps-deployer.git
+
+      - name: Create venv and install package
+        run: |
+          cd k8s-apps-deployer
+          python3 -m venv venv
+          echo "$PWD/venv/bin" >> $GITHUB_PATH
+          ./venv/bin/pip install --upgrade pip
+          ./venv/bin/pip install -e .
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install Ginkgo CLI
+        run: |
+          GINKGO_VERSION="$(go list -m -f '{{.Version}}' github.com/onsi/ginkgo/v2)"
+          go install "github.com/onsi/ginkgo/v2/ginkgo@$GINKGO_VERSION"
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+          ginkgo version
+
+      - name: Build crane CLI
+        run: go build -o crane .
+
+      - name: Run tier0 e2e tests (indirect)
+        run: |
+          ginkgo run -v -r --label-filter="tier0" e2e-tests/tests -- \
+            --k8sdeploy-bin=k8sdeploy \
+            --crane-bin=${{ github.workspace }}/crane \
+            --source-context=src \
+            --target-context=tgt \
+            --source-nonadmin-context=src-dev \
+            --target-nonadmin-context=tgt-dev \
+            --verbose-logs \
+            --cloud-storage="remote:crane-indirect-e2e" \
+            --rclone-config-file=/tmp/rclone-ci.conf
+
+  e2e-indirect-tier1:
+    needs: [detect-changes, setup-minio]
+    if: needs.detect-changes.outputs.run_tests == 'true' && needs.detect-changes.outputs.run_mode == 'all'
+    permissions:
+      contents: read
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup minikube clusters
+        uses: ./.github/actions/setup-minikube-clusters
+        with:
+          cpus: max
+          memory: "8192"
+          create_users: "true"
+          src_user: "dev"
+          tgt_user: "dev"
+
+      - name: Deploy MinIO on source cluster
+        run: |
+          kubectl --context src create namespace minio
+          cat <<'MINIO_EOF' | kubectl --context src apply -f -
+          apiVersion: v1
+          kind: PersistentVolumeClaim
+          metadata:
+            name: minio-data
+            namespace: minio
+          spec:
+            accessModes: [ReadWriteOnce]
+            resources:
+              requests:
+                storage: 2Gi
+          ---
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: minio
+            namespace: minio
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app: minio
+            template:
+              metadata:
+                labels:
+                  app: minio
+              spec:
+                containers:
+                - name: minio
+                  image: quay.io/minio/minio:latest
+                  command: ["minio", "server", "/data"]
+                  ports:
+                  - containerPort: 9000
+                  env:
+                  - name: MINIO_ROOT_USER
+                    value: minioadmin
+                  - name: MINIO_ROOT_PASSWORD
+                    value: minioadmin
+                  volumeMounts:
+                  - name: data
+                    mountPath: /data
+                volumes:
+                - name: data
+                  persistentVolumeClaim:
+                    claimName: minio-data
+          ---
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: minio
+            namespace: minio
+          spec:
+            type: NodePort
+            selector:
+              app: minio
+            ports:
+            - port: 9000
+              targetPort: 9000
+          MINIO_EOF
+          kubectl --context src wait --for=condition=Available deployment/minio -n minio --timeout=120s
+
+      - name: Create MinIO bucket
+        run: |
+          MINIO_IP=$(minikube ip -p src)
+          MINIO_PORT=$(kubectl --context src get svc minio -n minio -o jsonpath='{.spec.ports[0].nodePort}')
+          kubectl --context src run minio-setup --restart=Never \
+            --image=quay.io/minio/mc:latest \
+            --command -- sh -c "mc alias set local http://${MINIO_IP}:${MINIO_PORT} minioadmin minioadmin && mc mb local/crane-indirect-e2e --ignore-existing"
+          sleep 15
+          kubectl --context src logs minio-setup
+          kubectl --context src delete pod minio-setup --ignore-not-found
+
+      - name: Generate rclone config
+        run: |
+          MINIO_IP=$(minikube ip -p src)
+          MINIO_PORT=$(kubectl --context src get svc minio -n minio -o jsonpath='{.spec.ports[0].nodePort}')
+          cat > /tmp/rclone-ci.conf <<RCLONE_EOF
+          [remote]
+          type = s3
+          provider = Minio
+          access_key_id = minioadmin
+          secret_access_key = minioadmin
+          endpoint = http://${MINIO_IP}:${MINIO_PORT}
+          RCLONE_EOF
+          echo "MinIO endpoint: http://${MINIO_IP}:${MINIO_PORT}"
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Clone k8s-apps-deployer
+        run: git clone https://github.com/stillalearner/k8s-apps-deployer.git
+
+      - name: Create venv and install package
+        run: |
+          cd k8s-apps-deployer
+          python3 -m venv venv
+          echo "$PWD/venv/bin" >> $GITHUB_PATH
+          ./venv/bin/pip install --upgrade pip
+          ./venv/bin/pip install -e .
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install Ginkgo CLI
+        run: |
+          GINKGO_VERSION="$(go list -m -f '{{.Version}}' github.com/onsi/ginkgo/v2)"
+          go install "github.com/onsi/ginkgo/v2/ginkgo@$GINKGO_VERSION"
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+          ginkgo version
+
+      - name: Build crane CLI
+        run: go build -o crane .
+
+      - name: Run tier1 e2e tests (indirect)
+        run: |
+          ginkgo run -v -r --label-filter="tier1" e2e-tests/tests -- \
+            --k8sdeploy-bin=k8sdeploy \
+            --crane-bin=${{ github.workspace }}/crane \
+            --source-context=src \
+            --target-context=tgt \
+            --source-nonadmin-context=src-dev \
+            --target-nonadmin-context=tgt-dev \
+            --verbose-logs \
+            --cloud-storage="remote:crane-indirect-e2e" \
+            --rclone-config-file=/tmp/rclone-ci.conf
+
+  # Focused mode: only touched test files with indirect transfer
+  e2e-indirect-focused:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.run_tests == 'true' && needs.detect-changes.outputs.run_mode == 'focused'
+    permissions:
+      contents: read
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      CRANE_BIN: ${{ github.workspace }}/crane
+      E2E_SUITE_DIR: e2e-tests/tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup minikube clusters
+        uses: ./.github/actions/setup-minikube-clusters
+        with:
+          cpus: max
+          memory: "8192"
+          create_users: "true"
+          src_user: "dev"
+          tgt_user: "dev"
+
+      - name: Deploy MinIO on source cluster
+        run: |
+          kubectl --context src create namespace minio
+          cat <<'MINIO_EOF' | kubectl --context src apply -f -
+          apiVersion: v1
+          kind: PersistentVolumeClaim
+          metadata:
+            name: minio-data
+            namespace: minio
+          spec:
+            accessModes: [ReadWriteOnce]
+            resources:
+              requests:
+                storage: 2Gi
+          ---
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: minio
+            namespace: minio
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app: minio
+            template:
+              metadata:
+                labels:
+                  app: minio
+              spec:
+                containers:
+                - name: minio
+                  image: quay.io/minio/minio:latest
+                  command: ["minio", "server", "/data"]
+                  ports:
+                  - containerPort: 9000
+                  env:
+                  - name: MINIO_ROOT_USER
+                    value: minioadmin
+                  - name: MINIO_ROOT_PASSWORD
+                    value: minioadmin
+                  volumeMounts:
+                  - name: data
+                    mountPath: /data
+                volumes:
+                - name: data
+                  persistentVolumeClaim:
+                    claimName: minio-data
+          ---
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: minio
+            namespace: minio
+          spec:
+            type: NodePort
+            selector:
+              app: minio
+            ports:
+            - port: 9000
+              targetPort: 9000
+          MINIO_EOF
+          kubectl --context src wait --for=condition=Available deployment/minio -n minio --timeout=120s
+
+      - name: Create MinIO bucket
+        run: |
+          MINIO_IP=$(minikube ip -p src)
+          MINIO_PORT=$(kubectl --context src get svc minio -n minio -o jsonpath='{.spec.ports[0].nodePort}')
+          kubectl --context src run minio-setup --restart=Never \
+            --image=quay.io/minio/mc:latest \
+            --command -- sh -c "mc alias set local http://${MINIO_IP}:${MINIO_PORT} minioadmin minioadmin && mc mb local/crane-indirect-e2e --ignore-existing"
+          sleep 15
+          kubectl --context src logs minio-setup
+          kubectl --context src delete pod minio-setup --ignore-not-found
+
+      - name: Generate rclone config
+        run: |
+          MINIO_IP=$(minikube ip -p src)
+          MINIO_PORT=$(kubectl --context src get svc minio -n minio -o jsonpath='{.spec.ports[0].nodePort}')
+          cat > /tmp/rclone-ci.conf <<RCLONE_EOF
+          [remote]
+          type = s3
+          provider = Minio
+          access_key_id = minioadmin
+          secret_access_key = minioadmin
+          endpoint = http://${MINIO_IP}:${MINIO_PORT}
+          RCLONE_EOF
+          echo "MinIO endpoint: http://${MINIO_IP}:${MINIO_PORT}"
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Clone k8s-apps-deployer
+        run: git clone https://github.com/stillalearner/k8s-apps-deployer.git
+
+      - name: Create venv and install package
+        run: |
+          cd k8s-apps-deployer
+          python3 -m venv venv
+          echo "$PWD/venv/bin" >> $GITHUB_PATH
+          ./venv/bin/pip install --upgrade pip
+          ./venv/bin/pip install -e .
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install Ginkgo CLI
+        run: |
+          GINKGO_VERSION="$(go list -m -f '{{.Version}}' github.com/onsi/ginkgo/v2)"
+          go install "github.com/onsi/ginkgo/v2/ginkgo@$GINKGO_VERSION"
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+          ginkgo version
+
+      - name: Build crane CLI
+        run: go build -o "$CRANE_BIN" .
+
+      - name: Run touched crane e2e tests (indirect)
+        env:
+          FOCUS_FILE_REGEX: ${{ needs.detect-changes.outputs.focus_file_regex }}
+        run: |
+          ginkgo run -v -r --focus-file="$FOCUS_FILE_REGEX" "$E2E_SUITE_DIR" -- \
+            --k8sdeploy-bin=k8sdeploy \
+            --crane-bin=$CRANE_BIN \
+            --source-context=src \
+            --target-context=tgt \
+            --source-nonadmin-context=src-dev \
+            --target-nonadmin-context=tgt-dev \
+            --verbose-logs \
+            --cloud-storage="remote:crane-indirect-e2e" \
+            --rclone-config-file=/tmp/rclone-ci.conf
+
+  # Aggregator job for PR status check
+  run-indirect-e2e-tests:
+    needs:
+      - detect-changes
+      - e2e-indirect-tier0
+      - e2e-indirect-tier1
+      - e2e-indirect-focused
+    if: |
+      always() &&
+      needs.detect-changes.result == 'success' &&
+      needs.detect-changes.outputs.run_tests == 'true'
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    steps:
+      - name: Aggregate E2E results (indirect)
+        run: |
+          set -euo pipefail
+          run_mode="${{ needs.detect-changes.outputs.run_mode }}"
+          tier0_result="${{ needs.e2e-indirect-tier0.result }}"
+          tier1_result="${{ needs.e2e-indirect-tier1.result }}"
+          focused_result="${{ needs.e2e-indirect-focused.result }}"
+
+          echo "run_mode=${run_mode}"
+          echo "e2e-indirect-tier0=${tier0_result}"
+          echo "e2e-indirect-tier1=${tier1_result}"
+          echo "e2e-indirect-focused=${focused_result}"
+
+          if [ "$run_mode" = "all" ]; then
+            if [ "$tier0_result" != "success" ] || [ "$tier1_result" != "success" ]; then
+              echo "::error::Indirect E2E failed (tier0=${tier0_result}, tier1=${tier1_result})."
+              exit 1
+            fi
+            echo "Indirect E2E passed (tier0 + tier1)."
+            exit 0
+          fi
+
+          if [ "$run_mode" = "focused" ]; then
+            if [ "$focused_result" != "success" ]; then
+              echo "::error::Indirect focused E2E failed (e2e-indirect-focused=${focused_result})."
+              exit 1
+            fi
+            echo "Indirect focused E2E passed."
+            exit 0
+          fi
+
+          echo "::error::Unexpected run_mode=${run_mode}."
+          exit 1

--- a/.github/workflows/e2e-indirect-pr-tester.yaml
+++ b/.github/workflows/e2e-indirect-pr-tester.yaml
@@ -138,24 +138,9 @@ jobs:
               ;;
           esac
 
-  # Setup MinIO and generate rclone config (shared by tier jobs)
-  setup-minio:
-    needs: detect-changes
-    if: needs.detect-changes.outputs.run_tests == 'true'
-    permissions:
-      contents: read
-    runs-on: ubuntu-22.04
-    outputs:
-      rclone_config: ${{ steps.minio.outputs.rclone_config }}
-    steps:
-      - name: Generate MinIO config reference
-        id: minio
-        run: |
-          echo "rclone_config=generated-at-runtime" >> "$GITHUB_OUTPUT"
-
   # Full suite: run tier0 and tier1 in parallel with indirect transfer
   e2e-indirect-tier0:
-    needs: [detect-changes, setup-minio]
+    needs: detect-changes
     if: needs.detect-changes.outputs.run_tests == 'true' && needs.detect-changes.outputs.run_mode == 'all'
     permissions:
       contents: read
@@ -174,94 +159,8 @@ jobs:
           src_user: "dev"
           tgt_user: "dev"
 
-      - name: Deploy MinIO on source cluster
-        run: |
-          kubectl --context src create namespace minio
-          cat <<'MINIO_EOF' | kubectl --context src apply -f -
-          apiVersion: v1
-          kind: PersistentVolumeClaim
-          metadata:
-            name: minio-data
-            namespace: minio
-          spec:
-            accessModes: [ReadWriteOnce]
-            resources:
-              requests:
-                storage: 2Gi
-          ---
-          apiVersion: apps/v1
-          kind: Deployment
-          metadata:
-            name: minio
-            namespace: minio
-          spec:
-            replicas: 1
-            selector:
-              matchLabels:
-                app: minio
-            template:
-              metadata:
-                labels:
-                  app: minio
-              spec:
-                containers:
-                - name: minio
-                  image: quay.io/minio/minio:latest
-                  command: ["minio", "server", "/data"]
-                  ports:
-                  - containerPort: 9000
-                  env:
-                  - name: MINIO_ROOT_USER
-                    value: minioadmin
-                  - name: MINIO_ROOT_PASSWORD
-                    value: minioadmin
-                  volumeMounts:
-                  - name: data
-                    mountPath: /data
-                volumes:
-                - name: data
-                  persistentVolumeClaim:
-                    claimName: minio-data
-          ---
-          apiVersion: v1
-          kind: Service
-          metadata:
-            name: minio
-            namespace: minio
-          spec:
-            type: NodePort
-            selector:
-              app: minio
-            ports:
-            - port: 9000
-              targetPort: 9000
-          MINIO_EOF
-          kubectl --context src wait --for=condition=Available deployment/minio -n minio --timeout=120s
-
-      - name: Create MinIO bucket
-        run: |
-          MINIO_IP=$(minikube ip -p src)
-          MINIO_PORT=$(kubectl --context src get svc minio -n minio -o jsonpath='{.spec.ports[0].nodePort}')
-          kubectl --context src run minio-setup --restart=Never \
-            --image=quay.io/minio/mc:latest \
-            --command -- sh -c "mc alias set local http://${MINIO_IP}:${MINIO_PORT} minioadmin minioadmin && mc mb local/crane-indirect-e2e --ignore-existing"
-          kubectl --context src wait --for=jsonpath='{.status.phase}'=Succeeded pod/minio-setup --timeout=120s
-          kubectl --context src logs minio-setup
-          kubectl --context src delete pod minio-setup --ignore-not-found
-
-      - name: Generate rclone config
-        run: |
-          MINIO_IP=$(minikube ip -p src)
-          MINIO_PORT=$(kubectl --context src get svc minio -n minio -o jsonpath='{.spec.ports[0].nodePort}')
-          cat > /tmp/rclone-ci.conf <<RCLONE_EOF
-          [remote]
-          type = s3
-          provider = Minio
-          access_key_id = minioadmin
-          secret_access_key = minioadmin
-          endpoint = http://${MINIO_IP}:${MINIO_PORT}
-          RCLONE_EOF
-          echo "MinIO endpoint: http://${MINIO_IP}:${MINIO_PORT}"
+      - name: Setup MinIO for indirect transfer
+        uses: ./.github/actions/setup-indirect-minio
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -308,7 +207,7 @@ jobs:
             --rclone-config-file=/tmp/rclone-ci.conf
 
   e2e-indirect-tier1:
-    needs: [detect-changes, setup-minio]
+    needs: detect-changes
     if: needs.detect-changes.outputs.run_tests == 'true' && needs.detect-changes.outputs.run_mode == 'all'
     permissions:
       contents: read
@@ -327,94 +226,8 @@ jobs:
           src_user: "dev"
           tgt_user: "dev"
 
-      - name: Deploy MinIO on source cluster
-        run: |
-          kubectl --context src create namespace minio
-          cat <<'MINIO_EOF' | kubectl --context src apply -f -
-          apiVersion: v1
-          kind: PersistentVolumeClaim
-          metadata:
-            name: minio-data
-            namespace: minio
-          spec:
-            accessModes: [ReadWriteOnce]
-            resources:
-              requests:
-                storage: 2Gi
-          ---
-          apiVersion: apps/v1
-          kind: Deployment
-          metadata:
-            name: minio
-            namespace: minio
-          spec:
-            replicas: 1
-            selector:
-              matchLabels:
-                app: minio
-            template:
-              metadata:
-                labels:
-                  app: minio
-              spec:
-                containers:
-                - name: minio
-                  image: quay.io/minio/minio:latest
-                  command: ["minio", "server", "/data"]
-                  ports:
-                  - containerPort: 9000
-                  env:
-                  - name: MINIO_ROOT_USER
-                    value: minioadmin
-                  - name: MINIO_ROOT_PASSWORD
-                    value: minioadmin
-                  volumeMounts:
-                  - name: data
-                    mountPath: /data
-                volumes:
-                - name: data
-                  persistentVolumeClaim:
-                    claimName: minio-data
-          ---
-          apiVersion: v1
-          kind: Service
-          metadata:
-            name: minio
-            namespace: minio
-          spec:
-            type: NodePort
-            selector:
-              app: minio
-            ports:
-            - port: 9000
-              targetPort: 9000
-          MINIO_EOF
-          kubectl --context src wait --for=condition=Available deployment/minio -n minio --timeout=120s
-
-      - name: Create MinIO bucket
-        run: |
-          MINIO_IP=$(minikube ip -p src)
-          MINIO_PORT=$(kubectl --context src get svc minio -n minio -o jsonpath='{.spec.ports[0].nodePort}')
-          kubectl --context src run minio-setup --restart=Never \
-            --image=quay.io/minio/mc:latest \
-            --command -- sh -c "mc alias set local http://${MINIO_IP}:${MINIO_PORT} minioadmin minioadmin && mc mb local/crane-indirect-e2e --ignore-existing"
-          kubectl --context src wait --for=jsonpath='{.status.phase}'=Succeeded pod/minio-setup --timeout=120s
-          kubectl --context src logs minio-setup
-          kubectl --context src delete pod minio-setup --ignore-not-found
-
-      - name: Generate rclone config
-        run: |
-          MINIO_IP=$(minikube ip -p src)
-          MINIO_PORT=$(kubectl --context src get svc minio -n minio -o jsonpath='{.spec.ports[0].nodePort}')
-          cat > /tmp/rclone-ci.conf <<RCLONE_EOF
-          [remote]
-          type = s3
-          provider = Minio
-          access_key_id = minioadmin
-          secret_access_key = minioadmin
-          endpoint = http://${MINIO_IP}:${MINIO_PORT}
-          RCLONE_EOF
-          echo "MinIO endpoint: http://${MINIO_IP}:${MINIO_PORT}"
+      - name: Setup MinIO for indirect transfer
+        uses: ./.github/actions/setup-indirect-minio
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -484,94 +297,8 @@ jobs:
           src_user: "dev"
           tgt_user: "dev"
 
-      - name: Deploy MinIO on source cluster
-        run: |
-          kubectl --context src create namespace minio
-          cat <<'MINIO_EOF' | kubectl --context src apply -f -
-          apiVersion: v1
-          kind: PersistentVolumeClaim
-          metadata:
-            name: minio-data
-            namespace: minio
-          spec:
-            accessModes: [ReadWriteOnce]
-            resources:
-              requests:
-                storage: 2Gi
-          ---
-          apiVersion: apps/v1
-          kind: Deployment
-          metadata:
-            name: minio
-            namespace: minio
-          spec:
-            replicas: 1
-            selector:
-              matchLabels:
-                app: minio
-            template:
-              metadata:
-                labels:
-                  app: minio
-              spec:
-                containers:
-                - name: minio
-                  image: quay.io/minio/minio:latest
-                  command: ["minio", "server", "/data"]
-                  ports:
-                  - containerPort: 9000
-                  env:
-                  - name: MINIO_ROOT_USER
-                    value: minioadmin
-                  - name: MINIO_ROOT_PASSWORD
-                    value: minioadmin
-                  volumeMounts:
-                  - name: data
-                    mountPath: /data
-                volumes:
-                - name: data
-                  persistentVolumeClaim:
-                    claimName: minio-data
-          ---
-          apiVersion: v1
-          kind: Service
-          metadata:
-            name: minio
-            namespace: minio
-          spec:
-            type: NodePort
-            selector:
-              app: minio
-            ports:
-            - port: 9000
-              targetPort: 9000
-          MINIO_EOF
-          kubectl --context src wait --for=condition=Available deployment/minio -n minio --timeout=120s
-
-      - name: Create MinIO bucket
-        run: |
-          MINIO_IP=$(minikube ip -p src)
-          MINIO_PORT=$(kubectl --context src get svc minio -n minio -o jsonpath='{.spec.ports[0].nodePort}')
-          kubectl --context src run minio-setup --restart=Never \
-            --image=quay.io/minio/mc:latest \
-            --command -- sh -c "mc alias set local http://${MINIO_IP}:${MINIO_PORT} minioadmin minioadmin && mc mb local/crane-indirect-e2e --ignore-existing"
-          kubectl --context src wait --for=jsonpath='{.status.phase}'=Succeeded pod/minio-setup --timeout=120s
-          kubectl --context src logs minio-setup
-          kubectl --context src delete pod minio-setup --ignore-not-found
-
-      - name: Generate rclone config
-        run: |
-          MINIO_IP=$(minikube ip -p src)
-          MINIO_PORT=$(kubectl --context src get svc minio -n minio -o jsonpath='{.spec.ports[0].nodePort}')
-          cat > /tmp/rclone-ci.conf <<RCLONE_EOF
-          [remote]
-          type = s3
-          provider = Minio
-          access_key_id = minioadmin
-          secret_access_key = minioadmin
-          endpoint = http://${MINIO_IP}:${MINIO_PORT}
-          RCLONE_EOF
-          echo "MinIO endpoint: http://${MINIO_IP}:${MINIO_PORT}"
+      - name: Setup MinIO for indirect transfer
+        uses: ./.github/actions/setup-indirect-minio
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/reusable-e2e-tier-tests.yml
+++ b/.github/workflows/reusable-e2e-tier-tests.yml
@@ -11,6 +11,16 @@ on:
         description: E2E label filter to pass to the test action
         required: true
         type: string
+      cloud_storage:
+        description: S3-compatible cloud storage path for indirect transfer
+        required: false
+        type: string
+        default: ""
+      rclone_config_file:
+        description: Path to rclone.conf file for indirect transfer
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -34,3 +44,5 @@ jobs:
           create_users: "true"
           src_user: "dev"
           tgt_user: "dev"
+          cloud_storage: ${{ inputs.cloud_storage }}
+          rclone_config_file: ${{ inputs.rclone_config_file }}

--- a/cmd/transfer-pvc/indirect.go
+++ b/cmd/transfer-pvc/indirect.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -185,7 +186,7 @@ func followPodLogsUntilComplete(restCfg *rest.Config, c client.Client, podName, 
 		return fmt.Errorf("timed out waiting for pod %s/%s to start: %w", namespace, podName, err)
 	}
 
-	// Follow logs
+	// Follow logs — also capture output to detect rclone transfer stats
 	req := clientset.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{
 		Container: containerName,
 		Follow:    true,
@@ -200,6 +201,7 @@ func followPodLogsUntilComplete(restCfg *rest.Config, c client.Client, podName, 
 		}
 	}()
 
+	var logOutput strings.Builder
 	buf := make([]byte, 4096)
 	for {
 		n, readErr := stream.Read(buf)
@@ -207,6 +209,7 @@ func followPodLogsUntilComplete(restCfg *rest.Config, c client.Client, podName, 
 			if _, writeErr := os.Stderr.Write(buf[:n]); writeErr != nil {
 				return fmt.Errorf("failed to write logs for pod %s/%s: %w", namespace, podName, writeErr)
 			}
+			logOutput.Write(buf[:n])
 		}
 		if readErr != nil {
 			break
@@ -217,6 +220,7 @@ func followPodLogsUntilComplete(restCfg *rest.Config, c client.Client, podName, 
 	// ended before the pod completed (e.g. network interruption).
 	waitCtx, waitCancel := context.WithTimeout(context.TODO(), 2*time.Minute)
 	defer waitCancel()
+	var podFailed bool
 	if err := wait.PollUntilContextCancel(waitCtx, 3*time.Second, true, func(ctx context.Context) (bool, error) {
 		pod := &corev1.Pod{}
 		if err := c.Get(ctx, client.ObjectKey{Name: podName, Namespace: namespace}, pod); err != nil {
@@ -226,14 +230,75 @@ func followPodLogsUntilComplete(restCfg *rest.Config, c client.Client, podName, 
 		case corev1.PodSucceeded:
 			return true, nil
 		case corev1.PodFailed:
-			return true, fmt.Errorf("pod %s/%s failed", namespace, podName)
+			podFailed = true
+			return true, nil
 		default:
 			return false, nil
 		}
 	}); err != nil {
 		return err
 	}
+
+	if podFailed {
+		return checkRclonePartialSuccess(logOutput.String(), podName, namespace)
+	}
 	return nil
+}
+
+// checkRclonePartialSuccess examines rclone output when the pod exits non-zero.
+// rclone treats permission-denied on a single unreadable directory (e.g., MongoDB's
+// .mongodb) as a fatal sync error even though all data files transferred successfully.
+// This function detects that case and treats it as success when files were transferred.
+// It returns an error only when no files were transferred or the failure is not
+// a permission issue.
+func checkRclonePartialSuccess(output, podName, namespace string) error {
+	// Parse the last "Transferred: N / M, P%" file count line
+	var lastTransferred, lastTotal int
+	fileCountFound := false
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "Transferred:") {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) < 4 {
+			continue
+		}
+		// Skip byte-count lines (contain B, KiB, MiB, GiB units)
+		if strings.ContainsAny(parts[1], "BMKGi") {
+			continue
+		}
+		var n, m int
+		if _, err := fmt.Sscanf(parts[1], "%d", &n); err != nil {
+			continue
+		}
+		// parts[2] is "/" separator, parts[3] is total with possible comma
+		totalStr := strings.TrimRight(parts[3], ",")
+		if _, err := fmt.Sscanf(totalStr, "%d", &m); err != nil {
+			continue
+		}
+		lastTransferred = n
+		lastTotal = m
+		fileCountFound = true
+	}
+
+	if !fileCountFound {
+		return fmt.Errorf("pod %s/%s failed", namespace, podName)
+	}
+
+	if lastTransferred == 0 && lastTotal > 0 {
+		return fmt.Errorf("pod %s/%s: rclone transferred 0 of %d files — all files may be unreadable (check UID/permissions)",
+			namespace, podName, lastTotal)
+	}
+
+	hasPermissionError := strings.Contains(output, "permission denied")
+	if lastTransferred > 0 && hasPermissionError {
+		log.Printf("WARN: rclone completed with permission errors on %d of %d items (unreadable directories skipped)",
+			lastTotal-lastTransferred, lastTotal)
+		return nil
+	}
+
+	return fmt.Errorf("pod %s/%s failed", namespace, podName)
 }
 
 func (t *TransferPVCCommand) createTempRcloneSecret(c client.Client, namespace, configFilePath, labelPVCName string) (string, error) {

--- a/e2e-tests/config/config.go
+++ b/e2e-tests/config/config.go
@@ -15,6 +15,9 @@ var (
 	TargetNonAdminContext string
 	InsecureSkipTLSVerify bool
 	RunAs                 string
+	CloudStorage          string
+	RcloneConfigFile      string
+	RcloneConfigSecret    string
 )
 
 // Validates the --run-as flag value and logs the active mode.

--- a/e2e-tests/framework/crane.go
+++ b/e2e-tests/framework/crane.go
@@ -3,6 +3,8 @@ package framework
 import (
 	"fmt"
 	"os/exec"
+
+	"github.com/konveyor/crane/e2e-tests/config"
 )
 
 type CraneRunner struct {
@@ -13,13 +15,16 @@ type CraneRunner struct {
 
 // TransferPVCOptions contains arguments for the crane transfer-pvc command.
 type TransferPVCOptions struct {
-	SourceContext   string
-	TargetContext   string
-	PVCName         string
-	PVCNamespaceMap string
-	Endpoint        string
-	IngressClass    string
-	Subdomain       string
+	SourceContext      string
+	TargetContext      string
+	PVCName            string
+	PVCNamespaceMap    string
+	Endpoint           string
+	IngressClass       string
+	Subdomain          string
+	CloudStorage       string
+	RcloneConfigFile   string
+	RcloneConfigSecret string
 }
 
 // ValidateOptions contains arguments for the crane validate command.
@@ -177,32 +182,53 @@ func (c CraneRunner) Apply(opts ApplyOptions) error {
 }
 
 // TransferPVC runs crane transfer-pvc with the provided transfer options.
-// If Endpoint is empty, it auto-detects: "route" on OpenShift, "nginx-ingress" on vanilla K8s.
+// If CloudStorage is set (via opts or global config), uses indirect mode via S3.
+// Otherwise uses direct rsync/stunnel.
+// If Endpoint is empty in direct mode, it auto-detects: "route" on OpenShift, "nginx-ingress" on vanilla K8s.
 func (c CraneRunner) TransferPVC(opts TransferPVCOptions) error {
-	if opts.Endpoint == "" {
-		tgt := KubectlRunner{Bin: "kubectl", Context: opts.TargetContext}
-		if tgt.IsOpenShift() {
-			opts.Endpoint = "route"
-		} else {
-			opts.Endpoint = "nginx-ingress"
-			if opts.IngressClass == "" {
-				opts.IngressClass = "nginx"
-			}
-		}
+	if opts.CloudStorage == "" && config.CloudStorage != "" {
+		opts.CloudStorage = config.CloudStorage
+	}
+	if opts.RcloneConfigFile == "" && config.RcloneConfigFile != "" {
+		opts.RcloneConfigFile = config.RcloneConfigFile
+	}
+	if opts.RcloneConfigSecret == "" && config.RcloneConfigSecret != "" {
+		opts.RcloneConfigSecret = config.RcloneConfigSecret
 	}
 
 	args := []string{"transfer-pvc",
-		"--source-context",
-		opts.SourceContext,
+		"--source-context", opts.SourceContext,
 		"--destination-context", opts.TargetContext,
 		"--pvc-name", opts.PVCName,
 		"--pvc-namespace", opts.PVCNamespaceMap,
-		"--endpoint", opts.Endpoint,
 	}
-	if opts.Endpoint != "route" {
-		args = append(args, "--ingress-class", opts.IngressClass)
-		args = append(args, "--subdomain", opts.Subdomain)
+
+	if opts.CloudStorage != "" {
+		args = append(args, "--cloud-storage", opts.CloudStorage)
+		if opts.RcloneConfigSecret != "" {
+			args = append(args, "--rclone-config-secret", opts.RcloneConfigSecret)
+		} else if opts.RcloneConfigFile != "" {
+			args = append(args, "--rclone-config-file", opts.RcloneConfigFile)
+		}
+	} else {
+		if opts.Endpoint == "" {
+			tgt := KubectlRunner{Bin: "kubectl", Context: opts.TargetContext}
+			if tgt.IsOpenShift() {
+				opts.Endpoint = "route"
+			} else {
+				opts.Endpoint = "nginx-ingress"
+				if opts.IngressClass == "" {
+					opts.IngressClass = "nginx"
+				}
+			}
+		}
+		args = append(args, "--endpoint", opts.Endpoint)
+		if opts.Endpoint != "route" {
+			args = append(args, "--ingress-class", opts.IngressClass)
+			args = append(args, "--subdomain", opts.Subdomain)
+		}
 	}
+
 	logVerboseCommand(c.Bin, args)
 	cmd := exec.Command(c.Bin, args...)
 	cmd.Dir = c.WorkDir

--- a/e2e-tests/framework/crane.go
+++ b/e2e-tests/framework/crane.go
@@ -189,11 +189,12 @@ func (c CraneRunner) TransferPVC(opts TransferPVCOptions) error {
 	if opts.CloudStorage == "" && config.CloudStorage != "" {
 		opts.CloudStorage = config.CloudStorage
 	}
-	if opts.RcloneConfigFile == "" && config.RcloneConfigFile != "" {
-		opts.RcloneConfigFile = config.RcloneConfigFile
-	}
-	if opts.RcloneConfigSecret == "" && config.RcloneConfigSecret != "" {
-		opts.RcloneConfigSecret = config.RcloneConfigSecret
+	if opts.RcloneConfigFile == "" && opts.RcloneConfigSecret == "" {
+		if config.RcloneConfigSecret != "" {
+			opts.RcloneConfigSecret = config.RcloneConfigSecret
+		} else if config.RcloneConfigFile != "" {
+			opts.RcloneConfigFile = config.RcloneConfigFile
+		}
 	}
 
 	args := []string{"transfer-pvc",

--- a/e2e-tests/tests/tier0/e2e_suite_test.go
+++ b/e2e-tests/tests/tier0/e2e_suite_test.go
@@ -22,6 +22,9 @@ func init() {
 	flag.StringVar(&config.TargetNonAdminContext, "target-nonadmin-context", "", "Target cluster non-admin context for RBAC scenarios")
 	flag.BoolVar(&config.InsecureSkipTLSVerify, "insecure-skip-tls-verify", false, "Skip TLS certificate verification for k8sdeploy connections (use for OCP clusters with self-signed certs)")
 	flag.StringVar(&config.RunAs, "run-as", "", "Override user context: set to 'admin' to run all tests with cluster-admin credentials")
+	flag.StringVar(&config.CloudStorage, "cloud-storage", "", "S3-compatible cloud storage path for indirect transfer (e.g. remote:my-bucket)")
+	flag.StringVar(&config.RcloneConfigFile, "rclone-config-file", "", "Path to local rclone.conf file for indirect transfer")
+	flag.StringVar(&config.RcloneConfigSecret, "rclone-config-secret", "", "K8s Secret name containing rclone.conf for indirect transfer")
 }
 
 var _ = BeforeSuite(func() {

--- a/e2e-tests/tests/tier1/e2e_suite_test.go
+++ b/e2e-tests/tests/tier1/e2e_suite_test.go
@@ -22,6 +22,9 @@ func init() {
 	flag.StringVar(&config.TargetNonAdminContext, "target-nonadmin-context", "", "Target cluster non-admin context for RBAC scenarios")
 	flag.BoolVar(&config.InsecureSkipTLSVerify, "insecure-skip-tls-verify", false, "Skip TLS certificate verification for k8sdeploy connections (use for OCP clusters with self-signed certs)")
 	flag.StringVar(&config.RunAs, "run-as", "", "Override user context: set to 'admin' to run all tests with cluster-admin credentials")
+	flag.StringVar(&config.CloudStorage, "cloud-storage", "", "S3-compatible cloud storage path for indirect transfer (e.g. remote:my-bucket)")
+	flag.StringVar(&config.RcloneConfigFile, "rclone-config-file", "", "Path to local rclone.conf file for indirect transfer")
+	flag.StringVar(&config.RcloneConfigSecret, "rclone-config-secret", "", "K8s Secret name containing rclone.conf for indirect transfer")
 }
 
 var _ = BeforeSuite(func() {


### PR DESCRIPTION

 ## Summary

  Adds a parallel indirect migration E2E test workflow that mirrors the existing direct E2E workflow structure, running all e2e tests via S3-compatible cloud storage (MinIO) instead of direct rsync/stunnel.

  ### Changes

  **E2E Framework (backward-compatible)**
  - `e2e-tests/config/config.go` — Added `CloudStorage`, `RcloneConfigFile`, `RcloneConfigSecret` global config vars (default empty, no effect on direct mode)
  - `e2e-tests/framework/crane.go` — Extended `TransferPVCOptions` with indirect fields. `TransferPVC()` auto-populates from global config; when `CloudStorage` is set, uses `--cloud-storage` / `--rclone-config-file`
  flags instead of `--endpoint` / `--ingress-class`
  - `e2e-tests/tests/tier0/e2e_suite_test.go` and `tier1/e2e_suite_test.go` — Registered 3 new Ginkgo flags (`--cloud-storage`, `--rclone-config-file`, `--rclone-config-secret`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable cloud-storage and rclone settings for indirect transfers.
  - Added automated end-to-end testing with MinIO-backed storage and Kubernetes environment setup.
  - Tests can run selectively based on changed areas, with parallel execution where appropriate.

- **Improvements**
  - Added consolidated test results for clearer pull request status.
  - Improved transfer configuration flexibility across supported Kubernetes environments.
  - Improved handling of partial transfers and permission-related outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->