### PR TITLE
:book: chore: Update documentation semantic indexes

### DIFF
--- a/docs/.doc-index/commands.index.md
+++ b/docs/.doc-index/commands.index.md
@@ -1,37 +1,37 @@
 # COMMANDS Documentation Index
 
 ## Overview
-This documentation area defines the CLI tool `crane`, which orchestrates Kubernetes cluster-to-cluster migrations. It covers the full lifecycle of a migration project, including resource extraction, transformation pipelines, validation against target clusters, and persistent volume data migration.
+This documentation area defines the command-line interface and operational workflows for `crane`, a Kubernetes migration tool. It covers the end-to-end migration pipeline, including resource discovery, transformation, application, validation, and data-plane transfer of persistent volumes.
 
 ## Files Summary
-*   **commands/export.md**: Details the discovery and extraction process of Kubernetes resources (including CRDs and cluster-scoped items) from a source cluster into local YAML files.
-*   **commands/transform.md**: Explains the multi-stage transformation pipeline using Kustomize and plugins to modify, patch, or filter resources before they are applied.
-*   **commands/validate.md**: Describes how to verify the compatibility of transformed manifests against a target cluster’s API surface, supporting both live and offline modes.
-*   **commands/apply.md**: Covers the process of rendering final manifests by running embedded Kustomize on transform stages and preparing them for cluster deployment.
-*   **commands/transfer-pvc.md**: Details the mechanism for transferring PersistentVolumeClaim resources and underlying data between clusters using rsync and secure, self-signed connections.
+* **commands/export.md**: Explains the discovery and export of Kubernetes resources (including CRDs and cluster-scoped RBAC) from a source cluster to a local directory.
+* **commands/transform.md**: Details the process of applying Kustomize-based transformations and plugin-driven modifications to exported manifests.
+* **commands/apply.md**: Describes the process of rendering final manifests using embedded Kustomize and organizing them for deployment, including options for dependency ordering.
+* **commands/validate.md**: Outlines how to verify the compatibility of transformed manifests against a target cluster’s API surface, supporting both live and offline modes.
+* **commands/transfer-pvc.md**: Details the mechanism for migrating PersistentVolumeClaim resources and their underlying data between clusters using rsync-based pods.
 
 ## Code Changes That Would Require Documentation Updates
-*   **CLI Flags**: Addition, removal, or renaming of any flag (e.g., adding `--dry-run` or changing default QPS settings).
-*   **Output Structure**: Changes to the file organization of `export/`, `transform/`, or `output/` directories.
-*   **Pipeline Logic**: Modifications to the sequential nature of `crane apply` or the interaction between transform stages (e.g., how input/output directories are handled).
-*   **API/GVK Handling**: Changes to how `crane validate` identifies or verifies API versions and kinds, or how `crane export` discovers cluster-scoped resources.
-*   **Plugin Architecture**: Changes to how plugins are loaded, registered, or how their priorities/naming conventions function.
-*   **Transfer Logic**: Updates to the `transfer-pvc` rsync process, including new endpoint types, encryption methods, or pod templates used for data movement.
-*   **Default Behaviors**: Changes to exit codes, error handling, or default settings (e.g., changing the default behavior for cluster-scoped resource inclusion).
+* **Flag/Argument Modifications**: Adding, removing, or changing defaults for any CLI flags (e.g., changing `--qps` in `export` or adding new transformation options).
+* **Output Structure Changes**: Any changes to the directory hierarchy of `export/`, `transform/`, or `output/` folders.
+* **Plugin Architecture**: Updates to how transformation plugins are discovered, prioritized, or the introduction of new plugin lifecycle stages.
+* **API Version Requirements**: Changes to the validation logic or supported API surface identification methods in `crane validate`.
+* **Impersonation Logic**: Updates to `--as` or `--as-extras` handling in `crane export` for non-admin migrations.
+* **Transfer Protocol**: Changes to the rsync implementation, certificate generation, or supported endpoint types (e.g., adding `loadbalancer` or `nodeport` support) in `transfer-pvc`.
+* **Kustomize Integration**: Changes to the embedded `krusty` library usage or how `kustomization.yaml` files are generated/managed.
 
 ## Key Technical Concepts
