### PR TITLE
:seedling: ci: allow /rfr to re-notify Slack without label reset

### DIFF
--- a/.github/workflows/pr-ready-for-review-slack.yml
+++ b/.github/workflows/pr-ready-for-review-slack.yml
@@ -77,11 +77,9 @@ jobs:
             exit 0
           fi
 
-          if gh api "repos/${GITHUB_REPOSITORY}/issues/${pr_number}/labels" | jq -e '.[] | select(.name == "ready-for-review-notified")' >/dev/null; then
-            echo "::notice::PR #${pr_number} already has ready-for-review-notified label; skipping duplicate notification."
-            echo "should_notify=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+          # Allow repeated /rfr notifications. The ready-for-review-notified label is
+          # retained for audit and still applied after a successful notify, but it no
+          # longer blocks a subsequent author /rfr on an open, non-draft PR.
 
           pr_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}")"
           is_draft="$(printf '%s' "$pr_json" | jq -r '.draft')"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ready-for-review notifications can now be sent again when requested, even if a previous notification label is present.
  * The notification label remains available for audit purposes and is cleared when a reset command is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->