### PR TITLE
:bug: Fix resources filenames sanity across OS

### DIFF
--- a/cmd/export/discover.go
+++ b/cmd/export/discover.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/konveyor/crane/internal/file"
 	"github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -177,23 +178,12 @@ func writeErrors(errors []*groupResourceError, failuresDir string, log logrus.Fi
 func getFilePath(obj unstructured.Unstructured) string {
 	const maxFilenameLength = 255
 
-	namespace := obj.GetNamespace()
-	if namespace == "" {
-		namespace = "clusterscoped"
-	}
-
-	kind := obj.GetKind()
-	group := obj.GetObjectKind().GroupVersionKind().GroupKind().Group
-	version := obj.GetObjectKind().GroupVersionKind().Version
-	name := obj.GetName()
-
-	basename := strings.Join([]string{kind, group, version, namespace, name}, "_")
-	filename := basename + ".yaml"
-
+	filename := file.GetResourceFilename(obj)
 	if len(filename) <= maxFilenameLength {
 		return filename
 	}
 
+	basename := strings.TrimSuffix(filename, ".yaml")
 	maxBaseLen := maxFilenameLength - 22 // "_" + 16 hash chars + ".yaml"
 	truncated := basename
 	if len(basename) > maxBaseLen {

--- a/cmd/export/discover.go
+++ b/cmd/export/discover.go
@@ -2,7 +2,6 @@ package export
 
 import (
 	"context"
-	"crypto/sha256"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -101,7 +100,7 @@ func writeResources(resources []*groupResource, clusterResourceDir string, resou
 			if obj.GetNamespace() == "" {
 				targetDir = clusterResourceDir
 			}
-			path := filepath.Join(targetDir, getFilePath(obj))
+			path := filepath.Join(targetDir, file.GetResourceFilename(obj))
 			f, err := os.Create(path)
 			if err != nil {
 				errs = append(errs, err)
@@ -171,32 +170,6 @@ func writeErrors(errors []*groupResourceError, failuresDir string, log logrus.Fi
 	}
 
 	return errs
-}
-
-// getFilePath returns a stable filename from kind, group, version, namespace, and name.
-// If the filename exceeds 255 characters, it is truncated and a hash suffix is added.
-func getFilePath(obj unstructured.Unstructured) string {
-	const maxFilenameLength = 255
-
-	filename := file.GetResourceFilename(obj)
-	if len(filename) <= maxFilenameLength {
-		return filename
-	}
-
-	basename := strings.TrimSuffix(filename, ".yaml")
-	maxBaseLen := maxFilenameLength - 22 // "_" + 16 hash chars + ".yaml"
-	truncated := basename
-	if len(basename) > maxBaseLen {
-		truncated = basename[:maxBaseLen]
-	}
-
-	hash := sha256.Sum256([]byte(filename))
-	hashStr := fmt.Sprintf("%x", hash[:8])
-
-	if len(truncated) > 0 {
-		return truncated + "_" + hashStr + ".yaml"
-	}
-	return hashStr + ".yaml"
 }
 
 // discoverPreferredResources returns server-preferred API resource lists, filtered to

--- a/cmd/export/discover_test.go
+++ b/cmd/export/discover_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	openapi_v2 "github.com/google/gnostic-models/openapiv2"
+	"github.com/konveyor/crane/internal/file"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -24,172 +25,6 @@ import (
 	restclient "k8s.io/client-go/rest"
 	kubetesting "k8s.io/client-go/testing"
 )
-
-// ---------- getFilePath ----------
-
-func TestGetFilePath(t *testing.T) {
-	tests := []struct {
-		name      string
-		obj       unstructured.Unstructured
-		wantParts []string // substrings that must appear
-		maxLen    int      // if > 0, verify length is at most this
-	}{
-		{
-			name: "namespaced object",
-			obj: func() unstructured.Unstructured {
-				u := unstructured.Unstructured{}
-				u.SetKind("Deployment")
-				u.SetName("web")
-				u.SetNamespace("prod")
-				u.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"})
-				return u
-			}(),
-			wantParts: []string{"Deployment", "apps", "v1", "prod", "web", ".yaml"},
-		},
-		{
-			name: "cluster-scoped object uses clusterscoped",
-			obj: func() unstructured.Unstructured {
-				u := unstructured.Unstructured{}
-				u.SetKind("ClusterRole")
-				u.SetName("admin")
-				u.SetGroupVersionKind(schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRole"})
-				return u
-			}(),
-			wantParts: []string{"ClusterRole", "rbac.authorization.k8s.io", "v1", "clusterscoped", "admin", ".yaml"},
-		},
-		{
-			name: "resource with max-length name (253 chars) gets truncated",
-			obj: func() unstructured.Unstructured {
-				u := unstructured.Unstructured{}
-				u.SetKind("ConfigMap")
-				u.SetName(strings.Repeat("a", 253)) // Kubernetes max name length
-				u.SetNamespace("my-namespace")
-				u.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"})
-				return u
-			}(),
-			wantParts: []string{"ConfigMap", "_v1_", "my-namespace", ".yaml"},
-			maxLen:    255,
-		},
-		{
-			name: "resource name with colon is sanitized",
-			obj: func() unstructured.Unstructured {
-				u := unstructured.Unstructured{}
-				u.SetKind("RoleBinding")
-				u.SetName("system:deployers")
-				u.SetNamespace("my-ns")
-				u.SetGroupVersionKind(schema.GroupVersionKind{Group: "authorization.openshift.io", Version: "v1", Kind: "RoleBinding"})
-				return u
-			}(),
-			wantParts: []string{"RoleBinding", "authorization.openshift.io", "v1", "my-ns", "system_deployers_", ".yaml"},
-		},
-		{
-			name: "extremely long name gets truncated with hash",
-			obj: func() unstructured.Unstructured {
-				u := unstructured.Unstructured{}
-				u.SetKind("Secret")
-				u.SetName(strings.Repeat("b", 300))
-				u.SetNamespace("production")
-				u.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"})
-				return u
-			}(),
-			wantParts: []string{"Secret", "_v1_", "production", ".yaml"},
-			maxLen:    255,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := getFilePath(tt.obj)
-			for _, p := range tt.wantParts {
-				if !strings.Contains(got, p) {
-					t.Errorf("getFilePath() = %q, missing %q", got, p)
-				}
-			}
-			if tt.maxLen > 0 && len(got) > tt.maxLen {
-				t.Errorf("getFilePath() = %q (len=%d), exceeds max length %d", got, len(got), tt.maxLen)
-			}
-		})
-	}
-}
-
-func TestGetFilePath_NoWindowsReservedChars(t *testing.T) {
-	reserved := []string{"<", ">", ":", "\"", "/", "\\", "|", "?", "*"}
-	obj := unstructured.Unstructured{}
-	obj.SetKind("RoleBinding")
-	obj.SetName("system:deployers")
-	obj.SetNamespace("my-ns")
-	obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "authorization.openshift.io", Version: "v1", Kind: "RoleBinding"})
-
-	got := getFilePath(obj)
-	for _, ch := range reserved {
-		if strings.Contains(got, ch) {
-			t.Errorf("getFilePath() = %q, contains Windows-reserved character %q", got, ch)
-		}
-	}
-}
-
-func TestGetFilePath_LongNameCollisionPrevention(t *testing.T) {
-	// Two resources with long names that differ only at the end should produce different filenames
-	name1 := strings.Repeat("a", 253)
-	name2 := strings.Repeat("a", 252) + "b"
-
-	obj1 := unstructured.Unstructured{}
-	obj1.SetKind("ConfigMap")
-	obj1.SetName(name1)
-	obj1.SetNamespace("default")
-	obj1.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"})
-
-	obj2 := unstructured.Unstructured{}
-	obj2.SetKind("ConfigMap")
-	obj2.SetName(name2)
-	obj2.SetNamespace("default")
-	obj2.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"})
-
-	path1 := getFilePath(obj1)
-	path2 := getFilePath(obj2)
-
-	if path1 == path2 {
-		t.Errorf("getFilePath() produced identical paths for different resources:\npath1=%q\npath2=%q", path1, path2)
-	}
-
-	// Both should be within filesystem limits
-	if len(path1) > 255 {
-		t.Errorf("path1 length %d exceeds 255", len(path1))
-	}
-	if len(path2) > 255 {
-		t.Errorf("path2 length %d exceeds 255", len(path2))
-	}
-}
-
-func TestGetFilePath_LongPrefixAndName(t *testing.T) {
-	// Test with very long namespace + group + long name
-	longNamespace := strings.Repeat("n", 63) // Kubernetes max namespace length
-	longGroup := strings.Repeat("g", 100)
-	longName := strings.Repeat("x", 253)
-
-	obj := unstructured.Unstructured{}
-	obj.SetKind("CustomResource")
-	obj.SetName(longName)
-	obj.SetNamespace(longNamespace)
-	obj.SetGroupVersionKind(schema.GroupVersionKind{Group: longGroup, Version: "v1beta1", Kind: "CustomResource"})
-
-	path := getFilePath(obj)
-
-	// Should not exceed filesystem limit
-	if len(path) > 255 {
-		t.Errorf("path length %d exceeds 255: %q", len(path), path)
-	}
-
-	// Should end with .yaml
-	if !strings.HasSuffix(path, ".yaml") {
-		t.Errorf("path does not end with .yaml: %q", path)
-	}
-
-	// Should contain hash (16 hex chars before .yaml)
-	if len(path) < 22 { // at least "_" + 16 chars + ".yaml"
-		t.Errorf("path too short to contain hash: %q", path)
-	}
-}
 
 // ---------- isAdmittedResource ----------
 
@@ -521,13 +356,13 @@ func TestWriteResources(t *testing.T) {
 	}
 
 	// Namespaced resource written to resourceDir.
-	nsPath := filepath.Join(resourceDir, getFilePath(nsObj))
+	nsPath := filepath.Join(resourceDir, file.GetResourceFilename(nsObj))
 	if _, err := os.Stat(nsPath); err != nil {
 		t.Errorf("namespaced resource file not found: %v", err)
 	}
 
 	// Cluster-scoped resource written to clusterDir.
-	clPath := filepath.Join(clusterDir, getFilePath(clObj))
+	clPath := filepath.Join(clusterDir, file.GetResourceFilename(clObj))
 	if _, err := os.Stat(clPath); err != nil {
 		t.Errorf("cluster-scoped resource file not found: %v", err)
 	}
@@ -802,7 +637,7 @@ func TestWriteResources_createFailsWhenTargetPathIsDirectory(t *testing.T) {
 	nsObj := namespacedObj("ns", "pod-a")
 	nsObj.SetKind("Pod")
 	nsObj.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"})
-	baseName := getFilePath(nsObj)
+	baseName := file.GetResourceFilename(nsObj)
 	if err := os.Mkdir(filepath.Join(resourceDir, baseName), 0700); err != nil {
 		t.Fatal(err)
 	}
@@ -862,7 +697,7 @@ func TestWriteResources_createFailsWhenDestinationFileNotWritable(t *testing.T) 
 	nsObj := namespacedObj("ns", "pod-a")
 	nsObj.SetKind("Pod")
 	nsObj.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"})
-	path := filepath.Join(resourceDir, getFilePath(nsObj))
+	path := filepath.Join(resourceDir, file.GetResourceFilename(nsObj))
 	if err := os.WriteFile(path, []byte("seed"), 0400); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/export/discover_test.go
+++ b/cmd/export/discover_test.go
@@ -71,6 +71,18 @@ func TestGetFilePath(t *testing.T) {
 			maxLen:    255,
 		},
 		{
+			name: "resource name with colon is sanitized",
+			obj: func() unstructured.Unstructured {
+				u := unstructured.Unstructured{}
+				u.SetKind("RoleBinding")
+				u.SetName("system:deployers")
+				u.SetNamespace("my-ns")
+				u.SetGroupVersionKind(schema.GroupVersionKind{Group: "authorization.openshift.io", Version: "v1", Kind: "RoleBinding"})
+				return u
+			}(),
+			wantParts: []string{"RoleBinding", "authorization.openshift.io", "v1", "my-ns", "system_deployers", ".yaml"},
+		},
+		{
 			name: "extremely long name gets truncated with hash",
 			obj: func() unstructured.Unstructured {
 				u := unstructured.Unstructured{}
@@ -97,6 +109,22 @@ func TestGetFilePath(t *testing.T) {
 				t.Errorf("getFilePath() = %q (len=%d), exceeds max length %d", got, len(got), tt.maxLen)
 			}
 		})
+	}
+}
+
+func TestGetFilePath_NoWindowsReservedChars(t *testing.T) {
+	reserved := []string{"<", ">", ":", "\"", "/", "\\", "|", "?", "*"}
+	obj := unstructured.Unstructured{}
+	obj.SetKind("RoleBinding")
+	obj.SetName("system:deployers")
+	obj.SetNamespace("my-ns")
+	obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "authorization.openshift.io", Version: "v1", Kind: "RoleBinding"})
+
+	got := getFilePath(obj)
+	for _, ch := range reserved {
+		if strings.Contains(got, ch) {
+			t.Errorf("getFilePath() = %q, contains Windows-reserved character %q", got, ch)
+		}
 	}
 }
 

