### PR TITLE
:bug: fix EndpointFlags.Validate pointer receiver to persist nginx default

### DIFF
--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -97,7 +97,7 @@ type EndpointFlags struct {
 	IngressClass string
 }
 
-func (e EndpointFlags) Validate() error {
+func (e *EndpointFlags) Validate() error {
 	// default endpoint type is nginx-ingress
 	if e.Type == "" {
 		e.Type = endpointNginx

--- a/cmd/transfer-pvc/transfer-pvc_test.go
+++ b/cmd/transfer-pvc/transfer-pvc_test.go
@@ -18,6 +18,23 @@ import (
 
 func int64Ptr(v int64) *int64 { return &v }
 
+// TestEndpointFlags_Validate_DefaultPersists proves the value-receiver bug in
+// EndpointFlags.Validate: an empty Type with a valid Subdomain passes validation,
+// but the nginx default assigned inside Validate is lost because the receiver is a
+// value copy. The caller is left with Type == "", which fails later in createEndpoint.
+func TestEndpointFlags_Validate_DefaultPersists(t *testing.T) {
+	flags := EndpointFlags{
+		Type:      "",
+		Subdomain: "my.subdomain.example.com",
+	}
+	if err := flags.Validate(); err != nil {
+		t.Fatalf("EndpointFlags.Validate() unexpected error = %v", err)
+	}
+	if flags.Type != endpointNginx {
+		t.Errorf("EndpointFlags.Validate() did not persist default type: got %q, want %q", flags.Type, endpointNginx)
+	}
+}
+
 func int64PtrEqual(a, b *int64) bool {
 	if a == nil && b == nil {
 		return true


### PR DESCRIPTION
Fixes https://github.com/migtools/crane/issues/821

## Summary
  
  `EndpointFlags.Validate()` used a value receiver, so the nginx default assigned inside (`e.Type =
  endpointNginx`) was lost after the method returned. The caller was left with `Type == ""`, causing

  ## Changes
  
  - Changed `Validate()` receiver from value to pointer (`*EndpointFlags`) so the nginx default persists after the
  call
  - Added a regression test (`TestEndpointFlags_Validate_DefaultPersists`) verifying that an empty `Type` with a
  valid subdomain correctly defaults to `nginx-ingress` after `Validate()`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Default endpoint settings are now correctly preserved when validating transfer options with a valid subdomain.
  * Prevents endpoint type defaults from being lost during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->