### PR TITLE
  :bug: Validate --keep-cloud-data requires --cloud-storage

### DIFF
--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -234,6 +234,9 @@ func (t *TransferPVCCommand) Complete(c *cobra.Command, args []string) error {
 }
 
 func (t *TransferPVCCommand) Validate() error {
+	if t.Flags.KeepCloudData && t.Flags.CloudStorage == "" {
+		return fmt.Errorf("--keep-cloud-data requires --cloud-storage")
+	}
 	if t.sourceContext == nil {
 		return fmt.Errorf("cannot evaluate source context")
 	}
@@ -250,7 +253,7 @@ func (t *TransferPVCCommand) Validate() error {
 	if err != nil {
 		return err
 	}
-
+	
 	if t.Flags.CloudStorage != "" {
 		if t.Flags.RcloneConfigSecret == "" && t.Flags.RcloneConfigFile == "" {
 			return fmt.Errorf("--cloud-storage requires --rclone-config-secret or --rclone-config-file")

--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -253,7 +253,7 @@ func (t *TransferPVCCommand) Validate() error {
 	if err != nil {
 		return err
 	}
-	
+
 	if t.Flags.CloudStorage != "" {
 		if t.Flags.RcloneConfigSecret == "" && t.Flags.RcloneConfigFile == "" {
 			return fmt.Errorf("--cloud-storage requires --rclone-config-secret or --rclone-config-file")

--- a/cmd/transfer-pvc/transfer-pvc_test.go
+++ b/cmd/transfer-pvc/transfer-pvc_test.go
@@ -967,6 +967,45 @@ func TestValidateRejectsSameNameIntraCluster(t *testing.T) {
 	}
 }
 
+func TestValidateKeepCloudDataRequiresCloudStorage(t *testing.T) {
+	const guardErrMsg = "--keep-cloud-data requires --cloud-storage"
+	tests := []struct {
+		name           string
+		cmd            TransferPVCCommand
+		wantGuardError bool
+	}{
+		{
+			name: "keep-cloud-data without cloud-storage is rejected",
+			cmd: TransferPVCCommand{
+				Flags: Flags{KeepCloudData: true},
+			},
+			wantGuardError: true,
+		},
+		{
+			name: "keep-cloud-data with cloud-storage set does not trigger guard",
+			cmd: TransferPVCCommand{
+				Flags: Flags{
+					KeepCloudData: true,
+					CloudStorage:  "remote:my-bucket",
+				},
+			},
+			wantGuardError: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cmd.Validate()
+			hasGuardErr := err != nil && strings.Contains(err.Error(), guardErrMsg)
+			if tt.wantGuardError && !hasGuardErr {
+				t.Errorf("expected guard error %q but got: %v", guardErrMsg, err)
+			}
+			if !tt.wantGuardError && hasGuardErr {
+				t.Errorf("unexpected guard error: %v", err)
+			}
+		})
+	}
+}
+
 func TestCertSecretNaming(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
https://github.com/migtools/crane/issues/855

## Summary

  causing a confusing unrelated error instead of a clear validation message.

  - Added early validation in `Validate()` that returns an explicit error when `--keep-cloud-data` is set without `--cloud-storage`
  - Placed before context evaluation so the error is shown even with non-existent kubeconfig contexts

 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented invalid transfer configurations by rejecting `--keep-cloud-data` when cloud storage is not enabled.
  * Allowed `--keep-cloud-data` when valid cloud storage settings are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->