--- a/cmd/export/discover_test.go
+++ b/cmd/export/discover_test.go
@@ -80,7 +80,7 @@ func TestGetFilePath(t *testing.T) {
 				u.SetGroupVersionKind(schema.GroupVersionKind{Group: "authorization.openshift.io", Version: "v1", Kind: "RoleBinding"})
 				return u
 			}(),
-			wantParts: []string{"RoleBinding", "authorization.openshift.io", "v1", "my-ns", "system_deployers", ".yaml"},
+			wantParts: []string{"RoleBinding", "authorization.openshift.io", "v1", "my-ns", "system_deployers_", ".yaml"},
 		},
 		{
 			name: "extremely long name gets truncated with hash",

--- a/internal/file/file_helper.go
+++ b/internal/file/file_helper.go
@@ -2,6 +2,7 @@ package file
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -198,5 +199,10 @@ func GetResourceFilename(obj unstructured.Unstructured) string {
 		namespace,
 		obj.GetName(),
 	}, "_")
-	return sanitizeFilename(basename) + ".yaml"
+	sanitized := sanitizeFilename(basename)
+	if sanitized != basename {
+		hash := sha256.Sum256([]byte(basename))
+		sanitized = fmt.Sprintf("%s_%x", sanitized, hash[:4])
+	}
+	return sanitized + ".yaml"
 }

