### PR TITLE
:test_tube: crane validate: Add e2e test for multi-document YAML scanning

### DIFF
--- a/e2e-tests/testdata/scanner-multi-doc/app-multi-doc.yaml
+++ b/e2e-tests/testdata/scanner-multi-doc/app-multi-doc.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-app
+  labels:
+    app: multi-doc-test
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+  namespace: test-app
+data:
+  app.properties: |
+    environment=production
+    version=1.0.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: app-service
+  namespace: test-app
+spec:
+  selector:
+    app: multi-doc-test
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080
+  type: ClusterIP

--- a/e2e-tests/tests/tier1/mta_347_validate_scanner_multi_document_yaml_test.go
+++ b/e2e-tests/tests/tier1/mta_347_validate_scanner_multi_document_yaml_test.go
@@ -1,0 +1,113 @@
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	"github.com/konveyor/crane/e2e-tests/utils"
+	cranevalidate "github.com/konveyor/crane/internal/validate"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Validate scanner multi-document YAML behavior [Live Mode]", func() {
+	It("[MTA-847] should scan all resources from a single multi-document YAML file", Label("tier1", "validate", "admin"), func() {
+		scenario := NewMigrationScenario(
+			"scanner-multi-doc-validate-live",
+			"validate-multi-doc-yaml",
+			config.K8sDeployBin,
+			config.CraneBin,
+			config.SourceContext,
+			config.TargetContext,
+		)
+
+		if scenario.KubectlTgt.Context == "" {
+			Skip("target-context is required")
+		}
+
+		runner := scenario.Crane
+		paths, err := NewScenarioPaths("crane-validate-multi-doc-*")
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			Expect(os.RemoveAll(paths.TempDir)).To(Succeed())
+		})
+		runner.WorkDir = paths.TempDir
+
+		By("Copy multi-document YAML fixture into isolated input directory")
+		inputDir := filepath.Join(paths.TempDir, "input")
+		Expect(os.MkdirAll(inputDir, 0o755)).NotTo(HaveOccurred())
+
+		content, err := utils.ReadTestdataFile(filepath.Join("scanner-multi-doc", "app-multi-doc.yaml"))
+		Expect(err).NotTo(HaveOccurred(), "read multi-doc fixture")
+		destPath := filepath.Join(inputDir, "app-multi-doc.yaml")
+		Expect(os.WriteFile(destPath, []byte(content), 0o644)).NotTo(HaveOccurred())
+
+		By("Run crane validate in live mode against target context")
+		stdout, err := runner.Validate(ValidateOptions{
+			Context:      scenario.KubectlTgt.Context,
+			InputDir:     inputDir,
+			ValidateDir:  paths.ValidateDir,
+			OutputFormat: "json",
+		})
+		Expect(err).NotTo(HaveOccurred(), "validate should pass for all compatible resources")
+		Expect(stdout).To(ContainSubstring("Mode: live"))
+		Expect(stdout).To(ContainSubstring("Result: PASSED"))
+
+		By("Parse validation report")
+		reportPath := filepath.Join(paths.ValidateDir, "report.json")
+		Expect(reportPath).To(BeAnExistingFile())
+
+		reportBytes, err := os.ReadFile(reportPath)
+		Expect(err).NotTo(HaveOccurred())
+
+		var report cranevalidate.ValidationReport
+		Expect(json.Unmarshal(reportBytes, &report)).To(Succeed())
+
+		By("Verify report metadata")
+		Expect(report.Mode).To(Equal("live"))
+		Expect(report.ClusterContext).To(Equal(scenario.KubectlTgt.Context))
+
+		By("Verify all 3 resources from multi-document YAML were scanned")
+		Expect(report.TotalScanned).To(Equal(3), "expected 3 resources scanned from multi-document YAML (Namespace, ConfigMap, Service)")
+		Expect(report.Compatible).To(Equal(3))
+		Expect(report.Incompatible).To(Equal(0))
+		Expect(report.Results).To(HaveLen(3))
+
+		By("Verify each expected resource appears in results with correct metadata")
+		expectedKinds := map[string]struct {
+			apiVersion string
+			namespace  string
+		}{
+			"Namespace": {apiVersion: "v1", namespace: ""},
+			"ConfigMap": {apiVersion: "v1", namespace: "test-app"},
+			"Service":   {apiVersion: "v1", namespace: "test-app"},
+		}
+
+		foundKinds := map[string]bool{}
+		for _, result := range report.Results {
+			expected, ok := expectedKinds[result.Kind]
+			if !ok {
+				continue
+			}
+			foundKinds[result.Kind] = true
+			Expect(result.APIVersion).To(Equal(expected.apiVersion),
+				"expected %s to have apiVersion %s", result.Kind, expected.apiVersion)
+			Expect(result.Status).To(Equal(cranevalidate.StatusOK),
+				"expected %s to have status OK", result.Kind)
+			Expect(result.Namespace).To(Equal(expected.namespace),
+				fmt.Sprintf("unexpected namespace for %s", result.Kind))
+		}
+
+		for kind := range expectedKinds {
+			Expect(foundKinds[kind]).To(BeTrue(), "expected %s in validation results", kind)
+		}
+
+		By("Verify no failures directory exists")
+		failuresDir := filepath.Join(paths.ValidateDir, "failures")
+		Expect(failuresDir).NotTo(BeADirectory(), "expected no failures/ directory for all compatible resources")
+	})
+})

