### PR TITLE
:bug: switch code-to-docs workflow to use built-in GITHUB_TOKEN

### DIFF
--- a/.github/workflows/docs-assistant.yml
+++ b/.github/workflows/docs-assistant.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Get PR information
         id: pr_info
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           PR_NUMBER=${{ github.event.issue.number }}
@@ -51,7 +51,7 @@ jobs:
           repository: ${{ steps.pr_info.outputs.head_repo }}
           ref: ${{ steps.pr_info.outputs.head_sha }}
           fetch-depth: 0
-          token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Fetch PR Base Branch
         env:
@@ -62,7 +62,7 @@ jobs:
 
       - name: Rebind Origin to Main Repository
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git remote set-url origin "https://github.com/migtools/crane.git"
           git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n "x-access-token:${GH_TOKEN}" | base64)"
@@ -74,7 +74,7 @@ jobs:
           model-api-key: ${{ secrets.MODEL_API_KEY }}
           model-name: ${{ secrets.MODEL_NAME }}
           docs-repo-url: ${{ secrets.DOCS_REPO_URL }}
-          github-token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ steps.pr_info.outputs.pr_number }}
           pr-base: ${{ steps.pr_info.outputs.base_sha }}
           pr-head-sha: ${{ steps.pr_info.outputs.head_sha }}


### PR DESCRIPTION
## Summary
Updated the code-to-docs GitHub Actions workflow to use the built-in `GITHUB_TOKEN` instead of a Personal Access Token (`GH_PAT`).