### PR TITLE
:book: add guidelines for code-to-docs automated documentation review in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,18 @@ For comprehensive documentation, see the [docs/](docs/README.md) directory:
 - [Command Reference](docs/README.md#command-reference) — export, transform, apply, validate, transfer-pvc
 - [Contributing](CONTRIBUTING.md) | [Development Guide](docs/development/README.md)
 
+## Automated Documentation Review (`code-to-docs`)
+
+To keep documentation in sync with code changes, this repository uses an automated documentation bot.
+
+When creating a Pull Request that introduces new features, CLI flags, or changes functionality:
+
+1. Comment `[review-docs]` on your PR.
+2. The bot will analyze your code diff and suggest updates to the relevant documentation files under `docs/`.
+3. Review the AI suggestions. If satisfied, comment `[update-docs]` to apply the documentation updates directly.
+
+> **Note:** For security reasons, the `[review-docs]` and `[update-docs]` commands can only be triggered by repository **collaborators/maintainers** (users with write permissions). If you are an external contributor, a maintainer can trigger the bot on your PR.
+> 
 ## Further Examples
 
 Please see [konveyor/crane-runner/main/examples](https://github.com/konveyor/crane-runner/tree/main/examples#readme) for further scenarios to explore what can be done with Crane + Tekton for migrating applications. 

--- a/README.md
+++ b/README.md
@@ -136,8 +136,9 @@ When creating a Pull Request that introduces new features, CLI flags, or changes
 2. The bot will analyze your code diff and suggest updates to the relevant documentation files under `docs/`.
 3. Review the AI suggestions. If satisfied, comment `[update-docs]` to apply the documentation updates directly.
 
-> **Note:** For security reasons, the `[review-docs]` and `[update-docs]` commands can only be triggered by repository **collaborators/maintainers** (users with write permissions). If you are an external contributor, a maintainer can trigger the bot on your PR.
-> 
+> **Note:** For security reasons, the `[review-docs]` and `[update-docs]` commands can only be triggered by **authorized maintainers listed in the repository allowlist**. If you need the bot to run on your PR, please ask an authorized maintainer to trigger it for you.
+>
+
 ## Further Examples
 
 Please see [konveyor/crane-runner/main/examples](https://github.com/konveyor/crane-runner/tree/main/examples#readme) for further scenarios to explore what can be done with Crane + Tekton for migrating applications. 


### PR DESCRIPTION
## Summary
Adds a dedicated section to `README.md` under `## Documentation` explaining how to use the automated `code-to-docs` bot for documentation updates.

## Changes Introduced
- Added instructions on triggering `[review-docs]` and applying changes via `[update-docs]`.
- Added a security note specifying that bot commands are restricted to repository maintainers/collaborators with write access.

## Why is this change needed?
Provides clear guidelines for engineers and contributors on how documentation is maintained and updated automatically when code changes are made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for automated documentation review commands.
  * Documented access restrictions for applying documentation updates.
  * Reformatted the final line in the Known Issues section without changing its content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->