-*   **GVK (GroupVersionKind)**: Strict matching used for validation of API compatibility.
-*   **Multi-Stage Pipeline**: Sequential execution of transformation stages where each stage output feeds the next.
-*   **Kustomize/Krusty**: The engine used for patching and materializing manifests.
-*   **Whiteout Resources**: Filtering resources during the transform pipeline.
-*   **Impersonation**: Using `--as` and `--as-extras` flags for handling non-admin migration permissions.
-*   **API Surface**: The set of available APIs on a target cluster (often captured as a JSON blob).
-*   **Sync Endpoints**: Infrastructure components (Routes, Ingress) used to bridge source and destination clusters for PVC transfers.
-*   **Dependency Ordering**: Using `--ordered` to ensure sequential application of resources (e.g., ConfigMaps before Deployments).
+* **GVK (Group/Version/Kind)**: Used for API surface matching and resource identification.
+* **Kustomization Pipeline**: The sequential execution of transform stages using JSON patches.
+* **Whiteout Resources**: Files tracked during transformation but explicitly excluded from active deployment.
+* **Sequential Consistency**: The requirement that transformation stages operate on the materialized output of previous stages.
+* **Multi-Stage Pipelines**: The ability to chain plugins (`*Plugin`) and manual pass-through stages.
+* **Dependency-Ordered Deployment**: The `--ordered` flag functionality for `kubectl apply`.
+* **Rsync Daemon/Client Architecture**: The data-plane mechanism for `transfer-pvc`.
+* **API Surface Capture**: The offline validation workflow involving JSON-based API resource definitions.
 
 ## Related Components
-*   **Crane Core**: The orchestration engine for the migration pipeline.
-*   **Kustomize (embedded)**: Used for resource manipulation.
-*   **Kubernetes API/Client-go**: Used for discovery, listing, and applying resources.
-*   **Rsync**: The underlying tool utilized by `transfer-pvc` for data migration.
-*   **Plugin System**: The architectural extension point for custom migration logic.
+* **Kustomize (embedded)**: The core engine for resource modification and manifest generation.
+* **Kubernetes API Server**: The primary interaction point for `export` and `validate`.
+* **CRD Controllers**: The source of CustomResourceDefinitions managed during the migration pipeline.
+* **Rsync/Pod Execution**: The data-plane subsystem used for volume transfer.
+* **RBAC/Impersonation Subsystem**: Handles authentication context for non-admin cluster migration.

--- a/docs/.doc-index/development.index.md
+++ b/docs/.doc-index/development.index.md
@@ -1,40 +1,39 @@
 # DEVELOPMENT Documentation Index
 
 ## Overview
-This documentation area provides a comprehensive guide for contributors to the Crane project. It covers the technical architecture, development environment configuration, testing standards, and the plugin-based transformation system required to maintain and extend the tool.
+This documentation area provides a comprehensive guide for developers contributing to the Crane project, covering architecture, setup, testing, and extension via the plugin system. Its purpose is to onboard new contributors and maintain consistency across the project's pipeline-based migration toolset.
 
 ## Files Summary