--- a/internal/file/file_helper.go
+++ b/internal/file/file_helper.go
@@ -187,7 +187,13 @@ func sanitizeFilename(name string) string {
 // GetResourceFilename returns a stable filename from kind, group, version, namespace, and name.
 // Format matches export: Kind_group_version_namespace_name.yaml
 // Examples: "ConfigMap__v1_default_my-config.yaml", "Deployment_apps_v1_default_my-app.yaml"
+//
+// The result is capped at 255 bytes (filesystem limit). When the basename is
+// truncated or when sanitization replaces reserved characters, a deterministic
+// hash suffix is appended to prevent collisions.
 func GetResourceFilename(obj unstructured.Unstructured) string {
+	const maxFilenameLength = 255
+
 	namespace := obj.GetNamespace()
 	if namespace == "" {
 		namespace = "clusterscoped"
@@ -200,9 +206,22 @@ func GetResourceFilename(obj unstructured.Unstructured) string {
 		obj.GetName(),
 	}, "_")
 	sanitized := sanitizeFilename(basename)
-	if sanitized != basename {
+	needsHash := sanitized != basename
+	if needsHash {
 		hash := sha256.Sum256([]byte(basename))
 		sanitized = fmt.Sprintf("%s_%x", sanitized, hash[:4])
 	}
-	return sanitized + ".yaml"
+	filename := sanitized + ".yaml"
+
+	if len(filename) <= maxFilenameLength {
+		return filename
+	}
+
+	maxBaseLen := maxFilenameLength - 22 // "_" + 16 hash chars + ".yaml"
+	truncated := sanitized
+	if len(sanitized) > maxBaseLen {
+		truncated = sanitized[:maxBaseLen]
+	}
+	hash := sha256.Sum256([]byte(basename))
+	return fmt.Sprintf("%s_%x.yaml", truncated, hash[:8])
 }

--- a/internal/file/file_helper.go
+++ b/internal/file/file_helper.go
@@ -169,6 +169,20 @@ func (opts *PathOpts) GetStageOutputDir(stageName string) string {
 	return filepath.Join(opts.GetStageDir(stageName), OutputDirName)
 }
 
+// sanitizeFilename replaces characters that are reserved in Windows filenames
+// (NTFS Alternate Data Stream separator and other illegal chars) with underscores.
+// Applied to the joined basename so that exported files are valid on all platforms.
+func sanitizeFilename(name string) string {
+	return strings.Map(func(r rune) rune {
+		switch r {
+		case '<', '>', ':', '"', '/', '\\', '|', '?', '*':
+			return '_'
+		default:
+			return r
+		}
+	}, name)
+}
+
 // GetResourceFilename returns a stable filename from kind, group, version, namespace, and name.
 // Format matches export: Kind_group_version_namespace_name.yaml
 // Examples: "ConfigMap__v1_default_my-config.yaml", "Deployment_apps_v1_default_my-app.yaml"
@@ -177,11 +191,12 @@ func GetResourceFilename(obj unstructured.Unstructured) string {
 	if namespace == "" {
 		namespace = "clusterscoped"
 	}
-	return strings.Join([]string{
+	basename := strings.Join([]string{
 		obj.GetKind(),
 		obj.GetObjectKind().GroupVersionKind().GroupKind().Group,
 		obj.GetObjectKind().GroupVersionKind().Version,
 		namespace,
 		obj.GetName(),
-	}, "_") + ".yaml"
+	}, "_")
+	return sanitizeFilename(basename) + ".yaml"
 }

--- a/internal/file/file_helper_test.go
+++ b/internal/file/file_helper_test.go
@@ -204,6 +204,107 @@ func TestGetResourceFilename_SanitizesWindowsReservedChars(t *testing.T) {
 	}
 }
 
+func TestGetResourceFilename_TruncatesLongNames(t *testing.T) {
+	obj := unstructured.Unstructured{}
+	obj.SetName(strings.Repeat("a", 253))
+	obj.SetNamespace("default")
+	obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "ConfigMap"})
+
+	filename := file.GetResourceFilename(obj)
+	if len(filename) > 255 {
+		t.Errorf("GetResourceFilename() length = %d, want <= 255: %q", len(filename), filename)
+	}
+	if !strings.HasSuffix(filename, ".yaml") {
+		t.Errorf("GetResourceFilename() = %q, must end with .yaml", filename)
+	}
+}
+
+func TestGetResourceFilename_LongNameWithColonTruncates(t *testing.T) {
+	obj := unstructured.Unstructured{}
+	obj.SetName("system:" + strings.Repeat("x", 246))
+	obj.SetNamespace("default")
+	obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "ConfigMap"})
+
+	filename := file.GetResourceFilename(obj)
+	if len(filename) > 255 {
+		t.Errorf("GetResourceFilename() length = %d, want <= 255: %q", len(filename), filename)
+	}
+	if !strings.HasSuffix(filename, ".yaml") {
+		t.Errorf("GetResourceFilename() = %q, must end with .yaml", filename)
+	}
+	if strings.Contains(filename, ":") {
+		t.Errorf("GetResourceFilename() = %q, must not contain ':'", filename)
+	}
+}
+
+func TestGetResourceFilename_NoWindowsReservedChars(t *testing.T) {
+	reserved := []string{"<", ">", ":", "\"", "/", "\\", "|", "?", "*"}
+	obj := unstructured.Unstructured{}
+	obj.SetName("system:deployers")
+	obj.SetNamespace("my-ns")
+	obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "authorization.openshift.io", Version: "v1", Kind: "RoleBinding"})
+
+	got := file.GetResourceFilename(obj)
+	for _, ch := range reserved {
+		if strings.Contains(got, ch) {
+			t.Errorf("GetResourceFilename() = %q, contains Windows-reserved character %q", got, ch)
+		}
+	}
+}
+
+func TestGetResourceFilename_LongNameCollisionPrevention(t *testing.T) {
+	name1 := strings.Repeat("a", 253)
+	name2 := strings.Repeat("a", 252) + "b"
+
+	obj1 := unstructured.Unstructured{}
+	obj1.SetKind("ConfigMap")
+	obj1.SetName(name1)
+	obj1.SetNamespace("default")
+	obj1.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"})
+
+	obj2 := unstructured.Unstructured{}
+	obj2.SetKind("ConfigMap")
+	obj2.SetName(name2)
+	obj2.SetNamespace("default")
+	obj2.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"})
+
+	path1 := file.GetResourceFilename(obj1)
+	path2 := file.GetResourceFilename(obj2)
+
+	if path1 == path2 {
+		t.Errorf("GetResourceFilename() produced identical paths for different resources:\npath1=%q\npath2=%q", path1, path2)
+	}
+	if len(path1) > 255 {
+		t.Errorf("path1 length %d exceeds 255", len(path1))
+	}
+	if len(path2) > 255 {
+		t.Errorf("path2 length %d exceeds 255", len(path2))
+	}
+}
+
+func TestGetResourceFilename_LongPrefixAndName(t *testing.T) {
+	longNamespace := strings.Repeat("n", 63)
+	longGroup := strings.Repeat("g", 100)
+	longName := strings.Repeat("x", 253)
+
+	obj := unstructured.Unstructured{}
+	obj.SetKind("CustomResource")
+	obj.SetName(longName)
+	obj.SetNamespace(longNamespace)
+	obj.SetGroupVersionKind(schema.GroupVersionKind{Group: longGroup, Version: "v1beta1", Kind: "CustomResource"})
+
+	path := file.GetResourceFilename(obj)
+	if len(path) > 255 {
+		t.Errorf("path length %d exceeds 255: %q", len(path), path)
+	}
+	if !strings.HasSuffix(path, ".yaml") {
+		t.Errorf("path does not end with .yaml: %q", path)
+	}
+	if len(path) < 22 {
+		t.Errorf("path too short to contain hash: %q", path)
+	}
+}
+
 func TestGetResourceFilename_NoCollisionAfterSanitization(t *testing.T) {
 	colonObj := unstructured.Unstructured{}
 	colonObj.SetName("system:deployers")

--- a/internal/file/file_helper_test.go
+++ b/internal/file/file_helper_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/konveyor/crane/internal/file"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func createTestDir(t *testing.T) string {
@@ -127,6 +129,78 @@ func TestReadFilesNonExistentDir(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), dir) {
 		t.Errorf("error should contain directory path, got: %v", err)
+	}
+}
+
+func TestGetResourceFilename_SanitizesWindowsReservedChars(t *testing.T) {
+	tests := []struct {
+		name     string
+		obj      unstructured.Unstructured
+		expected string
+	}{
+		{
+			name: "system:deployers RoleBinding",
+			obj: func() unstructured.Unstructured {
+				u := unstructured.Unstructured{}
+				u.SetName("system:deployers")
+				u.SetNamespace("my-ns")
+				u.SetGroupVersionKind(schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "RoleBinding"})
+				return u
+			}(),
+			expected: "RoleBinding_rbac.authorization.k8s.io_v1_my-ns_system_deployers.yaml",
+		},
+		{
+			name: "system:image-builders RoleBinding",
+			obj: func() unstructured.Unstructured {
+				u := unstructured.Unstructured{}
+				u.SetName("system:image-builders")
+				u.SetNamespace("my-ns")
+				u.SetGroupVersionKind(schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "RoleBinding"})
+				return u
+			}(),
+			expected: "RoleBinding_rbac.authorization.k8s.io_v1_my-ns_system_image-builders.yaml",
+		},
+		{
+			name: "name without reserved chars is unchanged",
+			obj: func() unstructured.Unstructured {
+				u := unstructured.Unstructured{}
+				u.SetName("my-deployment")
+				u.SetNamespace("default")
+				u.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"})
+				return u
+			}(),
+			expected: "Deployment_apps_v1_default_my-deployment.yaml",
+		},
+		{
+			name: "name with multiple reserved chars",
+			obj: func() unstructured.Unstructured {
+				u := unstructured.Unstructured{}
+				u.SetName("a<b>c:d")
+				u.SetNamespace("ns")
+				u.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"})
+				return u
+			}(),
+			expected: "ConfigMap__v1_ns_a_b_c_d.yaml",
+		},
+		{
+			name: "cluster-scoped resource with colon",
+			obj: func() unstructured.Unstructured {
+				u := unstructured.Unstructured{}
+				u.SetName("system:admin")
+				u.SetGroupVersionKind(schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRole"})
+				return u
+			}(),
+			expected: "ClusterRole_rbac.authorization.k8s.io_v1_clusterscoped_system_admin.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := file.GetResourceFilename(tt.obj)
+			if got != tt.expected {
+				t.Errorf("GetResourceFilename() = %q, want %q", got, tt.expected)
+			}
+		})
 	}
 }
 

