### PR TITLE
:bug: fix base64 line wrapping in workflow and document code-to-docs config.json

### DIFF
--- a/.code-to-docs/config.json
+++ b/.code-to-docs/config.json
@@ -1,0 +1,3 @@
+{
+  "pr-title-prefix": ":book:"
+}

--- a/.github/workflows/docs-assistant.yml
+++ b/.github/workflows/docs-assistant.yml
@@ -65,7 +65,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git remote set-url origin "https://github.com/migtools/crane.git"
-          git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n "x-access-token:${GH_TOKEN}" | base64)"
+          git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n "x-access-token:${GH_TOKEN}" | base64 -w 0)"
 
       - name: Documentation Assistant
         uses: redhat-community-ai-tools/code-to-docs@main

--- a/.github/workflows/docs-assistant.yml
+++ b/.github/workflows/docs-assistant.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Get PR information
         id: pr_info
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           PR_NUMBER=${{ github.event.issue.number }}
@@ -51,7 +51,7 @@ jobs:
           repository: ${{ steps.pr_info.outputs.head_repo }}
           ref: ${{ steps.pr_info.outputs.head_sha }}
           fetch-depth: 0
-          token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Fetch PR Base Branch
         env:
@@ -62,7 +62,7 @@ jobs:
 
       - name: Rebind Origin to Main Repository
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git remote set-url origin "https://github.com/migtools/crane.git"
           git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n "x-access-token:${GH_TOKEN}" | base64)"
@@ -74,7 +74,7 @@ jobs:
           model-api-key: ${{ secrets.MODEL_API_KEY }}
           model-name: ${{ secrets.MODEL_NAME }}
           docs-repo-url: ${{ secrets.DOCS_REPO_URL }}
-          github-token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ steps.pr_info.outputs.pr_number }}
           pr-base: ${{ steps.pr_info.outputs.base_sha }}
           pr-head-sha: ${{ steps.pr_info.outputs.head_sha }}


### PR DESCRIPTION
## Summary
This PR addresses two updates for the `code-to-docs` workflow:
1. Fixes an authorization header corruption caused by `base64` line wrapping in the GitHub Actions workflow.
2. Adds documentation to `README.md` explaining how to configure custom PR title prefixes using `.code-to-docs/config.json`.

## Changes Introduced

### 1. Workflow Bug Fix (`docs-assistant.yml`)
* Added the `-w 0` flag to the `base64` command in the **Rebind Origin** step.
* **Why:** The default `base64` utility wraps output every 76 characters. Because `GITHUB_TOKEN` is longer than standard PATs, a newline was inserted into the middle of the string, corrupting the HTTP `AUTHORIZATION` header and resulting in `exit status 128` and `libcurl` errors during `git push`.

### 2. README Documentation Update (`README.md`)
* Documented the optional `.code-to-docs/config.json` file.
* Showcased how engineers can set a custom prefix (e.g., `pr-title-prefix`) for automatically generated PR titles and commit messages.
