### PR TITLE
chore: Update documentation semantic indexes

### DIFF
--- a/docs/.doc-index/commands.index.md
+++ b/docs/.doc-index/commands.index.md
@@ -1,37 +1,38 @@
 # COMMANDS Documentation Index
 
 ## Overview
-This documentation area defines the CLI tool `crane`, which orchestrates Kubernetes cluster-to-cluster migrations. It covers the full lifecycle of a migration project, including resource extraction, transformation pipelines, validation against target clusters, and persistent volume data migration.
+This documentation area defines the command-line interface for the Crane migration tool, covering the end-to-end lifecycle of Kubernetes workload migration. It provides instructions for exporting cluster state, performing multi-stage transformations, applying configurations, validating API compatibility, and transferring persistent volume data.
 
 ## Files Summary
-*   **commands/export.md**: Details the discovery and extraction process of Kubernetes resources (including CRDs and cluster-scoped items) from a source cluster into local YAML files.
-*   **commands/transform.md**: Explains the multi-stage transformation pipeline using Kustomize and plugins to modify, patch, or filter resources before they are applied.
-*   **commands/validate.md**: Describes how to verify the compatibility of transformed manifests against a target cluster’s API surface, supporting both live and offline modes.
-*   **commands/apply.md**: Covers the process of rendering final manifests by running embedded Kustomize on transform stages and preparing them for cluster deployment.
-*   **commands/transfer-pvc.md**: Details the mechanism for transferring PersistentVolumeClaim resources and underlying data between clusters using rsync and secure, self-signed connections.
+*   **commands/export.md**: Details the process of discovering and writing Kubernetes resources from a source cluster to a local filesystem.
+*   **commands/transform.md**: Explains how to use plugins and Kustomize stages to modify exported resources before migration.
+*   **commands/apply.md**: Describes the process of rendering and applying Kustomize patches to generate final, deployable YAML manifests.
+*   **commands/validate.md**: Outlines the verification process to ensure final manifests are compatible with the target cluster's API version surface.
+*   **commands/transfer-pvc.md**: Details the mechanism for migrating PersistentVolumeClaim resources and underlying data between clusters using rsync pods.
 
 ## Code Changes That Would Require Documentation Updates
-*   **CLI Flags**: Addition, removal, or renaming of any flag (e.g., adding `--dry-run` or changing default QPS settings).
-*   **Output Structure**: Changes to the file organization of `export/`, `transform/`, or `output/` directories.
-*   **Pipeline Logic**: Modifications to the sequential nature of `crane apply` or the interaction between transform stages (e.g., how input/output directories are handled).
-*   **API/GVK Handling**: Changes to how `crane validate` identifies or verifies API versions and kinds, or how `crane export` discovers cluster-scoped resources.
-*   **Plugin Architecture**: Changes to how plugins are loaded, registered, or how their priorities/naming conventions function.
-*   **Transfer Logic**: Updates to the `transfer-pvc` rsync process, including new endpoint types, encryption methods, or pod templates used for data movement.
-*   **Default Behaviors**: Changes to exit codes, error handling, or default settings (e.g., changing the default behavior for cluster-scoped resource inclusion).
+*   **Flag Additions/Removals**: Changing existing flags (e.g., `--crd-skip-group`) or adding new ones to any `crane` subcommand.
+*   **Output Structure Changes**: Altering the directory hierarchy (e.g., changing the `export/` or `transform/` structure) or file naming conventions (e.g., changing the `Kind_group_version_namespace_name.yaml` format).
+*   **Exit/Error Logic**: Modifying exit codes or error handling behavior (e.g., how the tool handles non-admin `Forbidden` errors during export).
+*   **Stage Processing Logic**: Changes to how `crane transform` or `crane apply` handles priority, naming conventions (e.g., the `number_Name` requirement), or the sequential execution of stages.
+*   **Plugin Architecture**: Introducing new requirements for custom plugins or changing how plugin discovery works during the transform stage.
+*   **Validation Logic**: Changes to the API surface capture script or the GVK (Group-Version-Kind) matching algorithm in `crane validate`.
+*   **Transfer-PVC Networking**: Adding new endpoint types (e.g., LoadBalancer) or changing how rsync pods/encryption certificates are generated in `crane transfer-pvc`.
 
 ## Key Technical Concepts