--- a/internal/file/file_helper_test.go
+++ b/internal/file/file_helper_test.go
@@ -147,7 +147,7 @@ func TestGetResourceFilename_SanitizesWindowsReservedChars(t *testing.T) {
 				u.SetGroupVersionKind(schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "RoleBinding"})
 				return u
 			}(),
-			expected: "RoleBinding_rbac.authorization.k8s.io_v1_my-ns_system_deployers.yaml",
+			expected: "RoleBinding_rbac.authorization.k8s.io_v1_my-ns_system_deployers_7ce771ca.yaml",
 		},
 		{
 			name: "system:image-builders RoleBinding",
@@ -158,7 +158,7 @@ func TestGetResourceFilename_SanitizesWindowsReservedChars(t *testing.T) {
 				u.SetGroupVersionKind(schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "RoleBinding"})
 				return u
 			}(),
-			expected: "RoleBinding_rbac.authorization.k8s.io_v1_my-ns_system_image-builders.yaml",
+			expected: "RoleBinding_rbac.authorization.k8s.io_v1_my-ns_system_image-builders_faff99cd.yaml",
 		},
 		{
 			name: "name without reserved chars is unchanged",
@@ -180,7 +180,7 @@ func TestGetResourceFilename_SanitizesWindowsReservedChars(t *testing.T) {
 				u.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"})
 				return u
 			}(),
-			expected: "ConfigMap__v1_ns_a_b_c_d.yaml",
+			expected: "ConfigMap__v1_ns_a_b_c_d_20b20061.yaml",
 		},
 		{
 			name: "cluster-scoped resource with colon",
@@ -190,7 +190,7 @@ func TestGetResourceFilename_SanitizesWindowsReservedChars(t *testing.T) {
 				u.SetGroupVersionKind(schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRole"})
 				return u
 			}(),
-			expected: "ClusterRole_rbac.authorization.k8s.io_v1_clusterscoped_system_admin.yaml",
+			expected: "ClusterRole_rbac.authorization.k8s.io_v1_clusterscoped_system_admin_f7295a44.yaml",
 		},
 	}
 
