### PR TITLE
:sparkles: fix: use library default for transfer-pvc inspect and indirect images

### DIFF
--- a/cmd/transfer-pvc/indirect.go
+++ b/cmd/transfer-pvc/indirect.go
@@ -107,13 +107,13 @@ func (t *TransferPVCCommand) runIndirect() error {
 	}
 
 	// Get security contexts for source and target separately
-	uploadSecCtx, err := getSourcePodSecurityContext(srcClient, srcPVC.Namespace, srcPVC.Name)
+	uploadSecCtx, err := getSourcePodSecurityContext(srcClient, srcPVC.Namespace, srcPVC.Name, t.Flags.SourceImage)
 	if err != nil {
 		log.Printf("WARN: could not determine source security context: %v", err)
 		uploadSecCtx = &corev1.PodSecurityContext{}
 	}
 
-	downloadSecCtx, err := getTargetPodSecurityContext(destClient, destPVC.Namespace, destPVC.Name)
+	downloadSecCtx, err := getTargetPodSecurityContext(destClient, destPVC.Namespace, destPVC.Name, t.Flags.DestinationImage)
 	if err != nil {
 		log.Printf("WARN: could not determine target security context: %v", err)
 		downloadSecCtx = &corev1.PodSecurityContext{}
@@ -122,18 +122,13 @@ func (t *TransferPVCCommand) runIndirect() error {
 		downloadSecCtx = uploadSecCtx
 	}
 
-	image := t.Flags.SourceImage
-	if image == "" {
-		image = "quay.io/konveyor/rsync-transfer:latest"
-	}
-
 	transfer := indirect.New(srcClient, destClient, indirect.Options{
-		Image:                  image,
-		CloudStorage:           t.Flags.CloudStorage,
-		ConfigSecret:           configSecret,
-		Encrypt:                t.Flags.Encrypt,
-		KeepCloudData:          t.Flags.KeepCloudData,
-		UploadSecurityContext:  *uploadSecCtx,
+		Image:                   t.Flags.SourceImage,
+		CloudStorage:            t.Flags.CloudStorage,
+		ConfigSecret:            configSecret,
+		Encrypt:                 t.Flags.Encrypt,
+		KeepCloudData:           t.Flags.KeepCloudData,
+		UploadSecurityContext:   *uploadSecCtx,
 		DownloadSecurityContext: *downloadSecCtx,
 	})
 

--- a/cmd/transfer-pvc/indirect.go
+++ b/cmd/transfer-pvc/indirect.go
@@ -113,7 +113,8 @@ func (t *TransferPVCCommand) runIndirect() error {
 		uploadSecCtx = &corev1.PodSecurityContext{}
 	}
 
-	downloadSecCtx, err := getTargetPodSecurityContext(destClient, destPVC.Namespace, destPVC.Name, t.Flags.DestinationImage)
+	// Indirect transfer uses a single Image (SourceImage) for upload and download.
+	downloadSecCtx, err := getTargetPodSecurityContext(destClient, destPVC.Namespace, destPVC.Name, t.Flags.SourceImage)
 	if err != nil {
 		log.Printf("WARN: could not determine target security context: %v", err)
 		downloadSecCtx = &corev1.PodSecurityContext{}

--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -180,8 +180,8 @@ func NewTransferPVCCommand(streams genericclioptions.IOStreams) *cobra.Command {
 func addFlagsToTransferPVCCommand(c *Flags, cmd *cobra.Command) {
 	cmd.Flags().StringVar(&c.SourceContext, "source-context", "", "Name of the source context in current kubeconfig")
 	cmd.Flags().StringVar(&c.DestinationContext, "destination-context", "", "Name of the destination context in current kubeconfig")
-	cmd.Flags().StringVar(&c.SourceImage, "source-image", "", "The container image to use on the source cluster. Defaults to quay.io/konveyor/esync-transfer:latest")
-	cmd.Flags().StringVar(&c.DestinationImage, "destination-image", "", "The container image to use on the destination cluster. Defaults to quay.io/konveyor/rsync-transfer:latest")
+	cmd.Flags().StringVar(&c.SourceImage, "source-image", transport.DefaultRsyncTransferImage, "The container image to use on the source cluster")
+	cmd.Flags().StringVar(&c.DestinationImage, "destination-image", transport.DefaultRsyncTransferImage, "The container image to use on the destination cluster")
 
 	cmd.Flags().Var(&c.PVC.Name, "pvc-name", "Name of the PVC to be transferred. Optionally, source name can be mapped to a different destination name in format <source>:<destination> ")
 	cmd.Flags().Var(&c.PVC.Namespace, "pvc-namespace", "Namespace of the PVC to be transferred. Optionally, source namespace can be mapped to a different destination namespace in format <source>:<destination>")

--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -496,12 +496,12 @@ func (t *TransferPVCCommand) run() (retErr error) {
 	destPVCList := transfer.NewSingletonPVC(destPVC)
 	srcPVCList := transfer.NewSingletonPVC(srcPVC)
 
-	clientPodSecCtx, err := getSourcePodSecurityContext(srcClient, srcPVC.Namespace, srcPVC.Name)
+	clientPodSecCtx, err := getSourcePodSecurityContext(srcClient, srcPVC.Namespace, srcPVC.Name, t.Flags.SourceImage)
 	if err != nil {
 		return phases.Fail(err, "error creating security context for rsync client")
 	}
 
-	serverPodSecContext, err := getTargetPodSecurityContext(destClient, destPVC.Namespace, destPVC.Name)
+	serverPodSecContext, err := getTargetPodSecurityContext(destClient, destPVC.Namespace, destPVC.Name, t.Flags.DestinationImage)
 	if err != nil {
 		return phases.Fail(err, "error creating security context for rsync server")
 	}
@@ -664,7 +664,7 @@ func getNodeNameForPVC(srcClient client.Client, namespace string, pvcName string
 	return "", nil
 }
 
-func getIDsForNamespace(c client.Client, namespace string, pvcName string) (*corev1.PodSecurityContext, error) {
+func getIDsForNamespace(c client.Client, namespace string, pvcName string, image string) (*corev1.PodSecurityContext, error) {
 	ps := &corev1.PodSecurityContext{}
 	ns := &corev1.Namespace{}
 	err := c.Get(context.TODO(), types.NamespacedName{Name: namespace}, ns)
@@ -709,7 +709,7 @@ func getIDsForNamespace(c client.Client, namespace string, pvcName string) (*cor
 	// Fallback 2: workload has no explicit runAsUser (app relies on
 	// Dockerfile USER). Inspect file ownership on the PVC to discover
 	// the UID that wrote the data.
-	uid, err := inspectPVCFileOwnership(c, namespace, pvcName)
+	uid, err := inspectPVCFileOwnership(c, namespace, pvcName, image)
 	if err != nil {
 		log.Printf("PVC file ownership inspection failed for %s/%s: %v", namespace, pvcName, err)
 		return ps, nil
@@ -886,7 +886,7 @@ func extractPodSecurityContext(spec corev1.PodSpec, pvcName ...string) *corev1.P
 // inside (requires the mount point to be listable, which is the common
 // case for PVC roots provisioned as 0755/0777). If the mount point is
 // 0700 root-owned, the glob will fail and the function returns nil.
-func inspectPVCFileOwnership(c client.Client, namespace string, pvcName string) (*int64, error) {
+func inspectPVCFileOwnership(c client.Client, namespace string, pvcName string, image string) (*int64, error) {
 	podName := fmt.Sprintf("crane-inspect-%x", sha256.Sum256([]byte(pvcName)))
 	if len(podName) > 63 {
 		podName = podName[:63]
@@ -902,7 +902,7 @@ func inspectPVCFileOwnership(c client.Client, namespace string, pvcName string) 
 			Containers: []corev1.Container{
 				{
 					Name:  "inspect",
-					Image: "quay.io/konveyor/rsync-transfer:latest",
+					Image: rsyncTransferImage(image),
 					SecurityContext: func() *corev1.SecurityContext {
 						t, f := true, false
 						return &corev1.SecurityContext{
@@ -990,12 +990,21 @@ func inspectPVCFileOwnership(c client.Client, namespace string, pvcName string) 
 	return &uid, nil
 }
 
-func getSourcePodSecurityContext(c client.Client, namespace string, pvcName string) (*corev1.PodSecurityContext, error) {
-	return getIDsForNamespace(c, namespace, pvcName)
+func getSourcePodSecurityContext(c client.Client, namespace string, pvcName string, image string) (*corev1.PodSecurityContext, error) {
+	return getIDsForNamespace(c, namespace, pvcName, image)
 }
 
-func getTargetPodSecurityContext(c client.Client, namespace string, pvcName string) (*corev1.PodSecurityContext, error) {
-	return getIDsForNamespace(c, namespace, pvcName)
+func getTargetPodSecurityContext(c client.Client, namespace string, pvcName string, image string) (*corev1.PodSecurityContext, error) {
+	return getIDsForNamespace(c, namespace, pvcName, image)
+}
+
+// rsyncTransferImage returns the runtime image flag when set, otherwise the
+// build-time default from pvc-transfer.
+func rsyncTransferImage(image string) string {
+	if image != "" {
+		return image
+	}
+	return transport.DefaultRsyncTransferImage
 }
 
 func garbageCollect(srcClient client.Client, destClient client.Client, labels map[string]string, endpoint endpointType, namespace mappedNameVar) error {

--- a/cmd/transfer-pvc/transfer-pvc_test.go
+++ b/cmd/transfer-pvc/transfer-pvc_test.go
@@ -1,19 +1,23 @@
 package transfer_pvc
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"strings"
 	"testing"
 
 	rsynctransfer "github.com/migtools/pvc-transfer/transfer/rsync"
+	"github.com/migtools/pvc-transfer/transport"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 func int64Ptr(v int64) *int64 { return &v }
@@ -718,6 +722,98 @@ func TestGetIDsForNamespace_OCPTakesPrecedence(t *testing.T) {
 	}
 	if got.RunAsUser == nil || *got.RunAsUser != 1000700000 {
 		t.Errorf("OCP annotation should take precedence: RunAsUser = %v, want 1000700000", fmtInt64Ptr(got.RunAsUser))
+	}
+}
+
+func TestGetIDsForNamespace_InspectUsesTransferImage(t *testing.T) {
+	tests := []struct {
+		name      string
+		image     string
+		wantImage string
+	}{
+		{
+			name:      "configured image is used on the inspect pod",
+			image:     "example.invalid/rsync-custom:1",
+			wantImage: "example.invalid/rsync-custom:1",
+		},
+		{
+			name:      "empty image falls back to library default",
+			image:     "",
+			wantImage: transport.DefaultRsyncTransferImage,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "k8s-ns"}}
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "app-data", Namespace: "k8s-ns"},
+			}
+			// Workload mounts the PVC but has no runAsUser, so inspect is reached.
+			deploy := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "k8s-ns"},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "app"}},
+							Volumes: []corev1.Volume{
+								{Name: "data", VolumeSource: corev1.VolumeSource{
+									PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "app-data"},
+								}},
+							},
+						},
+					},
+				},
+			}
+
+			var inspectImage string
+			c := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(ns, pvc, deploy).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Create: func(ctx context.Context, cli client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+						if pod, ok := obj.(*corev1.Pod); ok && len(pod.Spec.Containers) > 0 {
+							inspectImage = pod.Spec.Containers[0].Image
+						}
+						return cli.Create(ctx, obj, opts...)
+					},
+					Get: func(ctx context.Context, cli client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						if err := cli.Get(ctx, key, obj, opts...); err != nil {
+							return err
+						}
+						pod, ok := obj.(*corev1.Pod)
+						if !ok {
+							return nil
+						}
+						pod.Status.Phase = corev1.PodSucceeded
+						pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+							State: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{
+									ExitCode: 0,
+									Message:  "27",
+								},
+							},
+						}}
+						return nil
+					},
+				}).
+				Build()
+
+			got, err := getIDsForNamespace(c, "k8s-ns", "app-data", tt.image)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if inspectImage == "" {
+				t.Fatal("inspect pod was not created")
+			}
+			if inspectImage != tt.wantImage {
+				t.Errorf("inspect pod image = %q, want %q", inspectImage, tt.wantImage)
+			}
+			if got.RunAsUser == nil || *got.RunAsUser != 27 {
+				t.Errorf("RunAsUser = %v, want 27 from inspect", fmtInt64Ptr(got.RunAsUser))
+			}
+		})
 	}
 }
 