-*   **GVK (GroupVersionKind)**: Strict matching used for validation of API compatibility.
-*   **Multi-Stage Pipeline**: Sequential execution of transformation stages where each stage output feeds the next.
-*   **Kustomize/Krusty**: The engine used for patching and materializing manifests.
-*   **Whiteout Resources**: Filtering resources during the transform pipeline.
-*   **Impersonation**: Using `--as` and `--as-extras` flags for handling non-admin migration permissions.
-*   **API Surface**: The set of available APIs on a target cluster (often captured as a JSON blob).
-*   **Sync Endpoints**: Infrastructure components (Routes, Ingress) used to bridge source and destination clusters for PVC transfers.
-*   **Dependency Ordering**: Using `--ordered` to ensure sequential application of resources (e.g., ConfigMaps before Deployments).
+*   **Pipeline Lifecycle**: Export → Transform → Apply → Validate.
+*   **GVK Matching**: Strict API Group, Version, and Kind validation.
+*   **Kustomize/Krusty**: The engine used for resource patching and materialization.
+*   **Multi-Stage Pipelines**: Sequential processing of transformations where the output of one stage is the input of the next.
+*   **Cluster-Scoped Resources**: Handling of RBAC, CRDs, and SCCs specifically during non-admin migrations.
+*   **Impersonation**: Use of `--as` and `--as-extras` for RBAC-restricted migration.
+*   **Rsync Pods**: The mechanism for moving persistent data between clusters.
+*   **Whiteout Resources**: Filtering resources during the transformation process.
+*   **Pass-through vs. Plugin Stages**: Distinguishing between automatic plugin-based stages and manual edit stages.
 
 ## Related Components
-*   **Crane Core**: The orchestration engine for the migration pipeline.
-*   **Kustomize (embedded)**: Used for resource manipulation.
-*   **Kubernetes API/Client-go**: Used for discovery, listing, and applying resources.
-*   **Rsync**: The underlying tool utilized by `transfer-pvc` for data migration.
-*   **Plugin System**: The architectural extension point for custom migration logic.
+*   **Kustomize (embedded)**: The underlying engine for resource manipulation.
+*   **Kubernetes API Server**: The source and target of all resource discovery and validation.
+*   **Rsync Utility**: Used by `transfer-pvc` for data synchronization.
+*   **Migration Plugins**: External or internal logic providers that perform specific transformations (e.g., OpenShiftPlugin).
+*   **Kubeconfig**: The configuration mechanism for authenticating against source and destination clusters.

--- a/docs/.doc-index/development.index.md
+++ b/docs/.doc-index/development.index.md
@@ -1,40 +1,35 @@
 # DEVELOPMENT Documentation Index
 
 ## Overview
-This documentation area provides a comprehensive guide for contributors to the Crane project. It covers the technical architecture, development environment configuration, testing standards, and the plugin-based transformation system required to maintain and extend the tool.
+This documentation area provides a comprehensive guide for developers contributing to the Crane project. It covers project architecture, local development environment setup, plugin creation, testing procedures, and the end-to-end data pipeline lifecycle.
 
 ## Files Summary