-*   **development/README.md**: Serves as the primary entry point and navigator for all developer-focused documentation and project structure.
-*   **development/setup.md**: Details the prerequisites, environment setup, build procedures, and coding conventions for working on the Crane repository.
-*   **development/plugin-development.md**: Explains the architecture, interface, naming conventions, and best practices for creating custom transformation plugins.
-*   **development/testing.md**: Describes unit and E2E testing strategies, including table-driven test patterns, test infrastructure, and CI requirements.
-*   **development/architecture.md**: Provides a deep dive into the pipeline-based data flow, covering the export, transform, apply, validate, and PVC transfer phases.
+* **development/README.md**: Serves as the central entry point for the development documentation, linking to specialized guides and outlining the project directory structure.
+* **development/setup.md**: Details the prerequisites, build instructions, project layout, IDE configurations, and instructions for setting up local test Kubernetes clusters.
+* **development/plugin-development.md**: Explains the design, implementation, testing, and lifecycle of Crane plugins, including the JSONPatch-based transformation interface.
+* **development/testing.md**: Outlines the testing strategy for the project, including unit testing conventions, E2E test framework usage, and CI integration requirements.
+* **development/architecture.md**: Describes the core pipeline architecture of Crane, detailing the responsibilities and data flow of the `export`, `transform`, `apply`, and `validate` phases.
 
 ## Code Changes That Would Require Documentation Updates
-*   **CLI Command Structure**: Adding, renaming, or changing the signature of CLI commands under `cmd/`.
-*   **Pipeline Stages**: Any modification to how stages are discovered, executed, or persisted in the `transform/` directory.
-*   **Plugin Interface**: Changes to the stdin/stdout contract, JSONPatch structure, or plugin discovery paths (e.g., changing the default `~/.local/share/crane/plugins/` directory).
-*   **Kustomize Integration**: Changes to the embedded `krusty` API usage or how `kustomization.yaml` files are generated.
-*   **API Interactions**: Modifications to how `unstructured.Unstructured` objects are handled or how CRDs are collected during export.
-*   **Validation Logic**: Updates to how compatibility reports are generated or how the `validate` phase queries cluster API surfaces.
-*   **Testing Infrastructure**: Changes to the E2E framework under `e2e-tests/` or the introduction of new mock/helper utilities.
-*   **Project Layout**: Moving files out of `internal/` or changing the directory hierarchy.
+* **Changes to CLI structure**: Adding, removing, or renaming commands in `cmd/` or altering flag registration patterns.
+* **Changes to Pipeline phases**: Modifying the logic in `internal/export/`, `internal/transform/`, `internal/apply/`, or `internal/validate/`.
+* **Changes to Plugin interface**: Any modifications to the stdin/stdout contract, JSONPatch requirements, or the discovery path (`~/.local/share/crane/plugins/`).
+* **Changes to Project Layout**: Moving directories or packages within the `internal/` or `cmd/` structures.
+* **Changes to Test framework**: Updates to the `e2e-tests/` framework or changes in the "golden manifest" comparison strategy.
+* **Changes to build/CI requirements**: Updates to Go versioning in `go.mod` or modifications to GitHub Actions workflows.
+* **Changes to Kustomize integration**: Updates to the `krusty` API implementation or modifications to how patches are generated/applied.
 
 ## Key Technical Concepts
-*   **Pipeline Architecture**: Export → Transform → Apply → Validate flow.
-*   **JSONPatch (RFC 6902)**: Used for resource transformations via plugins.
-*   **Kustomize/Krusty**: Embedded Kubernetes configuration management library.
-*   **Plugin Stages**: Naming convention `<priority>_<PluginName>`.
-*   **Unstructured API**: `k8s.io/apimachinery/pkg/apis/meta/v1/unstructured`.
-*   **Table-Driven Tests**: The standard pattern for Go testing in the project.
-*   **Discovery Client**: Used for dynamic Kubernetes resource listing.
-*   **Stage Orchestrator**: The logic in `internal/transform/` managing sequential consistency.
-*   **Golden Manifests**: Fixtures used in `e2e-tests/` for verification.
+* **Pipeline Architecture**: The sequential `export -> transform -> apply -> validate` workflow.
+* **JSONPatch (RFC 6902)**: The format used by plugins for resource transformations.
+* **Kustomize Integration**: Using the `krusty` API to manage resource patches and manifest generation.
+* **Dynamic Client**: Using `dynamic.Interface` to handle Kubernetes API resources without static compilation.
+* **Stage Conventions**: The `<priority>_<name>` directory structure for transformation stages.
+* **Table-Driven Testing**: The standard for unit test implementation in Go.
+* **Golden Manifests**: Fixtures used in E2E testing to verify transformation/export output.
+* **PVC Transfer**: The specialized process for migrating Persistent Volume data using `rsync` and `stunnel`.
 
 ## Related Components