--- a/e2e-tests/tests/tier1/mta_847_validate_scanner_multi_document_yaml_test.go
+++ b/e2e-tests/tests/tier1/mta_847_validate_scanner_multi_document_yaml_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 var _ = Describe("Validate scanner multi-document YAML behavior [Live Mode]", func() {
-	It("[MTA-847] should scan all resources from a single multi-document YAML file", Label("tier1", "validate", "admin"), func() {
+	It("[MTA-847] should scan all resources from a single multi-document YAML file", Label("tier1", "validate"), func() {
 		scenario := NewMigrationScenario(
 			"scanner-multi-doc-validate-live",
 			"validate-multi-doc-yaml",
@@ -25,11 +25,11 @@ var _ = Describe("Validate scanner multi-document YAML behavior [Live Mode]", fu
 			config.TargetContext,
 		)
 
-		if scenario.KubectlTgt.Context == "" {
-			Skip("target-context is required")
+		if scenario.KubectlTgtNonAdmin.Context == "" {
+			Skip("target-nonadmin-context is required")
 		}
 
-		runner := scenario.Crane
+		runner := scenario.CraneNonAdmin
 		paths, err := NewScenarioPaths("crane-validate-multi-doc-*")
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() {
@@ -48,7 +48,7 @@ var _ = Describe("Validate scanner multi-document YAML behavior [Live Mode]", fu
 
 		By("Run crane validate in live mode against target context")
 		stdout, err := runner.Validate(ValidateOptions{
-			Context:      scenario.KubectlTgt.Context,
+			Context:      scenario.KubectlTgtNonAdmin.Context,
 			InputDir:     inputDir,
 			ValidateDir:  paths.ValidateDir,
 			OutputFormat: "json",
@@ -69,7 +69,7 @@ var _ = Describe("Validate scanner multi-document YAML behavior [Live Mode]", fu
 
 		By("Verify report metadata")
 		Expect(report.Mode).To(Equal("live"))
-		Expect(report.ClusterContext).To(Equal(scenario.KubectlTgt.Context))
+		Expect(report.ClusterContext).To(Equal(scenario.KubectlTgtNonAdmin.Context))
 
 		By("Verify all 3 resources from multi-document YAML were scanned")
 		Expect(report.TotalScanned).To(Equal(3), "expected 3 resources scanned from multi-document YAML (Namespace, ConfigMap, Service)")

--- a/e2e-tests/tests/tier1/mta_847_validate_scanner_multi_document_yaml_test.go
+++ b/e2e-tests/tests/tier1/mta_847_validate_scanner_multi_document_yaml_test.go
@@ -25,10 +25,6 @@ var _ = Describe("Validate scanner multi-document YAML behavior [Live Mode]", fu
 			config.TargetContext,
 		)
 
-		if scenario.KubectlTgtNonAdmin.Context == "" {
-			Skip("target-nonadmin-context is required")
-		}
-
 		runner := scenario.CraneNonAdmin
 		paths, err := NewScenarioPaths("crane-validate-multi-doc-*")
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Fixes [384](https://github.com/migtools/crane/issues/384)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for validating multi-document Kubernetes YAML manifests in live mode.
  * Added checks for accurate resource reporting, live-mode metadata, successful validation, and the absence of failure artifacts.
* **Test Data**
  * Added a representative manifest containing a namespace, configuration map, and internal service.
  * Included environment and version settings, plus service routing on port 8080 for realistic validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->