-*   **development/README.md**: Serves as the primary entry point and navigator for all developer-focused documentation and project structure.
-*   **development/setup.md**: Details the prerequisites, environment setup, build procedures, and coding conventions for working on the Crane repository.
-*   **development/plugin-development.md**: Explains the architecture, interface, naming conventions, and best practices for creating custom transformation plugins.
-*   **development/testing.md**: Describes unit and E2E testing strategies, including table-driven test patterns, test infrastructure, and CI requirements.
-*   **development/architecture.md**: Provides a deep dive into the pipeline-based data flow, covering the export, transform, apply, validate, and PVC transfer phases.
+* **`development/README.md`**: Serves as the central landing page and navigational index for all developer-focused documentation.
+* **`development/setup.md`**: Details environment prerequisites, repository cloning, building from source, IDE configurations, and instructions for setting up test clusters.
+* **`development/plugin-development.md`**: Explains the plugin system architecture, interface specifications (stdin/stdout), creation of Go/Bash plugins, and stage-based priority execution.
+* **`development/testing.md`**: Outlines standards for unit testing, table-driven test patterns, E2E testing using `kind`/`minikube`, and CI/CD integration requirements.
+* **`development/architecture.md`**: Describes the core "pipeline" philosophy, covering the design and flow of the Export, Transform, Apply, Validate, and PVC transfer phases.
 
 ## Code Changes That Would Require Documentation Updates
-*   **CLI Command Structure**: Adding, renaming, or changing the signature of CLI commands under `cmd/`.
-*   **Pipeline Stages**: Any modification to how stages are discovered, executed, or persisted in the `transform/` directory.
-*   **Plugin Interface**: Changes to the stdin/stdout contract, JSONPatch structure, or plugin discovery paths (e.g., changing the default `~/.local/share/crane/plugins/` directory).
-*   **Kustomize Integration**: Changes to the embedded `krusty` API usage or how `kustomization.yaml` files are generated.
-*   **API Interactions**: Modifications to how `unstructured.Unstructured` objects are handled or how CRDs are collected during export.
-*   **Validation Logic**: Updates to how compatibility reports are generated or how the `validate` phase queries cluster API surfaces.
-*   **Testing Infrastructure**: Changes to the E2E framework under `e2e-tests/` or the introduction of new mock/helper utilities.
-*   **Project Layout**: Moving files out of `internal/` or changing the directory hierarchy.
+* **Command Structure Changes**: Adding, removing, or modifying CLI commands (requires updating `cmd/` directory documentation in `setup.md`).
+* **Pipeline Logic Updates**: Changes to how stages are discovered, how plugins are executed, or updates to the `orchestrator` logic in `internal/transform/`.
+* **Plugin Interface Changes**: Altering the stdin/stdout contract for plugins or the naming convention for stage directories.
+* **Kustomize Integration**: Modifying how `krusty` (embedded kustomize) is invoked or how patch files are generated/applied.
+* **API/Discovery Logic**: Updates to how `dynamic.Interface` or Kubernetes discovery clients are used in the export or validation phases.
+* **New Supported Platforms**: Adding platform-specific transformations or changing how cluster-scoped resources are handled.
+* **Testing Infrastructure**: Changes to the `e2e-tests/` framework or the introduction of new mock/helper utilities.
+* **Dependency Changes**: Updates to the Go version, external libraries, or build dependencies listed in `setup.md`.
 
 ## Key Technical Concepts
-*   **Pipeline Architecture**: Export → Transform → Apply → Validate flow.
-*   **JSONPatch (RFC 6902)**: Used for resource transformations via plugins.
-*   **Kustomize/Krusty**: Embedded Kubernetes configuration management library.
-*   **Plugin Stages**: Naming convention `<priority>_<PluginName>`.
-*   **Unstructured API**: `k8s.io/apimachinery/pkg/apis/meta/v1/unstructured`.
-*   **Table-Driven Tests**: The standard pattern for Go testing in the project.
-*   **Discovery Client**: Used for dynamic Kubernetes resource listing.
-*   **Stage Orchestrator**: The logic in `internal/transform/` managing sequential consistency.
-*   **Golden Manifests**: Fixtures used in `e2e-tests/` for verification.
+* **Pipeline Stages**: `export`, `transform`, `apply`, `validate`, `transfer-pvc`.
+* **Plugin System**: JSONPatch (RFC 6902), `~/.local/share/crane/plugins/`, stage priority numeric prefixes.
+* **Infrastructure**: `kustomize` (krusty API), Kubernetes `unstructured.Unstructured`, `cobra` (CLI framework), `viper` (flags).
+* **Test Patterns**: Table-driven tests, `t.TempDir()`, `golden-manifests`, E2E test framework.
+* **Orchestration**: `Orchestrator`, `Stage` discovery, `KustomizeApplier`.
 
 ## Related Components