-*   **`cmd/`**: CLI command entry points.
-*   **`internal/`**: Core business logic packages (apply, transform, validate, plugin, kustomize).
-*   **`e2e-tests/`**: Integration and regression testing framework.
-*   **`crane-lib`**: External library for built-in transformation logic.
-*   **`pvc-transfer`**: External library used for persistent volume migration.
-*   **Kubernetes API/Discovery**: The source of truth for cluster-scoped and namespaced resources.
+* **`cmd/`**: CLI command implementations (export, transform, apply, validate, etc.).
+* **`internal/transform/`**: The Orchestrator and logic for plugin/stage management.
+* **`internal/apply/`**: The embedded `krusty` Kustomize engine wrapper.
+* **`internal/plugin/`**: Logic for loading and executing external plugin binaries.
+* **`e2e-tests/`**: The integrated testing suite and framework.
+* **`crane-lib`**: External library for core transformation logic.
+* **`pvc-transfer`**: External library for handling PV migration pods.

--- a/docs/.doc-index/manifest.json
+++ b/docs/.doc-index/manifest.json
@@ -18,25 +18,25 @@
       }
     },
     "commands": {
-      "built": "2026-08-06T09:58:45.478067",
+      "built": "2026-08-13T14:13:07.658197",
       "doc_hashes": {
         "commands/export.md": "18d5f3a7088cb799a8d88d34c033fd44221128ff1a72d9b7cadffc211493f3d4",
         "commands/transform.md": "2f067699ade74ba84c49fa40f12fe7253f30978a503cddb3186b7ae65d51d80e",
         "commands/validate.md": "be296169a1e5dbf222ae233c49843d7b76cbbe8759fc0f16220c27d68592d305",
         "commands/apply.md": "64902f9c980f3aa86f7aeddc0a9819cbb1031467e3263b26ac83b9494ba7b4ba",
-        "commands/transfer-pvc.md": "c0a6e7fb147d0ac5e52e696ca2be4cb44ca1589f8389807f1e9811008b874ba1"
+        "commands/transfer-pvc.md": "b6a2d593d56ef973f480228b770d7c034863e0830b210fd8dd66585df82ece2d"
       }
     },
     "development": {
-      "built": "2026-08-06T09:58:49.012222",
+      "built": "2026-08-13T14:13:13.737408",
       "doc_hashes": {
         "development/setup.md": "c2064cf8412e64c2d259a121c1717fe305d9e3c6782413640a1041ed5c8e1ea4",
         "development/plugin-development.md": "18be806fa9771eda99dfd7af775ac728f2e86b647ea9280f7b4f7271b29b220e",
         "development/testing.md": "60d476a324f8c241ef502f61e85f1fc444d45dbc299e1658afc24b0b253de357",
-        "development/architecture.md": "e1346c1411bebf6aca860317bdb0fbbc92eae3810e3a2a66ab5a981b4bec9531",
-        "development/README.md": "02cb2ad963534727279a3cddd5a357a95e95b8117dad2f38803ae4333cf3c271"
+        "development/architecture.md": "ba955b12e3bc729e70a8ec776501398d6e8a30cabeff75038b3a0b6a28fd770f",
+        "development/README.md": "af080e30c5f3a549753aa53045ab99ecda515bd28a1317e7125fb2db66758df8"
       }
     }
   },
-  "updated": "2026-08-06T09:58:49.012677"
+  "updated": "2026-08-13T14:13:13.738034"
 }


### PR DESCRIPTION
This PR updates documentation semantic indexes.

These are auto-generated indexes and file summaries used by the code-to-docs action to speed up documentation file discovery.

*Auto-generated by code-to-docs action*