--- a/cmd/transfer-pvc/transfer-pvc_test.go
+++ b/cmd/transfer-pvc/transfer-pvc_test.go
@@ -631,7 +631,7 @@ func TestGetIDsForNamespace_OCPAnnotation(t *testing.T) {
 	}
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(ns).Build()
-	got, err := getIDsForNamespace(c, "ocp-ns", "any-pvc")
+	got, err := getIDsForNamespace(c, "ocp-ns", "any-pvc", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -670,7 +670,7 @@ func TestGetIDsForNamespace_WorkloadFallback(t *testing.T) {
 	}
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(ns, deploy).Build()
-	got, err := getIDsForNamespace(c, "k8s-ns", "mysql-data")
+	got, err := getIDsForNamespace(c, "k8s-ns", "mysql-data", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -712,7 +712,7 @@ func TestGetIDsForNamespace_OCPTakesPrecedence(t *testing.T) {
 	}
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(ns, deploy).Build()
-	got, err := getIDsForNamespace(c, "ocp-ns", "mysql-data")
+	got, err := getIDsForNamespace(c, "ocp-ns", "mysql-data", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1046,10 +1046,10 @@ func TestStripServerManagedPVCAnnotations(t *testing.T) {
 		{
 			name: "only server-managed annotations — all stripped",
 			annotations: map[string]string{
-				"pv.kubernetes.io/bind-completed":                   "yes",
-				"volume.kubernetes.io/storage-provisioner":          "ebs.csi.aws.com",
-				"volume.beta.kubernetes.io/storage-provisioner":     "kubernetes.io/gce-pd",
-				"kubectl.kubernetes.io/last-applied-configuration":  "{}",
+				"pv.kubernetes.io/bind-completed":                  "yes",
+				"volume.kubernetes.io/storage-provisioner":         "ebs.csi.aws.com",
+				"volume.beta.kubernetes.io/storage-provisioner":    "kubernetes.io/gce-pd",
+				"kubectl.kubernetes.io/last-applied-configuration": "{}",
 			},
 			want: nil,
 		},

--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/google/gnostic-models v0.7.0
 	github.com/google/go-cmp v0.7.0
 	github.com/jarcoal/httpmock v1.2.0
-	github.com/konveyor/crane-lib v0.1.6-0.20260818123419-d279d85c1dd1
-	github.com/migtools/pvc-transfer v0.0.0-20260805073413-1b1f9d254821
+	github.com/konveyor/crane-lib v0.1.6-0.20260820041859-f7a1f8ac605d
+	github.com/migtools/pvc-transfer v0.0.0-20260820041907-3bfa753b411a
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.0
@@ -29,6 +29,7 @@ require (
 	k8s.io/apimachinery v0.35.3
 	k8s.io/cli-runtime v0.35.3
 	k8s.io/client-go v0.35.3
+	k8s.io/component-helpers v0.35.3
 	sigs.k8s.io/controller-runtime v0.23.3
 	sigs.k8s.io/kustomize/api v0.21.1
 	sigs.k8s.io/kustomize/kustomize/v5 v5.8.1
@@ -100,7 +101,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.66.4 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	k8s.io/component-helpers v0.35.3 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -337,10 +337,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/konveyor/crane-lib v0.1.6-0.20260807130033-222a325c7cee h1:T3i160U9L0PjkleTXOFpoyAS/npIc8oG9XBlEjE/Uo8=
-github.com/konveyor/crane-lib v0.1.6-0.20260807130033-222a325c7cee/go.mod h1:oYw915/11lZhW5k+nVxZtWdpl5AGc0lL52Z1YcKjU7Y=
-github.com/konveyor/crane-lib v0.1.6-0.20260818123419-d279d85c1dd1 h1:TfmdlBmsUSisxVDIREk0SrV+xAi7fmp27Yn+609cCFU=
-github.com/konveyor/crane-lib v0.1.6-0.20260818123419-d279d85c1dd1/go.mod h1:oYw915/11lZhW5k+nVxZtWdpl5AGc0lL52Z1YcKjU7Y=
+github.com/konveyor/crane-lib v0.1.6-0.20260820041859-f7a1f8ac605d h1:ynlHX9Rg4+qAuP0uSn24MyIOQMvW1JJz/p0A+045y78=
+github.com/konveyor/crane-lib v0.1.6-0.20260820041859-f7a1f8ac605d/go.mod h1:oYw915/11lZhW5k+nVxZtWdpl5AGc0lL52Z1YcKjU7Y=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -378,8 +376,8 @@ github.com/maxatome/go-testdeep v1.11.0/go.mod h1:011SgQ6efzZYAen6fDn4BqQ+lUR72y
 github.com/mfridman/tparse v0.18.0 h1:wh6dzOKaIwkUGyKgOntDW4liXSo37qg5AXbIhkMV3vE=
 github.com/mfridman/tparse v0.18.0/go.mod h1:gEvqZTuCgEhPbYk/2lS3Kcxg1GmTxxU7kTC8DvP0i/A=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
-github.com/migtools/pvc-transfer v0.0.0-20260805073413-1b1f9d254821 h1:C84du165fwGWJY40kr2bbpxMiECFO6JNI6ELKJHjy2I=
-github.com/migtools/pvc-transfer v0.0.0-20260805073413-1b1f9d254821/go.mod h1:ep8dIwq9ZA5oIQKzYL0eVMugUaNWOfIr1fAq02yURgo=
+github.com/migtools/pvc-transfer v0.0.0-20260820041907-3bfa753b411a h1:bSsyUn96V8oLl6S//jWK78nHicx5u7Wr7qhPSZYbZkI=
+github.com/migtools/pvc-transfer v0.0.0-20260820041907-3bfa753b411a/go.mod h1:ep8dIwq9ZA5oIQKzYL0eVMugUaNWOfIr1fAq02yURgo=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Indirect PVC transfers can now securely generate and use encrypted transfer configuration data.
  * Source and destination secrets are created consistently from the transfer configuration.

* **Bug Fixes**
  * Improved PVC transfers when custom source or destination transfer images are configured.
  * Security-context and file-ownership checks now consistently use the selected transfer image.
  * Retained a default transfer image when no custom image is provided.
  * Prevented unsupported encryption combinations involving an existing transfer configuration Secret.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->