-*   **`cmd/`**: CLI command entry points.
-*   **`internal/`**: Core business logic packages (apply, transform, validate, plugin, kustomize).
-*   **`e2e-tests/`**: Integration and regression testing framework.
-*   **`crane-lib`**: External library for built-in transformation logic.
-*   **`pvc-transfer`**: External library used for persistent volume migration.
-*   **Kubernetes API/Discovery**: The source of truth for cluster-scoped and namespaced resources.
+* **`cmd/`**: CLI entry points for all functional phases.
+* **`internal/`**: Core business logic packages including `transform/`, `apply/`, `validate/`, and `plugin/`.
+* **`e2e-tests/`**: The dedicated suite for integration and regression testing.
+* **`crane-lib`**: External library containing common transformation utilities.
+* **`pvc-transfer`**: External subsystem used for data volume migrations.

--- a/docs/.doc-index/manifest.json
+++ b/docs/.doc-index/manifest.json
@@ -18,25 +18,25 @@
       }
     },
     "commands": {
-      "built": "2026-08-06T09:58:45.478067",
+      "built": "2026-08-13T07:56:21.363284",
       "doc_hashes": {
         "commands/export.md": "18d5f3a7088cb799a8d88d34c033fd44221128ff1a72d9b7cadffc211493f3d4",
         "commands/transform.md": "2f067699ade74ba84c49fa40f12fe7253f30978a503cddb3186b7ae65d51d80e",
         "commands/validate.md": "be296169a1e5dbf222ae233c49843d7b76cbbe8759fc0f16220c27d68592d305",
         "commands/apply.md": "64902f9c980f3aa86f7aeddc0a9819cbb1031467e3263b26ac83b9494ba7b4ba",
-        "commands/transfer-pvc.md": "c0a6e7fb147d0ac5e52e696ca2be4cb44ca1589f8389807f1e9811008b874ba1"
+        "commands/transfer-pvc.md": "b6a2d593d56ef973f480228b770d7c034863e0830b210fd8dd66585df82ece2d"
       }
     },
     "development": {
-      "built": "2026-08-06T09:58:49.012222",
+      "built": "2026-08-13T07:56:29.879726",
       "doc_hashes": {
         "development/setup.md": "c2064cf8412e64c2d259a121c1717fe305d9e3c6782413640a1041ed5c8e1ea4",
         "development/plugin-development.md": "18be806fa9771eda99dfd7af775ac728f2e86b647ea9280f7b4f7271b29b220e",
         "development/testing.md": "60d476a324f8c241ef502f61e85f1fc444d45dbc299e1658afc24b0b253de357",
-        "development/architecture.md": "e1346c1411bebf6aca860317bdb0fbbc92eae3810e3a2a66ab5a981b4bec9531",
-        "development/README.md": "02cb2ad963534727279a3cddd5a357a95e95b8117dad2f38803ae4333cf3c271"
+        "development/architecture.md": "ba955b12e3bc729e70a8ec776501398d6e8a30cabeff75038b3a0b6a28fd770f",
+        "development/README.md": "af080e30c5f3a549753aa53045ab99ecda515bd28a1317e7125fb2db66758df8"
       }
     }
   },
-  "updated": "2026-08-06T09:58:49.012677"
+  "updated": "2026-08-13T07:56:29.880332"
 }


### PR DESCRIPTION
This PR updates documentation semantic indexes.

These are auto-generated indexes and file summaries used by the code-to-docs action to speed up documentation file discovery.

*Auto-generated by code-to-docs action*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded command documentation coverage for the Crane migration lifecycle, flags, output, errors, stages, plugins, validation, and PVC networking.
  * Updated development documentation guidance for setup, plugins, testing, architecture, pipeline stages, infrastructure, and orchestration.
  * Refined documentation concepts and related component references, including Kubernetes, Kustomize, rsync, migration plugins, and kubeconfig.
  * Refreshed documentation manifest metadata and tracked content updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->