@@ -201,6 +201,25 @@ func TestGetResourceFilename_SanitizesWindowsReservedChars(t *testing.T) {
 				t.Errorf("GetResourceFilename() = %q, want %q", got, tt.expected)
 			}
 		})
+	}
+}
+
+func TestGetResourceFilename_NoCollisionAfterSanitization(t *testing.T) {
+	colonObj := unstructured.Unstructured{}
+	colonObj.SetName("system:deployers")
+	colonObj.SetNamespace("ns")
+	colonObj.SetGroupVersionKind(schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "RoleBinding"})
+
+	underscoreObj := unstructured.Unstructured{}
+	underscoreObj.SetName("system_deployers")
+	underscoreObj.SetNamespace("ns")
+	underscoreObj.SetGroupVersionKind(schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "RoleBinding"})
+
+	colonFile := file.GetResourceFilename(colonObj)
+	underscoreFile := file.GetResourceFilename(underscoreObj)
+
+	if colonFile == underscoreFile {
+		t.Errorf("system:deployers and system_deployers must produce distinct filenames, both got %q", colonFile)
 	}
 }
 


### PR DESCRIPTION
Windows systems consider `:` as a special charater, crane should avoid using this character in filenames in file sit creates. Adding replacement of `:` and other potentially dangerous chars with `_` in resources filenames and additional hash to avoid collisions.

Fixes: https://github.com/migtools/crane/issues/797

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exported resource filenames by replacing Windows-reserved characters with underscores.
  * Added support for safely handling resource names containing colons and other reserved characters.
  * Prevented filename collisions when sanitization or truncation produces matching names.
  * Preserved consistent filenames for namespaced and cluster-scoped resources.
  * Ensured exported filenames remain within supported length limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->